### PR TITLE
Use DatacenterId parameter instead of VirtualDatacenterId parameter (now deprecated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.0 (March 16, 2023)
+
+BUG FIXES:
+
+  * The `datacenter_id` replaces the `virtual_datacenter_id` argument in the `compute_virtual_machine` resource. `virtual_datacenter_id` was deprecated and has been removed.
+
+  * The `datacenter_id` replaces the `virtual_datacenter_id` attribute in the `compute_virtual_machine` and `compute_virtual_machines` datasources. `virtual_datacenter_id` was deprecated and has been removed.
+
 ## 0.4.2 (February 3, 2023)
 
 BUG FIXES:

--- a/docs/data-sources/compute_virtual_machine.md
+++ b/docs/data-sources/compute_virtual_machine.md
@@ -37,6 +37,7 @@ data "cloudtemple_compute_virtual_machine" "name" {
 - `cpu_hot_add_enabled` (Boolean)
 - `cpu_hot_remove_enabled` (Boolean)
 - `cpu_usage` (Number)
+- `datacenter_id` (String)
 - `datastore_name` (String)
 - `distributed_virtual_port_group_ids` (List of String)
 - `extra_config` (List of Object) (see [below for nested schema](#nestedatt--extra_config))
@@ -60,7 +61,6 @@ data "cloudtemple_compute_virtual_machine" "name" {
 - `tools` (String)
 - `tools_version` (Number)
 - `triggered_alarms` (List of Object) (see [below for nested schema](#nestedatt--triggered_alarms))
-- `virtual_datacenter_id` (String)
 
 <a id="nestedatt--boot_options"></a>
 ### Nested Schema for `boot_options`

--- a/docs/data-sources/compute_virtual_machines.md
+++ b/docs/data-sources/compute_virtual_machines.md
@@ -35,6 +35,7 @@ Read-Only:
 - `cpu_hot_add_enabled` (Boolean)
 - `cpu_hot_remove_enabled` (Boolean)
 - `cpu_usage` (Number)
+- `datacenter_id` (String)
 - `datastore_name` (String)
 - `distributed_virtual_port_group_ids` (List of String)
 - `extra_config` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--extra_config))
@@ -59,7 +60,6 @@ Read-Only:
 - `tools` (String)
 - `tools_version` (Number)
 - `triggered_alarms` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--triggered_alarms))
-- `virtual_datacenter_id` (String)
 
 <a id="nestedobjatt--virtual_machines--boot_options"></a>
 ### Nested Schema for `virtual_machines.boot_options`

--- a/docs/resources/backup_sla_policy_assignment.md
+++ b/docs/resources/backup_sla_policy_assignment.md
@@ -41,7 +41,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/docs/resources/compute_network_adapter.md
+++ b/docs/resources/compute_network_adapter.md
@@ -34,7 +34,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "web" {
   name = "hello-world"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/docs/resources/compute_virtual_disk.md
+++ b/docs/resources/compute_virtual_disk.md
@@ -46,7 +46,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/docs/resources/compute_virtual_machine.md
+++ b/docs/resources/compute_virtual_machine.md
@@ -57,7 +57,7 @@ resource "cloudtemple_compute_virtual_machine" "scratch" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -73,9 +73,9 @@ resource "cloudtemple_compute_virtual_machine" "cloned" {
 
   clone_virtual_machine_id = cloudtemple_compute_virtual_machine.scratch.id
 
-  virtual_datacenter_id = data.cloudtemple_compute_virtual_datacenter.dc.id
-  host_cluster_id       = data.cloudtemple_compute_host_cluster.flo.id
-  datastore_cluster_id  = data.cloudtemple_compute_datastore_cluster.koukou.id
+  datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  host_cluster_id      = data.cloudtemple_compute_host_cluster.flo.id
+  datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
 
   tags = {
     created_by = "Terraform"
@@ -102,10 +102,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   content_library_id      = data.cloudtemple_compute_content_library.public.id
   content_library_item_id = data.cloudtemple_compute_content_library_item.centos.id
 
-  virtual_datacenter_id = data.cloudtemple_compute_virtual_datacenter.dc.id
-  host_cluster_id       = data.cloudtemple_compute_host_cluster.flo.id
-  datastore_cluster_id  = data.cloudtemple_compute_datastore_cluster.koukou.id
-  datastore_id          = data.cloudtemple_compute_datastore.ds.id
+  datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  host_cluster_id      = data.cloudtemple_compute_host_cluster.flo.id
+  datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
+  datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
   deploy_options = {
     trak_sshpublickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpZ5juF5a/CXV9nQ0PANptTG9Gh3J0aj6yVjkF0fSkC remi@cloud-temple.com"
@@ -122,9 +122,9 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 
 ### Required
 
+- `datacenter_id` (String) The datacenter to start the virtual machine in.
 - `host_cluster_id` (String) The host cluster to start the virtual machine on.
 - `name` (String)
-- `virtual_datacenter_id` (String) The datacenter to start the virtual machine in.
 
 ### Optional
 

--- a/examples/resources/cloudtemple_backup_sla_policy_assignment/resource.tf
+++ b/examples/resources/cloudtemple_backup_sla_policy_assignment/resource.tf
@@ -20,7 +20,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/examples/resources/cloudtemple_compute_network_adapter/resource.tf
+++ b/examples/resources/cloudtemple_compute_network_adapter/resource.tf
@@ -13,7 +13,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "web" {
   name = "hello-world"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/examples/resources/cloudtemple_compute_virtual_disk/resource.tf
+++ b/examples/resources/cloudtemple_compute_virtual_disk/resource.tf
@@ -21,7 +21,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
+++ b/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
@@ -21,7 +21,7 @@ resource "cloudtemple_compute_virtual_machine" "scratch" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -37,9 +37,9 @@ resource "cloudtemple_compute_virtual_machine" "cloned" {
 
   clone_virtual_machine_id = cloudtemple_compute_virtual_machine.scratch.id
 
-  virtual_datacenter_id = data.cloudtemple_compute_virtual_datacenter.dc.id
-  host_cluster_id       = data.cloudtemple_compute_host_cluster.flo.id
-  datastore_cluster_id  = data.cloudtemple_compute_datastore_cluster.koukou.id
+  datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  host_cluster_id      = data.cloudtemple_compute_host_cluster.flo.id
+  datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
 
   tags = {
     created_by = "Terraform"
@@ -66,10 +66,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   content_library_id      = data.cloudtemple_compute_content_library.public.id
   content_library_item_id = data.cloudtemple_compute_content_library_item.centos.id
 
-  virtual_datacenter_id = data.cloudtemple_compute_virtual_datacenter.dc.id
-  host_cluster_id       = data.cloudtemple_compute_host_cluster.flo.id
-  datastore_cluster_id  = data.cloudtemple_compute_datastore_cluster.koukou.id
-  datastore_id          = data.cloudtemple_compute_datastore.ds.id
+  datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  host_cluster_id      = data.cloudtemple_compute_host_cluster.flo.id
+  datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
+  datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
   deploy_options = {
     trak_sshpublickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpZ5juF5a/CXV9nQ0PANptTG9Gh3J0aj6yVjkF0fSkC remi@cloud-temple.com"

--- a/internal/client/api_test.go
+++ b/internal/client/api_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 
 				activityId, err := client.Compute().VirtualMachine().Power(ctx, &PowerRequest{
 					ID:           vm.ID,
-					DatacenterId: vm.VirtualDatacenterId,
+					DatacenterId: vm.DatacenterId,
 					PowerAction:  "off",
 				})
 				if err != nil {

--- a/internal/client/compute_datastore.go
+++ b/internal/client/compute_datastore.go
@@ -30,7 +30,7 @@ type Datastore struct {
 func (d *DatastoreClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	DatacenterId string,
+	datacenterId string,
 	hostId string,
 	datastoreClusterId string,
 	hostClusterId string) ([]*Datastore, error) {

--- a/internal/client/compute_datastore.go
+++ b/internal/client/compute_datastore.go
@@ -30,7 +30,7 @@ type Datastore struct {
 func (d *DatastoreClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	virtualDatacenterId string,
+	DatacenterId string,
 	hostId string,
 	datastoreClusterId string,
 	hostClusterId string) ([]*Datastore, error) {

--- a/internal/client/compute_datastore_cluster.go
+++ b/internal/client/compute_datastore_cluster.go
@@ -35,7 +35,7 @@ type DatastoreClusterMetrics struct {
 	IoLoadBalanceEnabled          bool   `terraform:"io_load_balance_enabled"`
 }
 
-func (d *DatastoreClusterClient) List(ctx context.Context, machineManagerId string, DatacenterId string, hostId string, hostClusterId string) ([]*DatastoreCluster, error) {
+func (d *DatastoreClusterClient) List(ctx context.Context, machineManagerId string, datacenterId string, hostId string, hostClusterId string) ([]*DatastoreCluster, error) {
 	// TODO: filters
 	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastore_clusters")
 	resp, err := d.c.doRequest(ctx, r)

--- a/internal/client/compute_datastore_cluster.go
+++ b/internal/client/compute_datastore_cluster.go
@@ -35,7 +35,7 @@ type DatastoreClusterMetrics struct {
 	IoLoadBalanceEnabled          bool   `terraform:"io_load_balance_enabled"`
 }
 
-func (d *DatastoreClusterClient) List(ctx context.Context, machineManagerId string, virtualDatacenterId string, hostId string, hostClusterId string) ([]*DatastoreCluster, error) {
+func (d *DatastoreClusterClient) List(ctx context.Context, machineManagerId string, DatacenterId string, hostId string, hostClusterId string) ([]*DatastoreCluster, error) {
 	// TODO: filters
 	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastore_clusters")
 	resp, err := d.c.doRequest(ctx, r)

--- a/internal/client/compute_folder.go
+++ b/internal/client/compute_folder.go
@@ -19,7 +19,7 @@ type Folder struct {
 func (f *FolderClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	DatacenterId string) ([]*Folder, error) {
+	datacenterId string) ([]*Folder, error) {
 
 	// TODO: filters
 	r := f.c.newRequest("GET", "/api/compute/v1/vcenters/folders")

--- a/internal/client/compute_folder.go
+++ b/internal/client/compute_folder.go
@@ -19,7 +19,7 @@ type Folder struct {
 func (f *FolderClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	virtualDatacenterId string) ([]*Folder, error) {
+	DatacenterId string) ([]*Folder, error) {
 
 	// TODO: filters
 	r := f.c.newRequest("GET", "/api/compute/v1/vcenters/folders")

--- a/internal/client/compute_host.go
+++ b/internal/client/compute_host.go
@@ -54,7 +54,7 @@ type HostVirtualMachinesStub struct {
 func (h *HostClient) List(
 	ctx context.Context,
 	machineManagerID string,
-	virtualDatacenterID string,
+	DatacenterID string,
 	hostClusterID string,
 	datastoreID string) ([]*Host, error) {
 

--- a/internal/client/compute_host_cluster.go
+++ b/internal/client/compute_host_cluster.go
@@ -37,7 +37,7 @@ type HostClusterMetrics struct {
 func (h *HostClusterClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	DatacenterId string,
+	datacenterId string,
 	datastoreId string) ([]*HostCluster, error) {
 
 	// TODO: filters

--- a/internal/client/compute_host_cluster.go
+++ b/internal/client/compute_host_cluster.go
@@ -37,7 +37,7 @@ type HostClusterMetrics struct {
 func (h *HostClusterClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	virtualDatacenterId string,
+	DatacenterId string,
 	datastoreId string) ([]*HostCluster, error) {
 
 	// TODO: filters

--- a/internal/client/compute_network.go
+++ b/internal/client/compute_network.go
@@ -23,7 +23,7 @@ type Network struct {
 func (n *NetworkClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	virtualDatacenterId string,
+	DatacenterId string,
 	virtualMachineId string,
 	typ string,
 	virtualSwitchId string,

--- a/internal/client/compute_network.go
+++ b/internal/client/compute_network.go
@@ -23,7 +23,7 @@ type Network struct {
 func (n *NetworkClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	DatacenterId string,
+	datacenterId string,
 	virtualMachineId string,
 	typ string,
 	virtualSwitchId string,

--- a/internal/client/compute_network_adapter_test.go
+++ b/internal/client/compute_network_adapter_test.go
@@ -91,7 +91,7 @@ func TestNetworkAdapterClient_Create(t *testing.T) {
 
 	activityId, err = client.Compute().VirtualMachine().Power(ctx, &PowerRequest{
 		ID:             vm.ID,
-		DatacenterId:   vm.VirtualDatacenterId,
+		DatacenterId:   vm.DatacenterId,
 		PowerAction:    "on",
 		ForceEnterBIOS: false,
 	})
@@ -136,7 +136,7 @@ func TestNetworkAdapterClient_Create(t *testing.T) {
 
 	activityId, err = client.Compute().VirtualMachine().Power(ctx, &PowerRequest{
 		ID:             vm.ID,
-		DatacenterId:   vm.VirtualDatacenterId,
+		DatacenterId:   vm.DatacenterId,
 		PowerAction:    "off",
 		ForceEnterBIOS: false,
 	})

--- a/internal/client/compute_resource_pool.go
+++ b/internal/client/compute_resource_pool.go
@@ -43,7 +43,7 @@ type ResourcePoolMemoryMetrics struct {
 func (rp *ResourcePoolClient) List(
 	ctx context.Context,
 	machineManagerID string,
-	virtualDatacenterID string,
+	DatacenterID string,
 	hostClusterID string) ([]*ResourcePool, error) {
 
 	// TODO: filters

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -35,7 +35,7 @@ type VirtualMachine struct {
 	MemoryUsage                    int                             `terraform:"memory_usage"`
 	Tools                          string                          `terraform:"tools"`
 	ToolsVersion                   int                             `terraform:"tools_version"`
-	VirtualDatacenterId            string                          `terraform:"virtual_datacenter_id"`
+	DatacenterId                   string                          `terraform:"virtual_datacenter_id"`
 	DistributedVirtualPortGroupIds []string                        `terraform:"distributed_virtual_port_group_ids"`
 	SppMode                        string                          `terraform:"spp_mode"`
 	Snapshoted                     bool                            `terraform:"snapshoted"`

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -35,7 +35,7 @@ type VirtualMachine struct {
 	MemoryUsage                    int                             `terraform:"memory_usage"`
 	Tools                          string                          `terraform:"tools"`
 	ToolsVersion                   int                             `terraform:"tools_version"`
-	DatacenterId                   string                          `terraform:"virtual_datacenter_id"`
+	DatacenterId                   string                          `terraform:"datacenter_id"`
 	DistributedVirtualPortGroupIds []string                        `terraform:"distributed_virtual_port_group_ids"`
 	SppMode                        string                          `terraform:"spp_mode"`
 	Snapshoted                     bool                            `terraform:"snapshoted"`

--- a/internal/client/compute_virtual_machine_test.go
+++ b/internal/client/compute_virtual_machine_test.go
@@ -55,7 +55,7 @@ func TestCompute_VirtualMachineRead(t *testing.T) {
 		MemoryUsage:                    10485760,
 		Tools:                          "toolsNotInstalled",
 		ToolsVersion:                   0,
-		VirtualDatacenterId:            "85d53d08-0fa9-491e-ab89-90919516df25",
+		DatacenterId:                   "85d53d08-0fa9-491e-ab89-90919516df25",
 		DistributedVirtualPortGroupIds: []string{},
 		SppMode:                        "production",
 		Snapshoted:                     false,
@@ -199,7 +199,7 @@ func TestCompute_UpdateAndPower(t *testing.T) {
 
 	activityId, err = client.Compute().VirtualMachine().Power(ctx, &PowerRequest{
 		ID:           instanceId,
-		DatacenterId: vm.VirtualDatacenterId,
+		DatacenterId: vm.DatacenterId,
 		PowerAction:  "on",
 	})
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestCompute_UpdateAndPower(t *testing.T) {
 
 	activityId, err = client.Compute().VirtualMachine().Power(ctx, &PowerRequest{
 		ID:           instanceId,
-		DatacenterId: vm.VirtualDatacenterId,
+		DatacenterId: vm.DatacenterId,
 		PowerAction:  "off",
 	})
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestVirtualMachineClient_Relocate(t *testing.T) {
 
 	vm, err := client.Compute().VirtualMachine().Read(ctx, instanceId)
 	require.NoError(t, err)
-	require.Equal(t, "ac33c033-693b-4fc5-9196-26df77291dbb", vm.VirtualDatacenterId)
+	require.Equal(t, "ac33c033-693b-4fc5-9196-26df77291dbb", vm.DatacenterId)
 
 	activityId, err = client.Compute().VirtualMachine().Delete(ctx, instanceId)
 	require.NoError(t, err)

--- a/internal/client/compute_virtual_switch.go
+++ b/internal/client/compute_virtual_switch.go
@@ -21,7 +21,7 @@ type VirtualSwitch struct {
 func (v *VirtualSwitchClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	DatacenterId string,
+	datacenterId string,
 	hostClusterId string) ([]*VirtualSwitch, error) {
 
 	// TODO: filters

--- a/internal/client/compute_virtual_switch.go
+++ b/internal/client/compute_virtual_switch.go
@@ -21,7 +21,7 @@ type VirtualSwitch struct {
 func (v *VirtualSwitchClient) List(
 	ctx context.Context,
 	machineManagerId string,
-	virtualDatacenterId string,
+	DatacenterId string,
 	hostClusterId string) ([]*VirtualSwitch, error) {
 
 	// TODO: filters

--- a/internal/provider/data_source_compute_virtual_machine.go
+++ b/internal/provider/data_source_compute_virtual_machine.go
@@ -124,7 +124,7 @@ func dataSourceVirtualMachine() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"virtual_datacenter_id": {
+			"datacenter_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/internal/provider/data_source_compute_virtual_machines.go
+++ b/internal/provider/data_source_compute_virtual_machines.go
@@ -115,7 +115,7 @@ func dataSourceVirtualMachines() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"virtual_datacenter_id": {
+						"datacenter_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 			if vm.PowerState == "running" {
 				activityId, err := c.Compute().VirtualMachine().Power(ctx, &client.PowerRequest{
 					ID:           vm.ID,
-					DatacenterId: vm.VirtualDatacenterId,
+					DatacenterId: vm.DatacenterId,
 					PowerAction:  "off",
 				})
 				if err != nil {

--- a/internal/provider/resource_backup_sla_policy_assignment_test.go
+++ b/internal/provider/resource_backup_sla_policy_assignment_test.go
@@ -46,7 +46,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform-sla-policy"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/internal/provider/resource_compute_network_adapter_test.go
+++ b/internal/provider/resource_compute_network_adapter_test.go
@@ -96,7 +96,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform-network-adapter"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -130,7 +130,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "bar" {
   name = "test-terraform-network-adapter"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -165,7 +165,7 @@ resource "cloudtemple_compute_virtual_machine" "bar" {
   name        = "test-terraform-network-adapter-connected"
   power_state = "on"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -201,7 +201,7 @@ resource "cloudtemple_compute_virtual_machine" "bar" {
   name        = "test-terraform-network-adapter-connected"
   power_state = "on"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -235,7 +235,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "bar" {
   name        = "test-terraform-network-adapter-connected"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/internal/provider/resource_compute_virtual_disk_test.go
+++ b/internal/provider/resource_compute_virtual_disk_test.go
@@ -69,7 +69,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform-virtual-disk"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -100,7 +100,7 @@ data "cloudtemple_compute_datastore_cluster" "koukou" {
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform-virtual-disk"
 
-  virtual_datacenter_id        = data.cloudtemple_compute_virtual_datacenter.dc.id
+  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.dc.id
   host_cluster_id              = data.cloudtemple_compute_host_cluster.flo.id
   datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.koukou.id
   guest_operating_system_moref = "amazonlinux2_64Guest"

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -81,7 +81,7 @@ Virtual machines can be created using three different methods:
 				ConflictsWith: []string{"clone_virtual_machine_id", "content_library_item_id"},
 				AtLeastOneOf:  []string{"clone_virtual_machine_id", "guest_operating_system_moref", "content_library_item_id"},
 			},
-			"virtual_datacenter_id": {
+			"datacenter_id": {
 				Type:         schema.TypeString,
 				Description:  "The datacenter to start the virtual machine in.",
 				Required:     true,
@@ -385,7 +385,7 @@ func computeVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, me
 			Name:              name,
 			VirtualMachineId:  cloneVirtualMachineId,
 			PowerOn:           d.Get("power_state").(string) == "on",
-			DatacenterId:      d.Get("virtual_datacenter_id").(string),
+			DatacenterId:      d.Get("datacenter_id").(string),
 			HostClusterId:     d.Get("host_cluster_id").(string),
 			HostId:            d.Get("host_id").(string),
 			DatatoreClusterId: d.Get("datastore_cluster_id").(string),
@@ -422,7 +422,7 @@ func computeVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, me
 			HostClusterId:        d.Get("host_cluster_id").(string),
 			HostId:               d.Get("host_id").(string),
 			DatastoreId:          d.Get("datastore_id").(string),
-			DatacenterId:         d.Get("virtual_datacenter_id").(string),
+			DatacenterId:         d.Get("datacenter_id").(string),
 			PowerOn:              d.Get("power_state").(string) == "on",
 			DeployOptions:        deployOptions,
 		})
@@ -440,7 +440,7 @@ func computeVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, me
 		fromScratch = true
 		activityId, err = c.Compute().VirtualMachine().Create(ctx, &client.CreateVirtualMachineRequest{
 			Name:                      name,
-			DatacenterId:              d.Get("virtual_datacenter_id").(string),
+			DatacenterId:              d.Get("datacenter_id").(string),
 			HostId:                    d.Get("host_id").(string),
 			HostClusterId:             d.Get("host_cluster_id").(string),
 			DatastoreId:               d.Get("datastore_id").(string),
@@ -538,11 +538,11 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 		}
 	}
 
-	if d.HasChange("virtual_datacenter_id") || d.HasChange("host_id") || d.HasChange("host_cluster_id") || d.HasChange("datastore_id") || d.HasChange("datastore_cluster_id") {
+	if d.HasChange("datacenter_id") || d.HasChange("host_id") || d.HasChange("host_cluster_id") || d.HasChange("datastore_id") || d.HasChange("datastore_cluster_id") {
 		activityId, err := c.Compute().VirtualMachine().Relocate(ctx, &client.RelocateVirtualMachineRequest{
 			VirtualMachines:    []string{d.Id()},
 			Priority:           "highPriority",
-			DatacenterId:       d.Get("virtual_datacenter_id").(string),
+			DatacenterId:       d.Get("datacenter_id").(string),
 			HostId:             d.Get("host_id").(string),
 			HostClusterId:      d.Get("host_cluster_id").(string),
 			DatastoreId:        d.Get("datastore_id").(string),

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -567,7 +567,7 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 
 		activityId, err = c.Compute().VirtualMachine().Power(ctx, &client.PowerRequest{
 			ID:           d.Id(),
-			DatacenterId: vm.VirtualDatacenterId,
+			DatacenterId: vm.DatacenterId,
 			PowerAction:  powerState,
 		})
 		if err != nil {

--- a/internal/provider/resource_compute_virtual_machine_test.go
+++ b/internal/provider/resource_compute_virtual_machine_test.go
@@ -16,7 +16,7 @@ func TestAccResourceVirtualMachine(t *testing.T) {
 				Config: testAccResourceVirtualMachine,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "name", "test-terraform"),
-					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "virtual_datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
+					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "host_cluster_id", "dde72065-60f4-4577-836d-6ea074384d62"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "datastore_cluster_id", "6b06b226-ef55-4a0a-92bc-7aa071681b1b"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "guest_operating_system_moref", "amazonlinux2_64Guest"),
@@ -29,7 +29,7 @@ func TestAccResourceVirtualMachine(t *testing.T) {
 				Config: testAccResourceVirtualMachineRelocate,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "name", "test-terraform"),
-					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "virtual_datacenter_id", "ac33c033-693b-4fc5-9196-26df77291dbb"),
+					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "datacenter_id", "ac33c033-693b-4fc5-9196-26df77291dbb"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "host_cluster_id", "083b0ed7-8b0f-4cec-be47-78f48b457e6a"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "datastore_cluster_id", "1a996110-2746-4725-958f-f6fceef05b32"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.foo", "guest_operating_system_moref", "amazonlinux2_64Guest"),
@@ -91,7 +91,7 @@ func TestAccResourceVirtualMachine(t *testing.T) {
 				Config: testAccResourceVirtualMachineClone,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "name", "test-terraform-cloned"),
-					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "virtual_datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
+					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "host_cluster_id", "dde72065-60f4-4577-836d-6ea074384d62"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "datastore_cluster_id", "6b06b226-ef55-4a0a-92bc-7aa071681b1b"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.cloned", "tags.%", "1"),
@@ -102,7 +102,7 @@ func TestAccResourceVirtualMachine(t *testing.T) {
 				Config: testAccResourceVirtualMachineContentLibraryDeploy,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "name", "test-terraform-content-library-deployed"),
-					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "virtual_datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
+					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "datacenter_id", "85d53d08-0fa9-491e-ab89-90919516df25"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "host_cluster_id", "dde72065-60f4-4577-836d-6ea074384d62"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "tags.%", "1"),
 					resource.TestCheckResourceAttr("cloudtemple_compute_virtual_machine.content-library-deployed", "tags.environment", "cloned-from-content-library"),
@@ -116,7 +116,7 @@ const testAccResourceVirtualMachine = `
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform"
 
-  virtual_datacenter_id        = "85d53d08-0fa9-491e-ab89-90919516df25"
+  datacenter_id                = "85d53d08-0fa9-491e-ab89-90919516df25"
   host_cluster_id              = "dde72065-60f4-4577-836d-6ea074384d62"
   datastore_cluster_id         = "6b06b226-ef55-4a0a-92bc-7aa071681b1b"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -131,7 +131,7 @@ const testAccResourceVirtualMachineRelocate = `
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform"
 
-  virtual_datacenter_id        = "ac33c033-693b-4fc5-9196-26df77291dbb"
+  datacenter_id                = "ac33c033-693b-4fc5-9196-26df77291dbb"
   host_cluster_id              = "083b0ed7-8b0f-4cec-be47-78f48b457e6a"
   datastore_cluster_id         = "1a996110-2746-4725-958f-f6fceef05b32"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -153,7 +153,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true
 
-  virtual_datacenter_id        = "ac33c033-693b-4fc5-9196-26df77291dbb"
+  datacenter_id                = "ac33c033-693b-4fc5-9196-26df77291dbb"
   host_cluster_id              = "083b0ed7-8b0f-4cec-be47-78f48b457e6a"
   datastore_cluster_id         = "1a996110-2746-4725-958f-f6fceef05b32"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -168,7 +168,7 @@ const testAccResourceVirtualMachineRename = `
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform-rename"
 
-  virtual_datacenter_id        = "ac33c033-693b-4fc5-9196-26df77291dbb"
+  datacenter_id                = "ac33c033-693b-4fc5-9196-26df77291dbb"
   host_cluster_id              = "083b0ed7-8b0f-4cec-be47-78f48b457e6a"
   datastore_cluster_id         = "1a996110-2746-4725-958f-f6fceef05b32"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -184,7 +184,7 @@ resource "cloudtemple_compute_virtual_machine" "foo" {
   name        = "test-terraform-rename"
   power_state = "on"
 
-  virtual_datacenter_id        = "ac33c033-693b-4fc5-9196-26df77291dbb"
+  datacenter_id                = "ac33c033-693b-4fc5-9196-26df77291dbb"
   host_cluster_id              = "083b0ed7-8b0f-4cec-be47-78f48b457e6a"
   datastore_cluster_id         = "1a996110-2746-4725-958f-f6fceef05b32"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -195,7 +195,7 @@ const testAccResourceVirtualMachineClone = `
 resource "cloudtemple_compute_virtual_machine" "foo" {
   name = "test-terraform"
 
-  virtual_datacenter_id        = "ac33c033-693b-4fc5-9196-26df77291dbb"
+  datacenter_id                = "ac33c033-693b-4fc5-9196-26df77291dbb"
   host_cluster_id              = "083b0ed7-8b0f-4cec-be47-78f48b457e6a"
   datastore_cluster_id         = "1a996110-2746-4725-958f-f6fceef05b32"
   guest_operating_system_moref = "amazonlinux2_64Guest"
@@ -209,7 +209,7 @@ resource "cloudtemple_compute_virtual_machine" "cloned" {
   name = "test-terraform-cloned"
 
   clone_virtual_machine_id     = cloudtemple_compute_virtual_machine.foo.id
-  virtual_datacenter_id        = "85d53d08-0fa9-491e-ab89-90919516df25"
+  datacenter_id                = "85d53d08-0fa9-491e-ab89-90919516df25"
   host_cluster_id              = "dde72065-60f4-4577-836d-6ea074384d62"
   datastore_cluster_id         = "6b06b226-ef55-4a0a-92bc-7aa071681b1b"
 
@@ -235,7 +235,7 @@ resource "cloudtemple_compute_virtual_machine" "content-library-deployed" {
   content_library_id      = data.cloudtemple_compute_content_library.foo.id
   content_library_item_id = data.cloudtemple_compute_content_library_item.foo.id
 
-  virtual_datacenter_id = "85d53d08-0fa9-491e-ab89-90919516df25"
+  datacenter_id         = "85d53d08-0fa9-491e-ab89-90919516df25"
   host_cluster_id       = "dde72065-60f4-4577-836d-6ea074384d62"
   datastore_id          = "d439d467-943a-49f5-a022-c0c25b737022"
 


### PR DESCRIPTION
Fix issue #20 #25 

With 6ca12712d05308547914be8684696ef5745e7981, this PR introduces breaking changes on the following blocks:

resources:

- compute_virtual_machine

data sources:

- compute_virtual_machine
- compute_virtual_machines