### PR TITLE
35 data source cloudtemple compute host cluster returns the first it finds

### DIFF
--- a/docs/data-sources/compute_datastore.md
+++ b/docs/data-sources/compute_datastore.md
@@ -29,6 +29,10 @@ data "cloudtemple_compute_datastore" "name" {
 
 ### Optional
 
+- `datacenter_id` (String)
+- `host_cluster_id` (String)
+- `host_id` (String)
+- `machine_manager_id` (String)
 - `name` (String)
 
 ### Read-Only
@@ -39,7 +43,6 @@ data "cloudtemple_compute_datastore" "name" {
 - `hosts_names` (List of String)
 - `hosts_number` (Number)
 - `id` (String) The ID of this resource.
-- `machine_manager_id` (String)
 - `maintenance_status` (String)
 - `max_capacity` (Number)
 - `moref` (String)

--- a/docs/data-sources/compute_datastore_cluster.md
+++ b/docs/data-sources/compute_datastore_cluster.md
@@ -29,13 +29,16 @@ data "cloudtemple_compute_datastore_cluster" "name" {
 
 ### Optional
 
+- `datacenter_id` (String)
+- `host_cluster_id` (String)
+- `host_id` (String)
+- `machine_manager_id` (String)
 - `name` (String)
 
 ### Read-Only
 
 - `datastores` (List of String)
 - `id` (String) The ID of this resource.
-- `machine_manager_id` (String)
 - `metrics` (List of Object) (see [below for nested schema](#nestedatt--metrics))
 - `moref` (String)
 

--- a/docs/data-sources/compute_datastores.md
+++ b/docs/data-sources/compute_datastores.md
@@ -42,6 +42,5 @@ Read-Only:
 - `name` (String)
 - `type` (String)
 - `unique_id` (String)
-- `virtual_machines_number` (Number)
 
 

--- a/docs/data-sources/compute_host_cluster.md
+++ b/docs/data-sources/compute_host_cluster.md
@@ -27,13 +27,15 @@ data "cloudtemple_compute_host_cluster" "name" {
 
 ### Optional
 
+- `datacenter_id` (String)
+- `datastore_id` (String)
+- `machine_manager_id` (String)
 - `name` (String)
 
 ### Read-Only
 
 - `hosts` (List of Object) (see [below for nested schema](#nestedatt--hosts))
 - `id` (String) The ID of this resource.
-- `machine_manager_id` (String)
 - `metrics` (List of Object) (see [below for nested schema](#nestedatt--metrics))
 - `moref` (String)
 - `virtual_machines_number` (Number)

--- a/docs/data-sources/compute_virtual_datacenter.md
+++ b/docs/data-sources/compute_virtual_datacenter.md
@@ -27,12 +27,12 @@ data "cloudtemple_compute_virtual_datacenter" "name" {
 
 ### Optional
 
+- `machine_manager_id` (String)
 - `name` (String)
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `machine_manager_id` (String)
 - `tenant_id` (String)
 
 

--- a/internal/client/backup_job_session_test.go
+++ b/internal/client/backup_job_session_test.go
@@ -16,7 +16,7 @@ func TestBackupJobSessionClient_List(t *testing.T) {
 
 	var jobSession *BackupJobSession
 	for _, jb := range jobSessions {
-		if jb.ID == "1668240000212" {
+		if jb.ID == "1681977600058" {
 			jobSession = jb
 			break
 		}
@@ -24,26 +24,20 @@ func TestBackupJobSessionClient_List(t *testing.T) {
 	require.NotNil(t, jobSession)
 
 	expected := &BackupJobSession{
-		ID:            "1668240000212",
-		JobName:       "vmware_SLA_CATALOG_SPP",
+		ID:            "1681977600058",
+		JobName:       "catalog_SLA_CATALOG_SPP",
 		SlaPolicyType: "protection",
-		JobId:         "1166",
+		JobId:         "1003",
 		Type:          "protection",
-		Duration:      69102,
-		Start:         1668240001081,
-		End:           1668240070183,
-		Status:        "FAILED",
-		Statistics: BackupStatistics{
-			Total:   1,
-			Success: 0,
-			Failed:  1,
-			Skipped: 0,
-		},
+		Duration:      23036,
+		Start:         1681977600551,
+		End:           1681977623587,
+		Status:        "COMPLETED",
 		SLAPolicies: []*BackupSLAPolicyStub{
 			{
-				ID:   "2115",
+				ID:   "2103",
 				Name: "SLA_CATALOG_SPP",
-				HREF: "https://spp1-ctlabs-eqx6.backup.cloud-temple.lan/api/spec/storageprofile/2115",
+				HREF: "https://10.12.8.1/api/spec/storageprofile/2103",
 			},
 		},
 	}

--- a/internal/client/backup_job_test.go
+++ b/internal/client/backup_job_test.go
@@ -28,7 +28,7 @@ func TestBackupJobClient_List(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Len(t, jobs, 1)
+	require.Len(t, jobs, 2)
 }
 
 func TestBackupJobClient_Read(t *testing.T) {

--- a/internal/client/backup_metrics_test.go
+++ b/internal/client/backup_metrics_test.go
@@ -33,13 +33,13 @@ func TestBackupMetricsClient_Policies(t *testing.T) {
 	require.GreaterOrEqual(t, len(policiesMetrics), 1)
 
 	expected := &BackupMetricsPolicies{
-		Name:        "SLA_DAILY",
+		Name:        "sla001-daily-th3s",
 		TriggerType: "DAILY",
 	}
 
 	var found bool
 	for _, pm := range policiesMetrics {
-		if pm.Name == "SLA_DAILY" {
+		if pm.Name == "sla001-daily-th3s" {
 			// Ignore some fields
 			pm.NumberOfProtectedVM = 0
 
@@ -58,11 +58,11 @@ func TestBackupMetricsClient_Platform(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &BackupMetricsPlatform{
-		Version:        "10.1.12",
-		Build:          "124",
-		Date:           "Wed Sep  7 14:02:15 EDT 2022",
+		Version:        "10.1.14",
+		Build:          "158",
+		Date:           "Thu Mar  2 12:22:05 EST 2023",
 		Product:        "Spectrum Protect Plus",
-		Epoch:          1662573735000,
+		Epoch:          1677777725000,
 		DeploymentType: "standard",
 	}
 

--- a/internal/client/backup_site_test.go
+++ b/internal/client/backup_site_test.go
@@ -16,7 +16,7 @@ func TestBackupSiteClient_List(t *testing.T) {
 
 	var backupSite *BackupSite
 	for _, bs := range backupSites {
-		if bs.ID == "7e76f68f-3392-401b-9c3a-d504af96643d" {
+		if bs.ID == "98e75cf9-6b3c-4422-8d4e-826a032c2bf1" {
 			backupSite = bs
 			break
 		}
@@ -24,8 +24,8 @@ func TestBackupSiteClient_List(t *testing.T) {
 	require.NotNil(t, backupSite)
 
 	expected := &BackupSite{
-		ID:   "7e76f68f-3392-401b-9c3a-d504af96643d",
-		Name: "DC-EQX6",
+		ID:   "98e75cf9-6b3c-4422-8d4e-826a032c2bf1",
+		Name: "DC-TH3S",
 	}
 	require.Equal(t, expected, backupSite)
 }

--- a/internal/client/backup_sla_policy_test.go
+++ b/internal/client/backup_sla_policy_test.go
@@ -16,7 +16,7 @@ func TestBackupSLAPolicyClient_List(t *testing.T) {
 
 	var found bool
 	for _, sl := range slaPolicies {
-		if sl.ID == "442718ef-44a1-43d7-9b57-2d910d74e928" {
+		if sl.ID == "10c6a0f7-076b-43aa-9230-bc975dcb1f30" {
 			found = true
 			break
 		}
@@ -33,29 +33,24 @@ func TestBackupSLAPolicyClient_List(t *testing.T) {
 
 func TestBackupSLAPolicyClient_Read(t *testing.T) {
 	ctx := context.Background()
-	slaPolicy, err := client.Backup().SLAPolicy().Read(ctx, "442718ef-44a1-43d7-9b57-2d910d74e928")
+	slaPolicy, err := client.Backup().SLAPolicy().Read(ctx, "10c6a0f7-076b-43aa-9230-bc975dcb1f30")
 	require.NoError(t, err)
 
 	expected := &BackupSLAPolicy{
-		ID:   "442718ef-44a1-43d7-9b57-2d910d74e928",
-		Name: "SLA_ADMIN",
+		ID:   "10c6a0f7-076b-43aa-9230-bc975dcb1f30",
+		Name: "nobackup",
 		SubPolicies: []*BackupSLASubPolicy{
 			{
 				Type:          "REPLICATION",
 				UseEncryption: false,
 				Software:      true,
-				Site:          "DC-EQX6",
+				Site:          "DC-TH3S",
 				Retention: BackupSLAPolicyRetention{
 					Age: 15,
 				},
-				Trigger: BackupSLAPolicyTrigger{
-					Frequency:    1,
-					Type:         "DAILY",
-					ActivateDate: 1568617200000,
-				},
 				Target: BackupSLAPolicyTarget{
 					ID:           "1000",
-					Href:         "https://spp1-ctlabs-eqx6.backup.cloud-temple.lan/api/site/1000",
+					Href:         "https://10.12.8.1/api/site/1000",
 					ResourceType: "site",
 				},
 			},

--- a/internal/client/compute_datastore.go
+++ b/internal/client/compute_datastore.go
@@ -27,16 +27,22 @@ type Datastore struct {
 	AssociatedFolder      string   `terraform:"associated_folder"`
 }
 
+type DatastoreFilter struct {
+	Name               string `filter:"name"`
+	MachineManagerId   string `filter:"machineManagerId"`
+	DatacenterId       string `filter:"datacenterId"`
+	HostId             string `filter:"hostId"`
+	HostClusterId      string `filter:"hostClusterId"`
+	DatastoreClusterId string `filter:"datastoreClusterId"`
+}
+
 func (d *DatastoreClient) List(
 	ctx context.Context,
-	machineManagerId string,
-	datacenterId string,
-	hostId string,
-	datastoreClusterId string,
-	hostClusterId string) ([]*Datastore, error) {
+	filter *DatastoreFilter) ([]*Datastore, error) {
 
 	// TODO: filters
 	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastores")
+	r.addFilter(filter)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_datastore_cluster.go
+++ b/internal/client/compute_datastore_cluster.go
@@ -19,6 +19,14 @@ type DatastoreCluster struct {
 	Metrics          DatastoreClusterMetrics `terraform:"metrics"`
 }
 
+type DatastoreClusterFilter struct {
+	Name             string `filter:"name"`
+	MachineManagerId string `filter:"machineManagerId"`
+	DatacenterId     string `filter:"datacenterId"`
+	HostId           string `filter:"hostId"`
+	HostClusterId    string `filter:"hostClusterId"`
+}
+
 type DatastoreClusterMetrics struct {
 	FreeCapacity                  int    `terraform:"free_capacity"`
 	MaxCapacity                   int    `terraform:"max_capacity"`
@@ -35,9 +43,10 @@ type DatastoreClusterMetrics struct {
 	IoLoadBalanceEnabled          bool   `terraform:"io_load_balance_enabled"`
 }
 
-func (d *DatastoreClusterClient) List(ctx context.Context, machineManagerId string, datacenterId string, hostId string, hostClusterId string) ([]*DatastoreCluster, error) {
+func (d *DatastoreClusterClient) List(ctx context.Context, filter *DatastoreClusterFilter) ([]*DatastoreCluster, error) {
 	// TODO: filters
 	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastore_clusters")
+	r.addFilter(filter)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_datastore_cluster_test.go
+++ b/internal/client/compute_datastore_cluster_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCompute_DatastoreClusterList(t *testing.T) {
 	ctx := context.Background()
-	datastoreClusters, err := client.Compute().DatastoreCluster().List(ctx, "", "", "", "")
+	datastoreClusters, err := client.Compute().DatastoreCluster().List(ctx, nil)
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, len(datastoreClusters), 1)

--- a/internal/client/compute_datastore_test.go
+++ b/internal/client/compute_datastore_test.go
@@ -9,14 +9,16 @@ import (
 
 func TestCompute_DatastoreList(t *testing.T) {
 	ctx := context.Background()
-	datastores, err := client.Compute().Datastore().List(ctx, "", "", "", "", "")
+	datastores, err := client.Compute().Datastore().List(ctx, &DatastoreFilter{
+		DatacenterId: "7b56f202-83e3-4112-9771-8fb001fbac3e",
+	})
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, len(datastores), 1)
 
 	var found bool
 	for _, dc := range datastores {
-		if dc.ID == "d439d467-943a-49f5-a022-c0c25b737022" {
+		if dc.ID == "88fb9089-cf33-47f0-938a-fe792f4a9039" {
 			found = true
 			break
 		}
@@ -26,7 +28,7 @@ func TestCompute_DatastoreList(t *testing.T) {
 
 func TestCompute_DatastoreRead(t *testing.T) {
 	ctx := context.Background()
-	datastore, err := client.Compute().Datastore().Read(ctx, "d439d467-943a-49f5-a022-c0c25b737022")
+	datastore, err := client.Compute().Datastore().Read(ctx, "88fb9089-cf33-47f0-938a-fe792f4a9039")
 	require.NoError(t, err)
 
 	// Skip checking changes on metrics

--- a/internal/client/compute_host_cluster.go
+++ b/internal/client/compute_host_cluster.go
@@ -20,6 +20,13 @@ type HostCluster struct {
 	MachineManagerId      string                `terraform:"machine_manager_id"`
 }
 
+type HostClusterFilter struct {
+	Name             string `filter:"name"`
+	MachineManagerId string `filter:"machineManagerId"`
+	DatacenterId     string `filter:"datacenterId"`
+	DatastoreId      string `filter:"datastoreId"`
+}
+
 type HostClusterHostStub struct {
 	ID   string `terraform:"id"`
 	Type string `terraform:"type"`
@@ -36,12 +43,11 @@ type HostClusterMetrics struct {
 
 func (h *HostClusterClient) List(
 	ctx context.Context,
-	machineManagerId string,
-	datacenterId string,
-	datastoreId string) ([]*HostCluster, error) {
+	filter *HostClusterFilter) ([]*HostCluster, error) {
 
 	// TODO: filters
 	r := h.c.newRequest("GET", "/api/compute/v1/vcenters/host_clusters")
+	r.addFilter(filter)
 	resp, err := h.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_host_cluster_test.go
+++ b/internal/client/compute_host_cluster_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestCompute_HostClusterList(t *testing.T) {
 	ctx := context.Background()
-	hostClusters, err := client.Compute().HostCluster().List(ctx, "9dba240e-a605-4103-bac7-5336d3ffd124", "", "")
+	hostClusters, err := client.Compute().HostCluster().List(ctx, nil)
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, len(hostClusters), 1)
 
 	var found bool
 	for _, hc := range hostClusters {
-		if hc.ID == "dde72065-60f4-4577-836d-6ea074384d62" {
+		if hc.ID == "bd5d8bf4-953a-46fb-9997-45467ba1ae6f" {
 			found = true
 			break
 		}
@@ -26,7 +26,7 @@ func TestCompute_HostClusterList(t *testing.T) {
 
 func TestCompute_HostClusterRead(t *testing.T) {
 	ctx := context.Background()
-	hostCluster, err := client.Compute().HostCluster().Read(ctx, "dde72065-60f4-4577-836d-6ea074384d62")
+	hostCluster, err := client.Compute().HostCluster().Read(ctx, "bd5d8bf4-953a-46fb-9997-45467ba1ae6f")
 	require.NoError(t, err)
 
 	// ignore changes to metrics
@@ -34,17 +34,20 @@ func TestCompute_HostClusterRead(t *testing.T) {
 	hostCluster.VirtualMachinesNumber = 0
 
 	expected := &HostCluster{
-		ID:    "dde72065-60f4-4577-836d-6ea074384d62",
-		Name:  "clu002-ucs01_FLO",
-		Moref: "domain-c1041",
+		ID:    "bd5d8bf4-953a-46fb-9997-45467ba1ae6f",
+		Name:  "clu001-ucs12",
+		Moref: "domain-c1008",
 		Hosts: []HostClusterHostStub{
 			{
-				ID:   "host-1046",
+				ID:   "host-1022",
+				Type: "HostSystem",
+			},
+			{
+				ID:   "host-1015",
 				Type: "HostSystem",
 			},
 		},
-		Metrics:          HostClusterMetrics{},
-		MachineManagerId: "",
+		Metrics: HostClusterMetrics{},
 	}
 	require.Equal(t, expected, hostCluster)
 }

--- a/internal/client/compute_virtual_datacenter.go
+++ b/internal/client/compute_virtual_datacenter.go
@@ -17,13 +17,18 @@ type VirtualDatacenter struct {
 	TenantID         string `terraform:"tenant_id"`
 }
 
+type VirtualDatacenterFilter struct {
+	Name             string `filter:"name"`
+	MachineManagerId string `filter:"machineManagerId"`
+}
+
 func (v *VirtualDatacenterClient) List(
 	ctx context.Context,
-	machineManagerId string,
-	name string) ([]*VirtualDatacenter, error) {
+	filter *VirtualDatacenterFilter) ([]*VirtualDatacenter, error) {
 
 	// TODO: filters
 	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_datacenters")
+	r.addFilter(filter)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_virtual_datacenter_test.go
+++ b/internal/client/compute_virtual_datacenter_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCompute_VirtualDatacenterList(t *testing.T) {
 	ctx := context.Background()
-	virtualDatacenters, err := client.Compute().VirtualDatacenter().List(ctx, "", "")
+	virtualDatacenters, err := client.Compute().VirtualDatacenter().List(ctx, nil)
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, len(virtualDatacenters), 1)

--- a/internal/provider/data_source_backup_jobs_test.go
+++ b/internal/provider/data_source_backup_jobs_test.go
@@ -14,7 +14,7 @@ func TestAccDataBackupJobs(t *testing.T) {
 			{
 				Config: testAccDataBackupJobs,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_jobs.foo", "jobs.#", "9"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_jobs.foo", "jobs.#", "10"),
 				),
 			},
 		},

--- a/internal/provider/data_source_backup_sla_policy_test.go
+++ b/internal/provider/data_source_backup_sla_policy_test.go
@@ -15,27 +15,24 @@ func TestAccDataSourceBackupSLAPolicy(t *testing.T) {
 			{
 				Config: testAccDataSourceBackupSLAPolicy,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "id", "442718ef-44a1-43d7-9b57-2d910d74e928"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "name", "SLA_ADMIN"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "id", "10c6a0f7-076b-43aa-9230-bc975dcb1f30"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "name", "nobackup"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.#", "1"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.type", "REPLICATION"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.use_encryption", "false"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.software", "true"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.site", "DC-EQX6"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.site", "DC-TH3S"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.retention.0.age", "15"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.trigger.0.frequency", "1"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.trigger.0.type", "DAILY"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.trigger.0.activate_date", "1568617200000"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.target.0.id", "1000"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.target.0.href", "https://spp1-ctlabs-eqx6.backup.cloud-temple.lan/api/site/1000"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.target.0.href", "https://10.12.8.1/api/site/1000"),
 					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "sub_policies.0.target.0.resource_type", "site"),
 				),
 			},
 			{
 				Config: testAccDataSourceBackupSLAPolicyName,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "id", "442718ef-44a1-43d7-9b57-2d910d74e928"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "name", "SLA_ADMIN"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "id", "10c6a0f7-076b-43aa-9230-bc975dcb1f30"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_sla_policy.foo", "name", "nobackup"),
 				),
 			},
 			{
@@ -48,13 +45,13 @@ func TestAccDataSourceBackupSLAPolicy(t *testing.T) {
 
 const testAccDataSourceBackupSLAPolicy = `
 data "cloudtemple_backup_sla_policy" "foo" {
-  id = "442718ef-44a1-43d7-9b57-2d910d74e928"
+  id = "10c6a0f7-076b-43aa-9230-bc975dcb1f30"
 }
 `
 
 const testAccDataSourceBackupSLAPolicyName = `
 data "cloudtemple_backup_sla_policy" "foo" {
-  name = "SLA_ADMIN"
+  name = "nobackup"
 }
 `
 

--- a/internal/provider/data_source_backup_spp_server_test.go
+++ b/internal/provider/data_source_backup_spp_server_test.go
@@ -15,17 +15,17 @@ func TestAccDataSourceBackupSPPServer(t *testing.T) {
 			{
 				Config: testAccDataSourceBackupSPPServer,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "id", "a3d46fb5-29af-4b98-a665-1e82a62fd6d3"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "name", "10"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "address", "10.1.11.32"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "id", "a34d230c-dd0f-4fa9-a099-bec7d8609bd4"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "name", "spp01-rec-th3s"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "address", "spp01-rec-th3s.rbackup"),
 				),
 			},
 			{
 				Config: testAccDataSourceBackupSPPServerName,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "id", "a3d46fb5-29af-4b98-a665-1e82a62fd6d3"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "name", "10"),
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "address", "10.1.11.32"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "id", "a34d230c-dd0f-4fa9-a099-bec7d8609bd4"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "name", "spp01-rec-th3s"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_spp_server.foo", "address", "spp01-rec-th3s.rbackup"),
 				),
 			},
 			{
@@ -38,13 +38,13 @@ func TestAccDataSourceBackupSPPServer(t *testing.T) {
 
 const testAccDataSourceBackupSPPServer = `
 data "cloudtemple_backup_spp_server" "foo" {
-  id = "a3d46fb5-29af-4b98-a665-1e82a62fd6d3"
+  id = "a34d230c-dd0f-4fa9-a099-bec7d8609bd4"
 }
 `
 
 const testAccDataSourceBackupSPPServerName = `
 data "cloudtemple_backup_spp_server" "foo" {
-  name = "10"
+  name = "spp01-rec-th3s"
 }
 `
 

--- a/internal/provider/data_source_backup_storages_test.go
+++ b/internal/provider/data_source_backup_storages_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceStorages(t *testing.T) {
 			{
 				Config: testAccDataSourceStorages,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_storages.foo", "storages.#", "1"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_storages.foo", "storages.#", "2"),
 				),
 			},
 		},

--- a/internal/provider/data_source_backup_vcenters_test.go
+++ b/internal/provider/data_source_backup_vcenters_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceBackupVCenters(t *testing.T) {
 			{
 				Config: testAccDataSourceBackupVCenters,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_backup_vcenters.foo", "vcenters.#", "1"),
+					resource.TestCheckResourceAttr("data.cloudtemple_backup_vcenters.foo", "vcenters.#", "2"),
 				),
 			},
 		},
@@ -23,6 +23,6 @@ func TestAccDataSourceBackupVCenters(t *testing.T) {
 
 const testAccDataSourceBackupVCenters = `
 data "cloudtemple_backup_vcenters" "foo" {
-  spp_server_id = "a3d46fb5-29af-4b98-a665-1e82a62fd6d3"
+  spp_server_id = "a34d230c-dd0f-4fa9-a099-bec7d8609bd4"
 }
 `

--- a/internal/provider/data_source_compute_content_library_item_test.go
+++ b/internal/provider/data_source_compute_content_library_item_test.go
@@ -15,28 +15,24 @@ func TestAccDataSourceLibraryItem(t *testing.T) {
 			{
 				Config: testAccDataSourceLibraryItem,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "content_library_id", "355b654d-6ea2-4773-80ee-246d3f56964f"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "id", "8faded09-9f8b-4e27-a978-768f72f8e5f8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "name", "20211115132417_master_linux-centos-8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "description", "Centos 8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "type", "ovf"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "creation_time", "2021-12-02T03:26:39Z"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "size", "1706045044"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "content_library_id", "25db620e-ffb1-4152-a786-b36041fe00c8"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "id", "8d34ec8a-488a-4757-84d0-ae7bc2c3659f"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "name", "runnable-ubuntu-template"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "description", "Template ubuntu"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "type", "vm-template"),
 					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "stored", "true"),
 					resource.TestCheckResourceAttrSet("data.cloudtemple_compute_content_library_item.foo", "last_modified_time"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "ovf_properties.#", "0"),
 				),
 			},
 			{
 				Config: testAccDataSourceLibraryItemName,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "id", "8faded09-9f8b-4e27-a978-768f72f8e5f8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "name", "20211115132417_master_linux-centos-8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "description", "Centos 8"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "type", "ovf"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "id", "8d34ec8a-488a-4757-84d0-ae7bc2c3659f"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "name", "runnable-ubuntu-template"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "description", "Template ubuntu"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "type", "vm-template"),
 					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "stored", "true"),
 					resource.TestCheckResourceAttrSet("data.cloudtemple_compute_content_library_item.foo", "last_modified_time"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_content_library_item.foo", "ovf_properties.#", "0"),
 				),
 			},
 			{
@@ -49,29 +45,29 @@ func TestAccDataSourceLibraryItem(t *testing.T) {
 
 const testAccDataSourceLibraryItem = `
 data "cloudtemple_compute_content_library" "foo" {
-  name = "PUBLIC"
+  name = "local-vc-vstack-001-t0001"
 }
 
 data "cloudtemple_compute_content_library_item" "foo" {
   content_library_id = data.cloudtemple_compute_content_library.foo.id
-  id                 = "8faded09-9f8b-4e27-a978-768f72f8e5f8"
+  id                 = "8d34ec8a-488a-4757-84d0-ae7bc2c3659f"
 }
 `
 
 const testAccDataSourceLibraryItemName = `
 data "cloudtemple_compute_content_library" "foo" {
-  name = "PUBLIC"
+  name = "local-vc-vstack-001-t0001"
 }
 
 data "cloudtemple_compute_content_library_item" "foo" {
   content_library_id = data.cloudtemple_compute_content_library.foo.id
-  name               = "20211115132417_master_linux-centos-8"
+  name               = "runnable-ubuntu-template"
 }
 `
 
 const testAccDataSourceLibraryItemMissing = `
 data "cloudtemple_compute_content_library" "foo" {
-  name = "PUBLIC"
+  name = "local-vc-vstack-001-t0001"
 }
 
 data "cloudtemple_compute_content_library_item" "foo" {

--- a/internal/provider/data_source_compute_datastore.go
+++ b/internal/provider/data_source_compute_datastore.go
@@ -12,16 +12,22 @@ func dataSourceDatastore() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		ReadContext: readFullResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
+		ReadContext: readFullResource(func(ctx context.Context, c *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
 			return getBy(
 				ctx,
 				d,
 				"datastore",
 				func(id string) (any, error) {
-					return client.Compute().Datastore().Read(ctx, id)
+					return c.Compute().Datastore().Read(ctx, id)
 				},
 				func(d *schema.ResourceData) (any, error) {
-					return client.Compute().Datastore().List(ctx, "", "", "", "", "")
+					return c.Compute().Datastore().List(ctx, &client.DatastoreFilter{
+						Name:             d.Get("name").(string),
+						MachineManagerId: d.Get("machine_manager_id").(string),
+						DatacenterId:     d.Get("datacenter_id").(string),
+						HostId:           d.Get("host_id").(string),
+						HostClusterId:    d.Get("host_cluster_id").(string),
+					})
 				},
 				[]string{"name"},
 			)
@@ -39,6 +45,33 @@ func dataSourceDatastore() *schema.Resource {
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				AtLeastOneOf:  []string{"id", "name"},
+				ConflictsWith: []string{"id"},
+			},
+			"machine_manager_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				AtLeastOneOf:  []string{"id", "name"},
+				ConflictsWith: []string{"id"},
+			},
+			"datacenter_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				AtLeastOneOf:  []string{"id", "name"},
+				ConflictsWith: []string{"id"},
+			},
+			"host_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				AtLeastOneOf:  []string{"id", "name"},
+				ConflictsWith: []string{"id"},
+			},
+			"host_cluster_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
 				AtLeastOneOf:  []string{"id", "name"},
 				ConflictsWith: []string{"id"},
 			},
@@ -65,10 +98,6 @@ func dataSourceDatastore() *schema.Resource {
 				Computed: true,
 			},
 			"unique_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"machine_manager_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/internal/provider/data_source_compute_datastore_clusters.go
+++ b/internal/provider/data_source_compute_datastore_clusters.go
@@ -11,8 +11,13 @@ func dataSourceDatastoreClusters() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		ReadContext: readFullResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
-			datastoreClusters, err := client.Compute().DatastoreCluster().List(ctx, "", "", "", "")
+		ReadContext: readFullResource(func(ctx context.Context, c *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
+			datastoreClusters, err := c.Compute().DatastoreCluster().List(ctx, &client.DatastoreClusterFilter{
+				MachineManagerId: d.Get("machine_manager_id").(string),
+				DatacenterId:     d.Get("datacenter_id").(string),
+				HostId:           d.Get("host_id").(string),
+				HostClusterId:    d.Get("host_cluster_id").(string),
+			})
 			return map[string]interface{}{
 				"id":                 "datastore_clusters",
 				"datastore_clusters": datastoreClusters,

--- a/internal/provider/data_source_compute_datastores.go
+++ b/internal/provider/data_source_compute_datastores.go
@@ -11,8 +11,8 @@ func dataSourceDatastores() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		ReadContext: readFullResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
-			datastores, err := client.Compute().Datastore().List(ctx, "", "", "", "", "")
+		ReadContext: readFullResource(func(ctx context.Context, c *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
+			datastores, err := c.Compute().Datastore().List(ctx, nil)
 			return map[string]interface{}{
 				"id":         "datastores",
 				"datastores": datastores,
@@ -65,10 +65,6 @@ func dataSourceDatastores() *schema.Resource {
 						},
 						"type": {
 							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"virtual_machines_number": {
-							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"hosts_number": {

--- a/internal/provider/data_source_compute_host_cluster_test.go
+++ b/internal/provider/data_source_compute_host_cluster_test.go
@@ -15,15 +15,15 @@ func TestAccDataSourceHostCluster(t *testing.T) {
 			{
 				Config: testAccDataSourceHostCluster,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "id", "dde72065-60f4-4577-836d-6ea074384d62"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "name", "clu002-ucs01_FLO"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "id", "c80c4667-2f2d-4087-852b-995b0d5f1f2e"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "name", "clu001-ucs12"),
 				),
 			},
 			{
 				Config: testAccDataSourceHostClusterName,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "id", "dde72065-60f4-4577-836d-6ea074384d62"),
-					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "name", "clu002-ucs01_FLO"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "id", "c80c4667-2f2d-4087-852b-995b0d5f1f2e"),
+					resource.TestCheckResourceAttr("data.cloudtemple_compute_host_cluster.foo", "name", "clu001-ucs12"),
 				),
 			},
 			{
@@ -36,13 +36,14 @@ func TestAccDataSourceHostCluster(t *testing.T) {
 
 const testAccDataSourceHostCluster = `
 data "cloudtemple_compute_host_cluster" "foo" {
-  id = "dde72065-60f4-4577-836d-6ea074384d62"
+  id = "c80c4667-2f2d-4087-852b-995b0d5f1f2e"
 }
 `
 
 const testAccDataSourceHostClusterName = `
 data "cloudtemple_compute_host_cluster" "foo" {
-  name = "clu002-ucs01_FLO"
+  name               = "clu001-ucs12"
+	machine_manager_id = "8afdb4e8-b68d-4bb8-a606-3dc47cc2da0e"
 }
 `
 

--- a/internal/provider/data_source_compute_host_clusters.go
+++ b/internal/provider/data_source_compute_host_clusters.go
@@ -11,8 +11,12 @@ func dataSourceHostClusters() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		ReadContext: readFullResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
-			hcs, err := client.Compute().HostCluster().List(ctx, "", "", "")
+		ReadContext: readFullResource(func(ctx context.Context, c *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
+			hcs, err := c.Compute().HostCluster().List(ctx, &client.HostClusterFilter{
+				MachineManagerId: d.Get("machine_manager_id").(string),
+				DatacenterId:     d.Get("datacenter_id").(string),
+				DatastoreId:      d.Get("datastore_id").(string),
+			})
 			return map[string]interface{}{
 				"id":            "host_clusters",
 				"host_clusters": hcs,

--- a/internal/provider/data_source_compute_virtual_datacenter.go
+++ b/internal/provider/data_source_compute_virtual_datacenter.go
@@ -12,16 +12,19 @@ func dataSourceVirtualDatacenter() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		ReadContext: readFullResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
+		ReadContext: readFullResource(func(ctx context.Context, c *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, error) {
 			return getBy(
 				ctx,
 				d,
 				"virtual datacenter",
 				func(id string) (any, error) {
-					return client.Compute().VirtualDatacenter().Read(ctx, id)
+					return c.Compute().VirtualDatacenter().Read(ctx, id)
 				},
 				func(d *schema.ResourceData) (any, error) {
-					return client.Compute().VirtualDatacenter().List(ctx, "", "")
+					return c.Compute().VirtualDatacenter().List(ctx, &client.VirtualDatacenterFilter{
+						Name:             d.Get("name").(string),
+						MachineManagerId: d.Get("machine_manager_id").(string),
+					})
 				},
 				[]string{"name"},
 			)
@@ -42,12 +45,14 @@ func dataSourceVirtualDatacenter() *schema.Resource {
 				ConflictsWith: []string{"id"},
 				AtLeastOneOf:  []string{"id", "name"},
 			},
+			"machine_manager_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+				AtLeastOneOf:  []string{"id", "name"},
+			},
 
 			// Out
-			"machine_manager_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/provider/data_source_compute_virtual_datacenters.go
+++ b/internal/provider/data_source_compute_virtual_datacenters.go
@@ -12,7 +12,7 @@ func dataSourceVirtualDatacenters() *schema.Resource {
 		Description: "",
 
 		ReadContext: readResource(func(ctx context.Context, client *client.Client, d *schema.ResourceData, sw *stateWriter) (interface{}, []string, error) {
-			datacenters, err := client.Compute().VirtualDatacenter().List(ctx, "", "")
+			datacenters, err := client.Compute().VirtualDatacenter().List(ctx, nil)
 			return map[string]interface{}{
 				"id":                  "virtual_datacenters",
 				"virtual_datacenters": datacenters,

--- a/internal/provider/resource_backup_sla_policy_assignment.go
+++ b/internal/provider/resource_backup_sla_policy_assignment.go
@@ -76,8 +76,15 @@ func computeBackupSLAPolicyAssignmentUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("failed to find catalog job: %s", err)
 	}
 
+	var job = &client.BackupJob{}
+	for _, currJob := range jobs {
+		if currJob.Name == "Hypervisor Inventory" {
+			job = currJob
+		}
+	}
+
 	activityId, err := c.Backup().Job().Run(ctx, &client.BackupJobRunRequest{
-		JobId: jobs[0].ID,
+		JobId: job.ID,
 	})
 	if err != nil {
 		return diag.Errorf("failed to update catalog: %s", err)
@@ -88,7 +95,7 @@ func computeBackupSLAPolicyAssignmentUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("failed to update catalog, %s", err)
 	}
 
-	_, err = c.Backup().Job().WaitForCompletion(ctx, jobs[0].ID, getWaiterOptions(ctx))
+	_, err = c.Backup().Job().WaitForCompletion(ctx, job.ID, getWaiterOptions(ctx))
 	if err != nil {
 		return diag.Errorf("failed to update catalog, %s", err)
 	}


### PR DESCRIPTION
**What changed :**
- Updated some integration tests
- Fixed bad BackupJob triggered when updating/creating a `cloudtemple_compute_virtual_machine`
- Implemented filters on the following data_sources : 
    - `cloudtemple_compute_datastore`
    - `cloudtemple_compute_datastore_cluster`
    - `cloudtemple_compute_datacenter`
    - `cloudtemple_compute_host_cluster`