### PR TITLE
Remove the SSH key in example

### DIFF
--- a/docs/resources/compute_virtual_machine.md
+++ b/docs/resources/compute_virtual_machine.md
@@ -107,10 +107,6 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
   datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
-  deploy_options = {
-    trak_sshpublickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpZ5juF5a/CXV9nQ0PANptTG9Gh3J0aj6yVjkF0fSkC remi@cloud-temple.com"
-  }
-
   tags = {
     created_by = "Terraform"
   }

--- a/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
+++ b/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
@@ -71,10 +71,6 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
   datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
-  deploy_options = {
-    trak_sshpublickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpZ5juF5a/CXV9nQ0PANptTG9Gh3J0aj6yVjkF0fSkC remi@cloud-temple.com"
-  }
-
   tags = {
     created_by = "Terraform"
   }

--- a/internal/provider/resource_compute_virtual_machine_test.go
+++ b/internal/provider/resource_compute_virtual_machine_test.go
@@ -235,10 +235,6 @@ resource "cloudtemple_compute_virtual_machine" "content-library-deployed" {
 
   guest_operating_system_moref = "centos8_64Guest"
 
-  deploy_options = {
-	trak_sshpublickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpZ5juF5a/CXV9nQ0PANptTG9Gh3J0aj6yVjkF0fSkC remi@lenstra.fr"
-  }
-
   tags = {
 	"environment" = "cloned-from-content-library"
   }


### PR DESCRIPTION
Even thought only the public part of the key is shown in the examples and it was generated specially for the examples this is generating security alerts so it is best to remove it in order to avoid notification fatigue.

No changelog entry needed for this.