### PR TITLE
Enable the 'computed' option for guest_operating_system_moref property

### DIFF
--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -77,6 +77,7 @@ Virtual machines can be created using three different methods:
 				Type:         schema.TypeString,
 				Description:  "The operating system to launch the virtual machine with.",
 				Optional:     true,
+				Computed:     true,
 				AtLeastOneOf: []string{"clone_virtual_machine_id", "guest_operating_system_moref", "content_library_item_id"},
 			},
 			"datacenter_id": {


### PR DESCRIPTION
This PR fixes the following bug:

When I deploy a vm virtual machine from the content library, the `guest_operating_system_moref` property is not preserved (if I hadn't add it in the tf code) and so terraform wants to remove it.

```
Terraform will perform the following actions:

  # cloudtemple_compute_virtual_machine.ads-test-009 will be updated in-place
  ~ resource "cloudtemple_compute_virtual_machine" "ads-test-009" {
      - guest_operating_system_moref       = "ubuntu64Guest" -> null
        id                                 = "2ef070db-3bbd-4f95-9b09-78d3fcddf35a"
        name                               = "ads-test-009"
        tags                               = {
            "created_by" = "Terraform"
        }
        # (35 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After the fix:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```