### PR TITLE
Fixed tfstate incorrectly refreshing when updating SLAs from outside the provider and fixed empty recommendations causing vm not starting up

### DIFF
--- a/docs/resources/compute_virtual_machine.md
+++ b/docs/resources/compute_virtual_machine.md
@@ -118,13 +118,13 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 
 ### Required
 
-- `backup_sla_policies` (Set of String)
 - `datacenter_id` (String) The datacenter to start the virtual machine in.
 - `host_cluster_id` (String) The host cluster to start the virtual machine on.
 - `name` (String)
 
 ### Optional
 
+- `backup_sla_policies` (Set of String) The IDs of the SLA policies to assign to the virtual machine.
 - `clone_virtual_machine_id` (String) The ID of the virtual machine to clone. Conflict with `content_library_item_id`.
 - `content_library_id` (String) The ID of the content library to clone from. Conflict with `clone_virtual_machine_id`.
 - `content_library_item_id` (String) The ID of the content library item to clone. Conflict with `clone_virtual_machine_id`.

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -102,7 +102,7 @@ type PowerRequest struct {
 	DatacenterId   string                             `json:"datacenterId,omitempty"`
 	PowerAction    string                             `json:"powerAction,omitempty"`
 	ForceEnterBIOS bool                               `json:"forceEnterBIOS,omitempty"`
-	Recommendation *VirtualMachinePowerRecommendation `json:"recommendation"`
+	Recommendation *VirtualMachinePowerRecommendation `json:"recommendation,omitempty"`
 }
 
 func (v *VirtualMachineClient) List(

--- a/internal/provider/resource_compute_network_adapter.go
+++ b/internal/provider/resource_compute_network_adapter.go
@@ -116,6 +116,10 @@ func computeNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, me
 		MacAddress:   macAddress,
 		MacType:      macType,
 	})
+	if err != nil {
+		return diag.Errorf("failed to update network adapter, %s", err)
+	}
+
 	_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
 	if err != nil {
 		return diag.Errorf("failed to update network adapter, %s", err)

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -153,9 +153,9 @@ Virtual machines can be created using three different methods:
 				},
 			},
 			"backup_sla_policies": {
-				Type:     schema.TypeSet,
-				Required: true,
-
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The IDs of the SLA policies to assign to the virtual machine.",
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.IsUUID,


### PR DESCRIPTION
**What changed**
* Virtual machines that doesn't receive recommendations from VMWare can now startup.
* Changing the assigned SLA on a virtual machine from outside the provider is now detected when refreshing the state.
* Changed backup_sla_policies property on cloudtemple_compute_virtual_machine resource from required to optional.