### PR TITLE
compute_virtual_machine: add os_disk and os_network_adapter attributes

### DIFF
--- a/docs/resources/compute_virtual_machine.md
+++ b/docs/resources/compute_virtual_machine.md
@@ -109,6 +109,10 @@ data "cloudtemple_compute_datastore" "ds" {
   name = "ds001-bob-svc1-data4-eqx6"
 }
 
+data "cloudtemple_compute_network" "vlan" {
+  name = "VLAN_201"
+}
+
 resource "cloudtemple_compute_virtual_machine" "content-library" {
   name = "from-content-library-item"
 
@@ -122,6 +126,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 
   os_disk {
     capacity = 25 * 1024 * 1024 * 1024
+  }
+
+  os_network_adapter {
+    network_id = data.cloudtemple_compute_network.vlan.id
   }
 
   tags = {
@@ -157,6 +165,7 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 - `memory_hot_add_enabled` (Boolean)
 - `num_cores_per_socket` (Number)
 - `os_disk` (Block List) OS disks created from content lib item deployment or virtual machine clone. (see [below for nested schema](#nestedblock--os_disk))
+- `os_network_adapter` (Block List) OS network adapters created from content lib item deployment or virtual machine clone. (see [below for nested schema](#nestedblock--os_network_adapter))
 - `power_state` (String) Whether to start the virtual machine.
 - `tags` (Map of String) The tags to attach to the virtual machine.
 
@@ -207,6 +216,24 @@ Read-Only:
 - `name` (String)
 - `native_id` (String)
 - `provisioning_type` (String)
+
+
+<a id="nestedblock--os_network_adapter"></a>
+### Nested Schema for `os_network_adapter`
+
+Optional:
+
+- `auto_connect` (Boolean)
+- `connected` (Boolean)
+- `mac_address` (String)
+- `mac_type` (String)
+- `network_id` (String)
+
+Read-Only:
+
+- `id` (String) The ID of this resource.
+- `name` (String)
+- `type` (String)
 
 
 <a id="nestedatt--boot_options"></a>

--- a/docs/resources/compute_virtual_machine.md
+++ b/docs/resources/compute_virtual_machine.md
@@ -120,6 +120,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
   datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
+  os_disk {
+    capacity = 25 * 1024 * 1024 * 1024
+  }
+
   tags = {
     created_by = "Terraform"
   }
@@ -152,6 +156,7 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 - `memory` (Number) The quantity of memory to start the virtual machine with.
 - `memory_hot_add_enabled` (Boolean)
 - `num_cores_per_socket` (Number)
+- `os_disk` (Block List) OS disks created from content lib item deployment or virtual machine clone. (see [below for nested schema](#nestedblock--os_disk))
 - `power_state` (String) Whether to start the virtual machine.
 - `tags` (Map of String) The tags to attach to the virtual machine.
 
@@ -179,6 +184,30 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 - `tools` (String)
 - `tools_version` (Number)
 - `triggered_alarms` (List of Object) (see [below for nested schema](#nestedatt--triggered_alarms))
+
+<a id="nestedblock--os_disk"></a>
+### Nested Schema for `os_disk`
+
+Optional:
+
+- `capacity` (Number)
+- `disk_mode` (String)
+
+Read-Only:
+
+- `controller_bus_number` (Number)
+- `datastore_id` (String)
+- `datastore_name` (String)
+- `disk_path` (String)
+- `disk_unit_number` (Number)
+- `editable` (Boolean)
+- `id` (String) The ID of this resource.
+- `instant_access` (Boolean)
+- `machine_manager_id` (String)
+- `name` (String)
+- `native_id` (String)
+- `provisioning_type` (String)
+
 
 <a id="nestedatt--boot_options"></a>
 ### Nested Schema for `boot_options`

--- a/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
+++ b/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
@@ -84,6 +84,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
   datastore_cluster_id = data.cloudtemple_compute_datastore_cluster.koukou.id
   datastore_id         = data.cloudtemple_compute_datastore.ds.id
 
+  os_disk {
+    capacity = 25 * 1024 * 1024 * 1024
+  }
+
   tags = {
     created_by = "Terraform"
   }

--- a/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
+++ b/examples/resources/cloudtemple_compute_virtual_machine/resource.tf
@@ -73,6 +73,10 @@ data "cloudtemple_compute_datastore" "ds" {
   name = "ds001-bob-svc1-data4-eqx6"
 }
 
+data "cloudtemple_compute_network" "vlan" {
+  name = "VLAN_201"
+}
+
 resource "cloudtemple_compute_virtual_machine" "content-library" {
   name = "from-content-library-item"
 
@@ -86,6 +90,10 @@ resource "cloudtemple_compute_virtual_machine" "content-library" {
 
   os_disk {
     capacity = 25 * 1024 * 1024 * 1024
+  }
+
+  os_network_adapter {
+    network_id = data.cloudtemple_compute_network.vlan.id
   }
 
   tags = {

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/sethvargo/go-retry"
 )
 
 func resourceVirtualMachine() *schema.Resource {
@@ -233,7 +235,57 @@ Virtual machines can be created using three different methods:
 					},
 				},
 			},
+			"os_network_adapter": {
+				Type:        schema.TypeList,
+				Description: "OS network adapters created from content lib item deployment or virtual machine clone.",
+				Optional:    true,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// In
+						"network_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ComputedWhen: []string{"mac_type"},
+						},
+						"mac_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"auto_connect": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"connected": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
 
+						// Out
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			// Out
 			"moref": {
 				Type:     schema.TypeString,
@@ -561,6 +613,18 @@ func computeVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	networkAdapters, err := c.Compute().NetworkAdapter().List(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("failed to retrieve OS network adapters: %s", err)
+	}
+
+	// Overwrite with the desired config
+	osNetworkAdapters := updateNestedMapItems(d, flattenOSNetworkAdaptersData(networkAdapters), "os_network_adapter")
+
+	if err := d.Set("os_network_adapter", osNetworkAdapters); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if len(d.Get("backup_sla_policies").(*schema.Set).List()) > 0 {
 		// First we need to update the catalog
 		jobs, err := c.Backup().Job().List(ctx, &client.BackupJobFilter{
@@ -664,6 +728,20 @@ func computeVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		sw.set("os_disk", osDisks)
+
+		osNetworkAdapters := []interface{}{}
+		for _, osNetworkAdapter := range d.Get("os_network_adapter").([]interface{}) {
+			osNetworkAdapterId := osNetworkAdapter.(map[string]interface{})["id"].(string)
+			if osNetworkAdapterId != "" {
+				networkAdapter, err := c.Compute().NetworkAdapter().Read(ctx, osNetworkAdapterId)
+				if err != nil {
+					return nil, err
+				}
+				osNetworkAdapters = append(osNetworkAdapters, flattenOSNetworkAdapterData(networkAdapter))
+			}
+		}
+
+		sw.set("os_network_adapter", osNetworkAdapters)
 
 		readTags(ctx, sw, c, d.Id())
 
@@ -790,6 +868,63 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 		}
 	}
 
+	if d.HasChange("os_network_adapter") {
+		for i, osNetworkAdapter := range d.Get("os_network_adapter").([]interface{}) {
+			networkAdapter := osNetworkAdapter.(map[string]interface{})
+			if networkAdapter["id"].(string) != "" && d.HasChange(fmt.Sprintf("os_network_adapter.%d", i)) {
+				macType := networkAdapter["mac_type"].(string)
+				macAddress := networkAdapter["mac_address"].(string)
+				if macType == "ASSIGNED" {
+					macAddress = ""
+				}
+
+				activityId, err := c.Compute().NetworkAdapter().Update(ctx, &client.UpdateNetworkAdapterRequest{
+					ID:           networkAdapter["id"].(string),
+					NewNetworkId: networkAdapter["network_id"].(string),
+					AutoConnect:  networkAdapter["auto_connect"].(bool),
+					MacAddress:   macAddress,
+					MacType:      macType,
+				})
+				if err != nil {
+					return diag.Errorf("failed to update network adapter, %s", err)
+				}
+				_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
+				if err != nil {
+					return diag.Errorf("failed to update network adapter, %s", err)
+				}
+
+				if d.HasChange(fmt.Sprintf("os_network_adapter.%d.connected", i)) {
+					var msg string
+					var action func(context.Context, string) (string, error)
+					if networkAdapter["connected"].(bool) {
+						msg = "connect"
+						action = c.Compute().NetworkAdapter().Connect
+					} else {
+						msg = "disconnect"
+						action = c.Compute().NetworkAdapter().Disconnect
+					}
+
+					// Connecting a network adapter can fail right after the VM has been powered
+					// on so we retry here until we reach the timeout
+					b := retry.NewFibonacci(1 * time.Second)
+					b = retry.WithCappedDuration(20*time.Second, b)
+
+					err = retry.Do(ctx, b, func(ctx context.Context) error {
+						activityId, err = action(ctx, networkAdapter["id"].(string))
+						if err != nil {
+							return err
+						}
+						_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
+						return err
+					})
+					if err != nil {
+						return diag.Errorf("failed to %s network adapter, %s", msg, err)
+					}
+				}
+			}
+		}
+	}
+
 	if updatePower {
 		powerState := d.Get("power_state").(string)
 
@@ -871,6 +1006,30 @@ func computeVirtualMachineDelete(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
+func updateNestedMapItems(d *schema.ResourceData, nestedMapItems []interface{}, key string) []interface{} {
+	nestedMaps := make([]interface{}, len(nestedMapItems))
+
+	for i, mapItems := range nestedMapItems {
+		nestedMaps[i] = updateMapItems(d, mapItems, key, i)
+	}
+
+	return nestedMaps
+}
+
+func updateMapItems(d *schema.ResourceData, mapItems interface{}, key string, index int) interface{} {
+	m := mapItems.(map[string]interface{})
+
+	if value, ok := d.GetOk(fmt.Sprintf("%s.%d", key, index)); ok {
+
+		for k, v := range value.(map[string]interface{}) {
+			if _, ok := d.GetOk(fmt.Sprintf("%s.%d.%s", key, index, k)); ok {
+				m[k] = v
+			}
+		}
+	}
+	return m
+}
+
 func flattenOSDisksData(osDisks []*client.VirtualDisk) []interface{} {
 	if osDisks != nil {
 		disks := make([]interface{}, len(osDisks))
@@ -904,4 +1063,33 @@ func flattenOSDiskData(osDisk *client.VirtualDisk) interface{} {
 	disk["editable"] = osDisk.Editable
 
 	return disk
+}
+
+func flattenOSNetworkAdaptersData(osNetworkAdapters []*client.NetworkAdapter) []interface{} {
+	if osNetworkAdapters != nil {
+		networkAdapters := make([]interface{}, len(osNetworkAdapters))
+
+		for i, osNetworkAdapter := range osNetworkAdapters {
+			networkAdapters[i] = flattenOSNetworkAdapterData(osNetworkAdapter)
+		}
+
+		return networkAdapters
+	}
+
+	return make([]interface{}, 0)
+}
+
+func flattenOSNetworkAdapterData(osNetworkAdapter *client.NetworkAdapter) interface{} {
+	networkAdapter := make(map[string]interface{})
+
+	networkAdapter["id"] = osNetworkAdapter.ID
+	networkAdapter["name"] = osNetworkAdapter.Name
+	networkAdapter["network_id"] = osNetworkAdapter.NetworkId
+	networkAdapter["type"] = osNetworkAdapter.Type
+	networkAdapter["mac_type"] = osNetworkAdapter.MacType
+	networkAdapter["mac_address"] = osNetworkAdapter.MacAddress
+	networkAdapter["connected"] = osNetworkAdapter.Connected
+	networkAdapter["auto_connect"] = osNetworkAdapter.AutoConnect
+
+	return networkAdapter
 }

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/sethvargo/go-retry"
@@ -498,6 +499,24 @@ Virtual machines can be created using three different methods:
 				},
 			},
 		},
+		CustomizeDiff: customdiff.All(
+			customdiff.ValidateChange("os_disk", func(ctx context.Context, old, new, meta any) error {
+				o := len(old.([]interface{}))
+				n := len(new.([]interface{}))
+				if n > o && o > 0 {
+					return fmt.Errorf("new os_disk blocks are not allowed if that exceeds the number of existing OS disks (%d > %d)", n, o)
+				}
+				return nil
+			}),
+			customdiff.ValidateChange("os_network_adapter", func(ctx context.Context, old, new, meta any) error {
+				o := len(old.([]interface{}))
+				n := len(new.([]interface{}))
+				if n > o && o > 0 {
+					return fmt.Errorf("new os_network_adapter blocks are not allowed if that exceeds the number of existing OS network adapters (%d > %d)", n, o)
+				}
+				return nil
+			}),
+		),
 	}
 }
 

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -596,18 +596,8 @@ func computeVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("failed to retrieve OS disks: %s", err)
 	}
 
-	osDisks := flattenOSDisksData(disks)
-
 	// Overwrite with the desired config
-	for i, osDisk := range osDisks {
-		if v, ok := d.GetOk(fmt.Sprintf("os_disk.%d", i)); ok {
-			vDisk := v.(map[string]interface{})
-			disk := osDisk.(map[string]interface{})
-
-			disk["capacity"] = vDisk["capacity"].(int)
-			disk["disk_mode"] = vDisk["disk_mode"].(string)
-		}
-	}
+	osDisks := updateNestedMapItems(d, flattenOSDisksData(disks), "os_disk")
 
 	if err := d.Set("os_disk", osDisks); err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_compute_virtual_machine_test.go
+++ b/internal/provider/resource_compute_virtual_machine_test.go
@@ -235,6 +235,11 @@ resource "cloudtemple_compute_virtual_machine" "content-library-deployed" {
 
   guest_operating_system_moref = "centos8_64Guest"
 
+  os_disk {
+    capacity = 25 * 1024 * 1024 * 1024
+    disk_mode = "independent_persistent"
+  }
+
   tags = {
 	"environment" = "cloned-from-content-library"
   }

--- a/internal/provider/resource_compute_virtual_machine_test.go
+++ b/internal/provider/resource_compute_virtual_machine_test.go
@@ -223,6 +223,10 @@ data "cloudtemple_compute_content_library_item" "foo" {
   name               = "20211115132417_master_linux-centos-8"
 }
 
+data "cloudtemple_compute_network" "foo" {
+  name = "VLAN_201"
+}
+
 resource "cloudtemple_compute_virtual_machine" "content-library-deployed" {
   name = "test-terraform-content-library-deployed"
 
@@ -238,6 +242,13 @@ resource "cloudtemple_compute_virtual_machine" "content-library-deployed" {
   os_disk {
     capacity = 25 * 1024 * 1024 * 1024
     disk_mode = "independent_persistent"
+  }
+
+  os_network_adapter {
+    network_id   = data.cloudtemple_compute_network.foo.id
+    mac_type     = "MANUAL"
+    mac_address  = "00:50:56:83:84:61"
+	auto_connect = true
   }
 
   tags = {


### PR DESCRIPTION
This PR provides 2 new attributes `os_disk` and `os_network_adapter` for `compute_virtual_machine` resource to manage sub-resources (disks and network adapters) created from a content lib item deployment or a virtual machine clone