### PR TITLE
Fix crash when 'osDisk' or 'osNetworkAdapter' is nil

### DIFF
--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -724,6 +724,9 @@ func computeVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta
 
 		osDisks := []interface{}{}
 		for _, osDisk := range d.Get("os_disk").([]interface{}) {
+			if osDisk == nil {
+				continue
+			}
 			osDiskId := osDisk.(map[string]interface{})["id"].(string)
 			if osDiskId != "" {
 				disk, err := c.Compute().VirtualDisk().Read(ctx, osDiskId)
@@ -738,6 +741,9 @@ func computeVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta
 
 		osNetworkAdapters := []interface{}{}
 		for _, osNetworkAdapter := range d.Get("os_network_adapter").([]interface{}) {
+			if osNetworkAdapter == nil {
+				continue
+			}
 			osNetworkAdapterId := osNetworkAdapter.(map[string]interface{})["id"].(string)
 			if osNetworkAdapterId != "" {
 				networkAdapter, err := c.Compute().NetworkAdapter().Read(ctx, osNetworkAdapterId)
@@ -857,6 +863,9 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 
 	if d.HasChange("os_disk") {
 		for i, osDisk := range d.Get("os_disk").([]interface{}) {
+			if osDisk == nil {
+				continue
+			}
 			disk := osDisk.(map[string]interface{})
 			if disk["id"].(string) != "" && d.HasChange(fmt.Sprintf("os_disk.%d", i)) {
 				activityId, err := c.Compute().VirtualDisk().Update(ctx, &client.UpdateVirtualDiskRequest{
@@ -877,6 +886,9 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 
 	if d.HasChange("os_network_adapter") {
 		for i, osNetworkAdapter := range d.Get("os_network_adapter").([]interface{}) {
+			if osNetworkAdapter == nil {
+				continue
+			}
 			networkAdapter := osNetworkAdapter.(map[string]interface{})
 			if networkAdapter["id"].(string) != "" && d.HasChange(fmt.Sprintf("os_network_adapter.%d", i)) {
 				macType := networkAdapter["mac_type"].(string)


### PR DESCRIPTION
This PR fixes a provider crash when `terraform apply` is run after adding an empty `os_disk` or `os_network_adapter` block on an existing virtual machine resource (created from scratch):

```
╷
│ Error: Plugin did not respond
│ 
│   with cloudtemple_compute_virtual_machine.ads-test-002,
│   on r-ads-test-002.tf line 21, in resource "cloudtemple_compute_virtual_machine" "ads-test-002":
│   21: resource "cloudtemple_compute_virtual_machine" "ads-test-002" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-cloudtemple plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

[...]

Error: The terraform-provider-cloudtemple plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

Steps to reproduce the crash:

1. Define the following tfcode:

```hcl
data "cloudtemple_compute_virtual_datacenter" "lab" {
  name = "DC-ITX7"
}

data "cloudtemple_compute_host_cluster" "lab" {
  name = "clu003-ucs02_LAB01"
}

data "cloudtemple_compute_datastore_cluster" "lab" {
  name = "sdrs003-LIVE_LAB01"
}

resource "cloudtemple_compute_virtual_machine" "ads-test-002" {
  name = "ads-test-002"

  memory                 = 1 * 1024 * 1024 * 1024
  cpu                    = 1
  num_cores_per_socket   = 1
  cpu_hot_add_enabled    = true
  cpu_hot_remove_enabled = true
  memory_hot_add_enabled = true

  datacenter_id                = data.cloudtemple_compute_virtual_datacenter.lab.id
  host_cluster_id              = data.cloudtemple_compute_host_cluster.lab.id
  datastore_cluster_id         = data.cloudtemple_compute_datastore_cluster.lab.id
  guest_operating_system_moref = "debian11_64Guest"

  power_state = "off"
}
```

2. Run `terraform apply`

3. Add an empty `os_disk` or `os_network_adapter` block or both:

```hcl
[...]
  power_state = "off"

  os_disk {}

  os_network_adapter {}
}
```

4. Run again `terraform apply`
