### PR TITLE
Fixed mistyped property on newly added 'backup_virtual_machine' controller causes virtual machines struggling to power on.

### DIFF
--- a/internal/client/backup_virtual_machine.go
+++ b/internal/client/backup_virtual_machine.go
@@ -14,7 +14,7 @@ func (c *BackupClient) VirtualMachine() *BackupVirtualMachineClient {
 
 type BackupVirtualMachineVolume struct {
 	Name         string `terraform:"name"`
-	Key          int    `terraform:"key"`
+	Key          string `terraform:"key"`
 	Size         int    `terraform:"size"`
 	ConfigVolume bool   `terraform:"config_volume"`
 }
@@ -24,7 +24,7 @@ type BackupVirtualMachine struct {
 	Name              string                       `terraform:"name"`
 	Moref             string                       `terraform:"moref"`
 	InternalId        string                       `terraform:"internal_id"`
-	InternalVCenterId string                       `terraform:"internal_vcenter_id"`
+	InternalVCenterId int                          `terraform:"internal_vcenter_id"`
 	VCenterId         string                       `terraform:"vcenter_id"`
 	Href              string                       `terraform:"href"`
 	MetadataPath      string                       `terraform:"matadata_path"`


### PR DESCRIPTION
**What changed :**
* Fixed mistyped property on newly added 'backup_virtual_machine' controller causes virtual machines struggling to power on.