### PR TITLE
Fixed 20 minutes context timeout

### DIFF
--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -25,10 +25,10 @@ Virtual machines can be created using three different methods:
   - by cloning an existing virtual machine with ` + "`clone_virtual_machine_id`" + `
   - by deploying a content library item with ` + "`content_library_id` and `content_library_item_id`",
 
-		CreateContext: computeVirtualMachineCreate,
-		ReadContext:   computeVirtualMachineRead,
-		UpdateContext: computeVirtualMachineUpdate,
-		DeleteContext: computeVirtualMachineDelete,
+		CreateWithoutTimeout: computeVirtualMachineCreate,
+		ReadContext:          computeVirtualMachineRead,
+		UpdateContext:        computeVirtualMachineUpdate,
+		DeleteContext:        computeVirtualMachineDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,


### PR DESCRIPTION
**What changed :**
- Updated the CreateContext of resource `cloudtemple_compute_virtual_machine` to make it use the Background context so it doesn't use a timeout of 20 minutes.