### PR TITLE
Fixed a bug causing resource cloudtemple_compute_virtual_disk to fail its creation after 20 minutes of waiting

### DIFF
--- a/internal/provider/resource_compute_network_adapter.go
+++ b/internal/provider/resource_compute_network_adapter.go
@@ -15,10 +15,10 @@ func resourceNetworkAdapter() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		CreateContext: computeNetworkAdapterCreate,
-		ReadContext:   computeNetworkAdapterRead,
-		UpdateContext: computeNetworkAdapterUpdate,
-		DeleteContext: computeNetworkAdapterDelete,
+		CreateWithoutTimeout: computeNetworkAdapterCreate,
+		ReadContext:          computeNetworkAdapterRead,
+		UpdateContext:        computeNetworkAdapterUpdate,
+		DeleteContext:        computeNetworkAdapterDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/provider/resource_compute_virtual_disk.go
+++ b/internal/provider/resource_compute_virtual_disk.go
@@ -13,10 +13,10 @@ func resourceVirtualDisk() *schema.Resource {
 	return &schema.Resource{
 		Description: "",
 
-		CreateContext: computeVirtualDiskCreate,
-		ReadContext:   computeVirtualDiskRead,
-		UpdateContext: computeVirtualDiskUpdate,
-		DeleteContext: computeVirtualDiskDelete,
+		CreateWithoutTimeout: computeVirtualDiskCreate,
+		ReadContext:          computeVirtualDiskRead,
+		UpdateContext:        computeVirtualDiskUpdate,
+		DeleteContext:        computeVirtualDiskDelete,
 
 		Schema: map[string]*schema.Schema{
 			// In


### PR DESCRIPTION
**What changed :**
* Creation of resource `cloudtemple_compute_virtual_machine` can now wait or last more than 20 minutes.
* Creation of resource `cloudtemple_compute_network_adapter` can now wait or last more than 20 minutes.