### PR TITLE
Removed  from every URL used by the provider to make it more dynamic and reliable

### DIFF
--- a/internal/client/activity.go
+++ b/internal/client/activity.go
@@ -42,7 +42,7 @@ type ActivityConcernedItem struct {
 }
 
 func (c *ActivityClient) List(ctx context.Context, filter *struct{}) ([]*Activity, error) {
-	r := c.c.newRequest("GET", "/api/activity/v1/activities")
+	r := c.c.newRequest("GET", "/activity/v1/activities")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (c *ActivityClient) List(ctx context.Context, filter *struct{}) ([]*Activit
 }
 
 func (c *ActivityClient) Read(ctx context.Context, id string) (*Activity, error) {
-	r := c.c.newRequest("GET", "/api/activity/v1/activities/%s", id)
+	r := c.c.newRequest("GET", "/activity/v1/activities/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -208,7 +208,7 @@ func (c *Client) token(ctx context.Context) (*jwt.Token, error) {
 		}
 	}
 
-	r := c.newRequest("POST", "/api/iam/v2/auth/personal_access_token")
+	r := c.newRequest("POST", "/iam/v2/auth/personal_access_token")
 	r.obj = map[string]interface{}{
 		"id":     c.config.ClientID,
 		"secret": c.config.SecretID,

--- a/internal/client/backup_job.go
+++ b/internal/client/backup_job.go
@@ -30,7 +30,7 @@ type BackupJobFilter struct {
 }
 
 func (c *BackupJobClient) List(ctx context.Context, filter *BackupJobFilter) ([]*BackupJob, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/jobs")
+	r := c.c.newRequest("GET", "/backup/v1/jobs")
 	if filter != nil && filter.Type != "" {
 		r.params.Add("type", filter.Type)
 	}
@@ -52,7 +52,7 @@ func (c *BackupJobClient) List(ctx context.Context, filter *BackupJobFilter) ([]
 }
 
 func (c *BackupJobClient) Read(ctx context.Context, id string) (*BackupJob, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/jobs/%s", id)
+	r := c.c.newRequest("GET", "/backup/v1/jobs/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ type BackupJobRunRequest struct {
 }
 
 func (c *BackupJobClient) Run(ctx context.Context, req *BackupJobRunRequest) (string, error) {
-	r := c.c.newRequest("POST", "/api/backup/v1/jobs/run")
+	r := c.c.newRequest("POST", "/backup/v1/jobs/run")
 	r.obj = req
 	return c.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/backup_job_session.go
+++ b/internal/client/backup_job_session.go
@@ -38,7 +38,7 @@ type BackupSLAPolicyStub struct {
 }
 
 func (c *BackupJobSessionClient) List(ctx context.Context, filter *struct{}) ([]*BackupJobSession, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/jobs/session")
+	r := c.c.newRequest("GET", "/backup/v1/jobs/session")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/backup_metrics.go
+++ b/internal/client/backup_metrics.go
@@ -23,7 +23,7 @@ type BackupMetricsHistory struct {
 }
 
 func (c *BackupMetricsClient) History(ctx context.Context, rang int) (*BackupMetricsHistory, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/backup/history")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/backup/history")
 	r.params.Add("range", strconv.Itoa(rang))
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -51,7 +51,7 @@ type BackupMetricsCoverage struct {
 }
 
 func (c *BackupMetricsClient) Coverage(ctx context.Context) (*BackupMetricsCoverage, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/coverage")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/coverage")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ type BackupMetricsVirtualMachines struct {
 }
 
 func (c *BackupMetricsClient) VirtualMachines(ctx context.Context) (*BackupMetricsVirtualMachines, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/vm")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/vm")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ type BackupMetricsPolicies struct {
 }
 
 func (c *BackupMetricsClient) Policies(ctx context.Context) ([]*BackupMetricsPolicies, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/policies")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/policies")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ type BackupMetricsPlatform struct {
 }
 
 func (c *BackupMetricsClient) Platform(ctx context.Context) (*BackupMetricsPlatform, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/plateform")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/plateform")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ type BackupMetricsPlatformCPU struct {
 }
 
 func (c *BackupMetricsClient) PlatformCPU(ctx context.Context) (*BackupMetricsPlatformCPU, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/metrics/plateform/cpu")
+	r := c.c.newRequest("GET", "/backup/v1/metrics/plateform/cpu")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/backup_site.go
+++ b/internal/client/backup_site.go
@@ -16,7 +16,7 @@ type BackupSite struct {
 }
 
 func (c *BackupSiteClient) List(ctx context.Context) ([]*BackupSite, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/sites")
+	r := c.c.newRequest("GET", "/backup/v1/sites")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/backup_sla_policy.go
+++ b/internal/client/backup_sla_policy.go
@@ -49,7 +49,7 @@ type BackupSLAPolicyFilter struct {
 }
 
 func (c *BackupSLAPolicyClient) List(ctx context.Context, filter *BackupSLAPolicyFilter) ([]*BackupSLAPolicy, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/policies")
+	r := c.c.newRequest("GET", "/backup/v1/policies")
 	r.addFilter(filter)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *BackupSLAPolicyClient) List(ctx context.Context, filter *BackupSLAPolic
 }
 
 func (c *BackupSLAPolicyClient) Read(ctx context.Context, id string) (*BackupSLAPolicy, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/policies/%s", id)
+	r := c.c.newRequest("GET", "/backup/v1/policies/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ type BackupAssignVirtualMachineRequest struct {
 }
 
 func (c *BackupSLAPolicyClient) AssignVirtualMachine(ctx context.Context, req *BackupAssignVirtualMachineRequest) (string, error) {
-	r := c.c.newRequest("POST", "/api/backup/v1/policies/assign/virtual_machine")
+	r := c.c.newRequest("POST", "/backup/v1/policies/assign/virtual_machine")
 	r.obj = req
 	return c.c.doRequestAndReturnActivity(ctx, r)
 }
@@ -105,7 +105,7 @@ type BackupAssignVirtualDiskRequest struct {
 }
 
 func (c *BackupSLAPolicyClient) AssignVirtualDisk(ctx context.Context, req *BackupAssignVirtualDiskRequest) (string, error) {
-	r := c.c.newRequest("POST", "/api/backup/v1/policies/assign/virtual_disk")
+	r := c.c.newRequest("POST", "/backup/v1/policies/assign/virtual_disk")
 	r.obj = req
 	return c.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/backup_spp_server.go
+++ b/internal/client/backup_spp_server.go
@@ -17,7 +17,7 @@ type BackupSPPServer struct {
 }
 
 func (c *BackupSPPServerClient) List(ctx context.Context, tenantId string) ([]*BackupSPPServer, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/spp_servers")
+	r := c.c.newRequest("GET", "/backup/v1/spp_servers")
 	r.params.Add("tenantId", tenantId)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -37,7 +37,7 @@ func (c *BackupSPPServerClient) List(ctx context.Context, tenantId string) ([]*B
 }
 
 func (c *BackupSPPServerClient) Read(ctx context.Context, id string) (*BackupSPPServer, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/spp_servers/%s", id)
+	r := c.c.newRequest("GET", "/backup/v1/spp_servers/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/backup_storage.go
+++ b/internal/client/backup_storage.go
@@ -33,7 +33,7 @@ type BackupStorageCapacity struct {
 }
 
 func (c *BackupStorageClient) List(ctx context.Context) ([]*BackupStorage, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/storages")
+	r := c.c.newRequest("GET", "/backup/v1/storages")
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/backup_vcenter.go
+++ b/internal/client/backup_vcenter.go
@@ -19,7 +19,7 @@ type BackupVCenter struct {
 }
 
 func (c *BackupVCenterClient) List(ctx context.Context, sppServerId string) ([]*BackupVCenter, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/vcenters")
+	r := c.c.newRequest("GET", "/backup/v1/vcenters")
 	r.params.Add("sppServerId", sppServerId)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/backup_virtual_machine.go
+++ b/internal/client/backup_virtual_machine.go
@@ -38,7 +38,7 @@ type BackupVirtualMachine struct {
 }
 
 func (c *BackupVirtualMachineClient) Read(ctx context.Context, id string) (*BackupVirtualMachine, error) {
-	r := c.c.newRequest("GET", "/api/backup/v1/virtual_machines/%s", id)
+	r := c.c.newRequest("GET", "/backup/v1/virtual_machines/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_content_library.go
+++ b/internal/client/compute_content_library.go
@@ -32,7 +32,7 @@ type ContentLibraryFilter struct {
 }
 
 func (c *ContentLibraryClient) List(ctx context.Context, filter *ContentLibraryFilter) ([]*ContentLibrary, error) {
-	r := c.c.newRequest("GET", "/api/compute/v1/vcenters/content_libraries")
+	r := c.c.newRequest("GET", "/compute/v1/vcenters/content_libraries")
 	r.addFilter(filter)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -52,7 +52,7 @@ func (c *ContentLibraryClient) List(ctx context.Context, filter *ContentLibraryF
 }
 
 func (c *ContentLibraryClient) Read(ctx context.Context, id string) (*ContentLibrary, error) {
-	r := c.c.newRequest("GET", "/api/compute/v1/vcenters/content_libraries/%s", id)
+	r := c.c.newRequest("GET", "/compute/v1/vcenters/content_libraries/%s", id)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ type ContentLibraryItemFilter struct {
 }
 
 func (c *ContentLibraryClient) ListItems(ctx context.Context, filter *ContentLibraryItemFilter) ([]*ContentLibraryItem, error) {
-	r := c.c.newRequest("GET", "/api/compute/v1/vcenters/content_libraries/%s/items", filter.ContentLibraryId)
+	r := c.c.newRequest("GET", "/compute/v1/vcenters/content_libraries/%s/items", filter.ContentLibraryId)
 	r.addFilter(filter)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -111,7 +111,7 @@ func (c *ContentLibraryClient) ListItems(ctx context.Context, filter *ContentLib
 }
 
 func (c *ContentLibraryClient) ReadItem(ctx context.Context, contentLibraryId, contentLibraryItemId string) (*ContentLibraryItem, error) {
-	r := c.c.newRequest("GET", "/api/compute/v1/vcenters/content_libraries/%s/items/%s", contentLibraryId, contentLibraryItemId)
+	r := c.c.newRequest("GET", "/compute/v1/vcenters/content_libraries/%s/items/%s", contentLibraryId, contentLibraryItemId)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ type NetworkData struct {
 }
 
 func (c *ContentLibraryClient) Deploy(ctx context.Context, req *ComputeContentLibraryItemDeployRequest) (string, error) {
-	r := c.c.newRequest("POST", "/api/compute/v1/vcenters/content_libraries/%s/items", req.ContentLibraryId)
+	r := c.c.newRequest("POST", "/compute/v1/vcenters/content_libraries/%s/items", req.ContentLibraryId)
 	r.obj = req
 	return c.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/compute_datastore.go
+++ b/internal/client/compute_datastore.go
@@ -41,7 +41,7 @@ func (d *DatastoreClient) List(
 	filter *DatastoreFilter) ([]*Datastore, error) {
 
 	// TODO: filters
-	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastores")
+	r := d.c.newRequest("GET", "/compute/v1/vcenters/datastores")
 	r.addFilter(filter)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
@@ -61,7 +61,7 @@ func (d *DatastoreClient) List(
 }
 
 func (d *DatastoreClient) Read(ctx context.Context, id string) (*Datastore, error) {
-	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastores/%s", id)
+	r := d.c.newRequest("GET", "/compute/v1/vcenters/datastores/%s", id)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_datastore_cluster.go
+++ b/internal/client/compute_datastore_cluster.go
@@ -45,7 +45,7 @@ type DatastoreClusterMetrics struct {
 
 func (d *DatastoreClusterClient) List(ctx context.Context, filter *DatastoreClusterFilter) ([]*DatastoreCluster, error) {
 	// TODO: filters
-	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastore_clusters")
+	r := d.c.newRequest("GET", "/compute/v1/vcenters/datastore_clusters")
 	r.addFilter(filter)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
@@ -65,7 +65,7 @@ func (d *DatastoreClusterClient) List(ctx context.Context, filter *DatastoreClus
 }
 
 func (d *DatastoreClusterClient) Read(ctx context.Context, id string) (*DatastoreCluster, error) {
-	r := d.c.newRequest("GET", "/api/compute/v1/vcenters/datastore_clusters/%s", id)
+	r := d.c.newRequest("GET", "/compute/v1/vcenters/datastore_clusters/%s", id)
 	resp, err := d.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_folder.go
+++ b/internal/client/compute_folder.go
@@ -22,7 +22,7 @@ func (f *FolderClient) List(
 	datacenterId string) ([]*Folder, error) {
 
 	// TODO: filters
-	r := f.c.newRequest("GET", "/api/compute/v1/vcenters/folders")
+	r := f.c.newRequest("GET", "/compute/v1/vcenters/folders")
 	resp, err := f.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (f *FolderClient) List(
 }
 
 func (f *FolderClient) Read(ctx context.Context, id string) (*Folder, error) {
-	r := f.c.newRequest("GET", "/api/compute/v1/vcenters/folders/%s", id)
+	r := f.c.newRequest("GET", "/compute/v1/vcenters/folders/%s", id)
 	resp, err := f.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_guest_operating_system.go
+++ b/internal/client/compute_guest_operating_system.go
@@ -24,7 +24,7 @@ func (g *GuestOperatingSystemClient) List(
 	osFamily string) ([]*GuestOperatingSystem, error) {
 
 	// TODO: filters
-	r := g.c.newRequest("GET", "/api/compute/v1/vcenters/guest_operating_systems")
+	r := g.c.newRequest("GET", "/compute/v1/vcenters/guest_operating_systems")
 	r.params.Add("machineManagerId", machineManagerId)
 	resp, err := g.c.doRequest(ctx, r)
 	if err != nil {
@@ -45,7 +45,7 @@ func (g *GuestOperatingSystemClient) List(
 }
 
 func (g *GuestOperatingSystemClient) Read(ctx context.Context, machineManagerId string, moref string) (*GuestOperatingSystem, error) {
-	r := g.c.newRequest("GET", "/api/compute/v1/vcenters/guest_operating_systems/%s", moref)
+	r := g.c.newRequest("GET", "/compute/v1/vcenters/guest_operating_systems/%s", moref)
 	r.params.Add("machineManagerId", machineManagerId)
 	resp, err := g.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/compute_host.go
+++ b/internal/client/compute_host.go
@@ -59,7 +59,7 @@ func (h *HostClient) List(
 	datastoreID string) ([]*Host, error) {
 
 	// TODO: filters
-	r := h.c.newRequest("GET", "/api/compute/v1/vcenters/hosts")
+	r := h.c.newRequest("GET", "/compute/v1/vcenters/hosts")
 	resp, err := h.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (h *HostClient) List(
 }
 
 func (h *HostClient) Read(ctx context.Context, id string) (*Host, error) {
-	r := h.c.newRequest("GET", "/api/compute/v1/vcenters/hosts/%s", id)
+	r := h.c.newRequest("GET", "/compute/v1/vcenters/hosts/%s", id)
 	resp, err := h.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_host_cluster.go
+++ b/internal/client/compute_host_cluster.go
@@ -46,7 +46,7 @@ func (h *HostClusterClient) List(
 	filter *HostClusterFilter) ([]*HostCluster, error) {
 
 	// TODO: filters
-	r := h.c.newRequest("GET", "/api/compute/v1/vcenters/host_clusters")
+	r := h.c.newRequest("GET", "/compute/v1/vcenters/host_clusters")
 	r.addFilter(filter)
 	resp, err := h.c.doRequest(ctx, r)
 	if err != nil {
@@ -66,7 +66,7 @@ func (h *HostClusterClient) List(
 }
 
 func (h *HostClusterClient) Read(ctx context.Context, id string) (*HostCluster, error) {
-	r := h.c.newRequest("GET", "/api/compute/v1/vcenters/host_clusters/%s", id)
+	r := h.c.newRequest("GET", "/compute/v1/vcenters/host_clusters/%s", id)
 	resp, err := h.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_network.go
+++ b/internal/client/compute_network.go
@@ -36,7 +36,7 @@ func (n *NetworkClient) List(
 	ctx context.Context,
 	filter *NetworkFilter) ([]*Network, error) {
 
-	r := n.c.newRequest("GET", "/api/compute/v1/vcenters/networks")
+	r := n.c.newRequest("GET", "/compute/v1/vcenters/networks")
 	r.addFilter(filter)
 	resp, err := n.c.doRequest(ctx, r)
 	if err != nil {
@@ -56,7 +56,7 @@ func (n *NetworkClient) List(
 }
 
 func (n *NetworkClient) Read(ctx context.Context, id string) (*Network, error) {
-	r := n.c.newRequest("GET", "/api/compute/v1/vcenters/networks/%s", id)
+	r := n.c.newRequest("GET", "/compute/v1/vcenters/networks/%s", id)
 	resp, err := n.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_network_adapter.go
+++ b/internal/client/compute_network_adapter.go
@@ -23,7 +23,7 @@ type NetworkAdapter struct {
 }
 
 func (n *NetworkAdapterClient) List(ctx context.Context, virtualMachineId string) ([]*NetworkAdapter, error) {
-	r := n.c.newRequest("GET", "/api/compute/v1/vcenters/network_adapters")
+	r := n.c.newRequest("GET", "/compute/v1/vcenters/network_adapters")
 	r.params.Add("virtualMachineId", virtualMachineId)
 	resp, err := n.c.doRequest(ctx, r)
 	if err != nil {
@@ -51,13 +51,13 @@ type CreateNetworkAdapterRequest struct {
 }
 
 func (n *NetworkAdapterClient) Create(ctx context.Context, req *CreateNetworkAdapterRequest) (string, error) {
-	r := n.c.newRequest("POST", "/api/compute/v1/vcenters/network_adapters")
+	r := n.c.newRequest("POST", "/compute/v1/vcenters/network_adapters")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *NetworkAdapterClient) Read(ctx context.Context, id string) (*NetworkAdapter, error) {
-	r := n.c.newRequest("GET", "/api/compute/v1/vcenters/network_adapters/%s", id)
+	r := n.c.newRequest("GET", "/compute/v1/vcenters/network_adapters/%s", id)
 	resp, err := n.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,24 +85,24 @@ type UpdateNetworkAdapterRequest struct {
 }
 
 func (n *NetworkAdapterClient) Update(ctx context.Context, req *UpdateNetworkAdapterRequest) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/network_adapters")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/network_adapters")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *NetworkAdapterClient) Delete(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("DELETE", "/api/compute/v1/vcenters/network_adapters/%s", id)
+	r := n.c.newRequest("DELETE", "/compute/v1/vcenters/network_adapters/%s", id)
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *NetworkAdapterClient) Connect(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/network_adapters/connect")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/network_adapters/connect")
 	r.obj = map[string]string{"id": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *NetworkAdapterClient) Disconnect(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/network_adapters/disconnect")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/network_adapters/disconnect")
 	r.obj = map[string]string{"id": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/compute_resource_pool.go
+++ b/internal/client/compute_resource_pool.go
@@ -47,7 +47,7 @@ func (rp *ResourcePoolClient) List(
 	hostClusterID string) ([]*ResourcePool, error) {
 
 	// TODO: filters
-	r := rp.c.newRequest("GET", "/api/compute/v1/vcenters/resource_pools")
+	r := rp.c.newRequest("GET", "/compute/v1/vcenters/resource_pools")
 	resp, err := rp.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (rp *ResourcePoolClient) List(
 }
 
 func (rp *ResourcePoolClient) Read(ctx context.Context, id string) (*ResourcePool, error) {
-	r := rp.c.newRequest("GET", "/api/compute/v1/vcenters/resource_pools/%s", id)
+	r := rp.c.newRequest("GET", "/compute/v1/vcenters/resource_pools/%s", id)
 	resp, err := rp.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_snapshot.go
+++ b/internal/client/compute_snapshot.go
@@ -18,7 +18,7 @@ type Snapshot struct {
 }
 
 func (s *SnapshotClient) List(ctx context.Context, virtualMachineId string) ([]*Snapshot, error) {
-	r := s.c.newRequest("GET", "/api/compute/v1/vcenters/snapshots")
+	r := s.c.newRequest("GET", "/compute/v1/vcenters/snapshots")
 	r.params.Add("virtualMachineId", virtualMachineId)
 	resp, err := s.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/compute_virtual_controller.go
+++ b/internal/client/compute_virtual_controller.go
@@ -26,7 +26,7 @@ func (v *VirtualControllerClient) List(
 	types string) ([]*VirtualController, error) {
 
 	// TODO: filters
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_controllers")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_controllers")
 	r.params.Add("virtualMachineId", virtualMachineId)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
@@ -53,13 +53,13 @@ type CreateVirtualControllerRequest struct {
 }
 
 func (n *VirtualControllerClient) Create(ctx context.Context, req *CreateVirtualControllerRequest) (string, error) {
-	r := n.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_controllers")
+	r := n.c.newRequest("POST", "/compute/v1/vcenters/virtual_controllers")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualControllerClient) Read(ctx context.Context, id string) (*VirtualController, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_controllers/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_controllers/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,30 +85,30 @@ type MountVirtualControllerRequest struct {
 }
 
 func (n *VirtualControllerClient) Mount(ctx context.Context, req *MountVirtualControllerRequest) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_controllers/cdrom/mount")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_controllers/cdrom/mount")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualControllerClient) Unmount(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_controllers/cdrom/unmount")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_controllers/cdrom/unmount")
 	r.obj = map[string]string{"id": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualControllerClient) Connect(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_controllers/cdrom/connect")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_controllers/cdrom/connect")
 	r.obj = map[string]string{"id": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualControllerClient) Disconnect(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_controllers/cdrom/disconnect")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_controllers/cdrom/disconnect")
 	r.obj = map[string]string{"id": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualControllerClient) Delete(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("DELETE", "/api/compute/v1/vcenters/virtual_controllers/%s", id)
+	r := n.c.newRequest("DELETE", "/compute/v1/vcenters/virtual_controllers/%s", id)
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/compute_virtual_datacenter.go
+++ b/internal/client/compute_virtual_datacenter.go
@@ -27,7 +27,7 @@ func (v *VirtualDatacenterClient) List(
 	filter *VirtualDatacenterFilter) ([]*VirtualDatacenter, error) {
 
 	// TODO: filters
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_datacenters")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_datacenters")
 	r.addFilter(filter)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
@@ -47,7 +47,7 @@ func (v *VirtualDatacenterClient) List(
 }
 
 func (v *VirtualDatacenterClient) Read(ctx context.Context, id string) (*VirtualDatacenter, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_datacenters/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_datacenters/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_virtual_disk.go
+++ b/internal/client/compute_virtual_disk.go
@@ -29,7 +29,7 @@ type VirtualDisk struct {
 }
 
 func (v *VirtualDiskClient) List(ctx context.Context, virtualMachineId string) ([]*VirtualDisk, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_disks")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_disks")
 	r.params.Add("virtualMachineId", virtualMachineId)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
@@ -60,13 +60,13 @@ type CreateVirtualDiskRequest struct {
 }
 
 func (n *VirtualDiskClient) Create(ctx context.Context, req *CreateVirtualDiskRequest) (string, error) {
-	r := n.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_disks")
+	r := n.c.newRequest("POST", "/compute/v1/vcenters/virtual_disks")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualDiskClient) Read(ctx context.Context, id string) (*VirtualDisk, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_disks/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_disks/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -92,18 +92,18 @@ type UpdateVirtualDiskRequest struct {
 }
 
 func (n *VirtualDiskClient) Update(ctx context.Context, req *UpdateVirtualDiskRequest) (string, error) {
-	r := n.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_disks")
+	r := n.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_disks")
 	r.obj = req
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualDiskClient) Delete(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("DELETE", "/api/compute/v1/vcenters/virtual_disks/%s", id)
+	r := n.c.newRequest("DELETE", "/compute/v1/vcenters/virtual_disks/%s", id)
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (n *VirtualDiskClient) Mount(ctx context.Context, virtualMachineId string, path string) (string, error) {
-	r := n.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_disks/mount")
+	r := n.c.newRequest("POST", "/compute/v1/vcenters/virtual_disks/mount")
 	r.obj = map[string]string{
 		"virtualMachineId": virtualMachineId,
 		"path":             path,
@@ -112,7 +112,7 @@ func (n *VirtualDiskClient) Mount(ctx context.Context, virtualMachineId string, 
 }
 
 func (n *VirtualDiskClient) Unmount(ctx context.Context, id string) (string, error) {
-	r := n.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_disks/unmount")
+	r := n.c.newRequest("POST", "/compute/v1/vcenters/virtual_disks/unmount")
 	r.obj = map[string]string{"virtualDiskId": id}
 	return n.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -120,7 +120,7 @@ func (v *VirtualMachineClient) List(
 	vmwareToolsVersions []int) ([]*VirtualMachine, error) {
 
 	// TODO: filters
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_machines")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_machines")
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -151,13 +151,13 @@ type CreateVirtualMachineRequest struct {
 }
 
 func (v *VirtualMachineClient) Create(ctx context.Context, req *CreateVirtualMachineRequest) (string, error) {
-	r := v.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_machines")
+	r := v.c.newRequest("POST", "/compute/v1/vcenters/virtual_machines")
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualMachineClient) Read(ctx context.Context, id string) (*VirtualMachine, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_machines/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_machines/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -188,24 +188,24 @@ type UpdateVirtualMachineRequest struct {
 }
 
 func (v *VirtualMachineClient) Update(ctx context.Context, req *UpdateVirtualMachineRequest) (string, error) {
-	r := v.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_machines")
+	r := v.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_machines")
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualMachineClient) Delete(ctx context.Context, id string) (string, error) {
-	r := v.c.newRequest("DELETE", "/api/compute/v1/vcenters/virtual_machines/%s", id)
+	r := v.c.newRequest("DELETE", "/compute/v1/vcenters/virtual_machines/%s", id)
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualMachineClient) Power(ctx context.Context, req *PowerRequest) (string, error) {
-	r := v.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_machines/power")
+	r := v.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_machines/power")
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
 
 func (v *VirtualMachineClient) Rename(ctx context.Context, id string, name string) (string, error) {
-	r := v.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_machines/rename")
+	r := v.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_machines/rename")
 	r.obj = map[string]string{
 		"id":   id,
 		"name": name,
@@ -225,7 +225,7 @@ type CloneVirtualMachineRequest struct {
 }
 
 func (v *VirtualMachineClient) Clone(ctx context.Context, req *CloneVirtualMachineRequest) (string, error) {
-	r := v.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_machines/%s/clone", req.VirtualMachineId)
+	r := v.c.newRequest("POST", "/compute/v1/vcenters/virtual_machines/%s/clone", req.VirtualMachineId)
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
@@ -250,7 +250,7 @@ type DiskPlacement struct {
 }
 
 func (v *VirtualMachineClient) Relocate(ctx context.Context, req *RelocateVirtualMachineRequest) (string, error) {
-	r := v.c.newRequest("POST", "/api/compute/v1/vcenters/virtual_machines/relocate")
+	r := v.c.newRequest("POST", "/compute/v1/vcenters/virtual_machines/relocate")
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
@@ -260,7 +260,7 @@ type UpdateGuestRequest struct {
 }
 
 func (v *VirtualMachineClient) Guest(ctx context.Context, id string, req *UpdateGuestRequest) (string, error) {
-	r := v.c.newRequest("PATCH", "/api/compute/v1/vcenters/virtual_machines/%s/guest", id)
+	r := v.c.newRequest("PATCH", "/compute/v1/vcenters/virtual_machines/%s/guest", id)
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }
@@ -280,7 +280,7 @@ type VirtualMachinePowerRecommendation struct {
 }
 
 func (v *VirtualMachineClient) Recommendation(ctx context.Context, filter *VirtualMachineRecommendationFilter) ([]*VirtualMachinePowerRecommendation, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_machines/power/recommendations")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_machines/power/recommendations")
 	r.addFilter(filter)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/compute_virtual_switch.go
+++ b/internal/client/compute_virtual_switch.go
@@ -30,7 +30,7 @@ func (v *VirtualSwitchClient) List(
 	filter *VirtualSwitchFilter) ([]*VirtualSwitch, error) {
 
 	// TODO: filters
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_switchs")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_switchs")
 	r.addFilter(filter)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
@@ -50,7 +50,7 @@ func (v *VirtualSwitchClient) List(
 }
 
 func (v *VirtualSwitchClient) Read(ctx context.Context, id string) (*VirtualSwitch, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/virtual_switchs/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/virtual_switchs/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_worker.go
+++ b/internal/client/compute_worker.go
@@ -32,7 +32,7 @@ type Worker struct {
 
 func (v *WorkerClient) List(ctx context.Context, name string) ([]*Worker, error) {
 	// TODO: filters
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters")
+	r := v.c.newRequest("GET", "/compute/v1/vcenters")
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (v *WorkerClient) List(ctx context.Context, name string) ([]*Worker, error)
 }
 
 func (v *WorkerClient) Read(ctx context.Context, id string) (*Worker, error) {
-	r := v.c.newRequest("GET", "/api/compute/v1/vcenters/%s", id)
+	r := v.c.newRequest("GET", "/compute/v1/vcenters/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/iam_assignment.go
+++ b/internal/client/iam_assignment.go
@@ -17,7 +17,7 @@ type TenantAssignment struct {
 }
 
 func (a *AssignmentClient) List(ctx context.Context, userId, tenantId, roleId string) ([]*TenantAssignment, error) {
-	r := a.c.newRequest("GET", "/api/iam/v2/assignments/tenant")
+	r := a.c.newRequest("GET", "/iam/v2/assignments/tenant")
 	r.params.Set("userId", userId)
 	r.params.Set("tenantId", tenantId)
 	if roleId != "" {

--- a/internal/client/iam_company.go
+++ b/internal/client/iam_company.go
@@ -18,7 +18,7 @@ type Company struct {
 }
 
 func (c *CompanyClient) Read(ctx context.Context, companyID string) (*Company, error) {
-	r := c.c.newRequest("GET", "/api/iam/v2/companies/%s", companyID)
+	r := c.c.newRequest("GET", "/iam/v2/companies/%s", companyID)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/iam_feature.go
+++ b/internal/client/iam_feature.go
@@ -18,7 +18,7 @@ type Feature struct {
 }
 
 func (f *FeatureClient) List(ctx context.Context) ([]*Feature, error) {
-	r := f.c.newRequest("GET", "/api/iam/v2/features")
+	r := f.c.newRequest("GET", "/iam/v2/features")
 	resp, err := f.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ type FeatureAssignment struct {
 }
 
 func (f *FeatureClient) ListAssignments(ctx context.Context, tenantID string) ([]*FeatureAssignment, error) {
-	r := f.c.newRequest("GET", "/api/iam/v2/features/assignments")
+	r := f.c.newRequest("GET", "/iam/v2/features/assignments")
 	r.params.Set("tenantId", tenantID)
 	resp, err := f.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/iam_pat.go
+++ b/internal/client/iam_pat.go
@@ -24,7 +24,7 @@ type Token struct {
 }
 
 func (p *PATClient) List(ctx context.Context, userId string, tenantId string) ([]*Token, error) {
-	r := p.c.newRequest("GET", "/api/iam/v2/personal_access_tokens")
+	r := p.c.newRequest("GET", "/iam/v2/personal_access_tokens")
 	r.params.Set("userId", userId)
 	r.params.Set("tenantId", tenantId)
 	resp, err := p.c.doRequest(ctx, r)
@@ -45,7 +45,7 @@ func (p *PATClient) List(ctx context.Context, userId string, tenantId string) ([
 }
 
 func (p *PATClient) Read(ctx context.Context, patID string) (*Token, error) {
-	r := p.c.newRequest("GET", "/api/iam/v2/personal_access_tokens/%s", patID)
+	r := p.c.newRequest("GET", "/iam/v2/personal_access_tokens/%s", patID)
 	resp, err := p.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func (p *PATClient) Create(ctx context.Context, name string, roles []string, exp
 		return nil, fmt.Errorf("roles must not be empty")
 	}
 
-	r := p.c.newRequest("POST", "/api/iam/v2/personal_access_tokens")
+	r := p.c.newRequest("POST", "/iam/v2/personal_access_tokens")
 	r.obj = map[string]interface{}{
 		"name":           name,
 		"roles":          roles,
@@ -103,7 +103,7 @@ func (p *PATClient) Create(ctx context.Context, name string, roles []string, exp
 }
 
 func (p *PATClient) Delete(ctx context.Context, patID string) error {
-	r := p.c.newRequest("DELETE", "/api/iam/v2/personal_access_tokens/%s", patID)
+	r := p.c.newRequest("DELETE", "/iam/v2/personal_access_tokens/%s", patID)
 	resp, err := p.c.doRequest(ctx, r)
 	if err != nil {
 		return err

--- a/internal/client/iam_role.go
+++ b/internal/client/iam_role.go
@@ -16,7 +16,7 @@ type Role struct {
 }
 
 func (r *RoleClient) List(ctx context.Context) ([]*Role, error) {
-	req := r.c.newRequest("GET", "/api/iam/v2/roles")
+	req := r.c.newRequest("GET", "/iam/v2/roles")
 	resp, err := r.c.doRequest(ctx, req)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (r *RoleClient) List(ctx context.Context) ([]*Role, error) {
 }
 
 func (r *RoleClient) Read(ctx context.Context, roleID string) (*Role, error) {
-	req := r.c.newRequest("GET", "/api/iam/v2/roles/%s", roleID)
+	req := r.c.newRequest("GET", "/iam/v2/roles/%s", roleID)
 	resp, err := r.c.doRequest(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/client/iam_tenant.go
+++ b/internal/client/iam_tenant.go
@@ -18,7 +18,7 @@ type Tenant struct {
 }
 
 func (t *TenantClient) List(ctx context.Context) ([]*Tenant, error) {
-	r := t.c.newRequest("GET", "/api/iam/v2/tenants")
+	r := t.c.newRequest("GET", "/iam/v2/tenants")
 	resp, err := t.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err

--- a/internal/client/iam_user.go
+++ b/internal/client/iam_user.go
@@ -22,7 +22,7 @@ type User struct {
 }
 
 func (t *UserClient) Read(ctx context.Context, userID string) (*User, error) {
-	r := t.c.newRequest("GET", "/api/iam/v2/users/%s", userID)
+	r := t.c.newRequest("GET", "/iam/v2/users/%s", userID)
 	resp, err := t.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (t *UserClient) Read(ctx context.Context, userID string) (*User, error) {
 }
 
 func (t *UserClient) List(ctx context.Context, companyID string) ([]*User, error) {
-	r := t.c.newRequest("GET", "/api/iam/v2/users")
+	r := t.c.newRequest("GET", "/iam/v2/users")
 	r.params.Add("companyId", companyID)
 	resp, err := t.c.doRequest(ctx, r)
 	if err != nil {

--- a/internal/client/tag_resource.go
+++ b/internal/client/tag_resource.go
@@ -23,7 +23,7 @@ type CreateTagRequestResource struct {
 }
 
 func (c *TagResourceClient) Create(ctx context.Context, req *CreateTagRequest) error {
-	r := c.c.newRequest("POST", "/api/tag/v1/tags")
+	r := c.c.newRequest("POST", "/tag/v1/tags")
 	r.obj = req
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
@@ -34,7 +34,7 @@ func (c *TagResourceClient) Create(ctx context.Context, req *CreateTagRequest) e
 }
 
 func (c *TagResourceClient) Read(ctx context.Context, resourceId string) ([]*Tag, error) {
-	r := c.c.newRequest("GET", "/api/tag/v1/tags/resources/%s", resourceId)
+	r := c.c.newRequest("GET", "/tag/v1/tags/resources/%s", resourceId)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func (c *TagResourceClient) Read(ctx context.Context, resourceId string) ([]*Tag
 }
 
 func (c *TagResourceClient) Delete(ctx context.Context, resourceId string, key string) error {
-	r := c.c.newRequest("DELETE", "/api/tag/v1/tags/resources/%s/keys/%s", resourceId, key)
+	r := c.c.newRequest("DELETE", "/tag/v1/tags/resources/%s/keys/%s", resourceId, key)
 	resp, err := c.c.doRequest(ctx, r)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What changed :**
* Removed `/api` from every URLs in the go http client used by the provider

**Release notes :**
* Users have to update their configuration of the provider. (See example below)

```HCL
provider "cloudtemple" {
  client_id  = "56da0c8d-4dfa-49e5-a388-f2da1dab5d37"
  secret_id = "8cc0639a-69d5-4f9c-8552-c725556567c4"
  address   = "shiva.cloud-temple.com" // BEFORE
  address   = "shiva.cloud-temple.com/api" // NOW
}
```