### PR TITLE
Fixed a bug causing some data not to be imported in state when importing a cloudtemple_compute_virtual_machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 0.13.0-rc.1 (March 19th, 2024)
 
+NEW FEATURES:
+
   * Added the ability to create NVME controllers.
+
+BUG FIXES:
+
+  * Fixed a bug causing `datastore_id` and `datastore_cluster_id` not to be imported in state when importing a `cloudtemple_compute_virtual_machine`
 
 ## 0.12.4-rc.3 (February 13th, 2024)
 

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -38,6 +38,8 @@ type VirtualMachine struct {
 	ToolsVersion                   int                             `terraform:"tools_version"`
 	DatacenterId                   string                          `terraform:"datacenter_id"`
 	HostClusterId                  string                          `terraform:"host_cluster_id"`
+	DatastoreId                    string                          `terraform:"datastore_id"`
+	DatastoreClusterId             string                          `terraform:"datastore_cluster_id"`
 	DistributedVirtualPortGroupIds []string                        `terraform:"distributed_virtual_port_group_ids"`
 	SppMode                        string                          `terraform:"spp_mode"`
 	Snapshoted                     bool                            `terraform:"snapshoted"`


### PR DESCRIPTION
**What changed :**
* Fixed a bug causing `datastore_id` and `datastore_cluster_id` not to be imported in state when importing a `cloudtemple_compute_virtual_machine`