### PR TITLE
Updated release.yml to handle deprecated flag '--rm-dist'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4.4.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
Flag `--rm-dist` is deprecated since GoReleaser v1.15.0
* https://goreleaser.com/deprecations/?h=rm#-rm-dist