### PR TITLE
Implemented relocate, update, attach, detach virtual disk on iaas open source

### DIFF
--- a/docs/data-sources/compute_iaas_opensource_pool.md
+++ b/docs/data-sources/compute_iaas_opensource_pool.md
@@ -59,6 +59,9 @@ output "pool-2" {
 - `high_availability_enabled` (Boolean) Whether high availability is enabled for this pool.
 - `hosts` (List of String) List of host IDs in this pool.
 - `internal_id` (String) The internal identifier of the pool in the Open IaaS system.
+- `label` (String) The label of the pool.
+- `master` (String) The ID of the master host in this pool.
+- `memory` (List of Object) Memory information for the pool. (see [below for nested schema](#nestedatt--memory))
 - `type` (List of Object) Information about the pool type. (see [below for nested schema](#nestedatt--type))
 
 <a id="nestedatt--cpu"></a>
@@ -68,6 +71,15 @@ Read-Only:
 
 - `cores` (Number)
 - `sockets` (Number)
+
+
+<a id="nestedatt--memory"></a>
+### Nested Schema for `memory`
+
+Read-Only:
+
+- `size` (Number)
+- `usage` (Number)
 
 
 <a id="nestedatt--type"></a>

--- a/docs/data-sources/compute_iaas_opensource_storage_repository.md
+++ b/docs/data-sources/compute_iaas_opensource_storage_repository.md
@@ -67,7 +67,7 @@ output "storage_repository-2" {
 - `description` (String) The description of the storage repository.
 - `free_capacity` (Number) The available free space in the storage repository in bytes.
 - `internal_id` (String) The internal identifier of the storage repository in the Open IaaS system.
-- `maintenance_status` (Boolean) Whether the storage repository is in maintenance mode.
+- `maintenance_mode` (Boolean) Whether the storage repository is in maintenance mode.
 - `max_capacity` (Number) The maximum capacity of the storage repository in bytes.
 - `virtual_disks` (List of String) List of virtual disk IDs stored in this repository.
 

--- a/docs/data-sources/compute_iaas_opensource_virtual_machine.md
+++ b/docs/data-sources/compute_iaas_opensource_virtual_machine.md
@@ -61,6 +61,7 @@ output "virtual_machine-2" {
 - `boot_order` (List of String) The boot order of the virtual machine, listing devices in the order they will be tried during boot.
 - `cpu` (Number) The number of virtual CPUs allocated to the virtual machine.
 - `dvd_drive` (List of Object) Information about the virtual machine's DVD drive. (see [below for nested schema](#nestedatt--dvd_drive))
+- `high_availability` (String) High Availability configuration for the virtual machine. Possible values are: 'disabled', 'restart' and 'best-effort'. For more information, refer to the documentation : https://docs.cloud-temple.com/iaas_opensource/concepts#haute-disponibilit%C3%A9
 - `host_id` (String) The ID of the host the virtual machine is running on.
 - `internal_id` (String) The internal identifier of the virtual machine in the Open IaaS system.
 - `memory` (Number) The amount of memory allocated to the virtual machine in Bytes.

--- a/docs/resources/compute_iaas_opensource_virtual_disk.md
+++ b/docs/resources/compute_iaas_opensource_virtual_disk.md
@@ -81,6 +81,7 @@ Read-Only:
 
 Read-Only:
 
+- `connected` (Boolean)
 - `id` (String)
 - `name` (String)
 - `read_only` (Boolean)

--- a/internal/client/compute_iaas_opensource_pool.go
+++ b/internal/client/compute_iaas_opensource_pool.go
@@ -15,9 +15,15 @@ type OpenIaasPool struct {
 	MachineManager          BaseObject
 	InternalID              string
 	Name                    string
+	Label                   string
 	HighAvailabilityEnabled bool
+	Master                  string
 	Hosts                   []string
-	Cpu                     struct {
+	Memory                  struct {
+		Usage int
+		Size  int
+	}
+	Cpu struct {
 		Cores   int
 		Sockets int
 	}

--- a/internal/client/compute_iaas_opensource_storage_repository.go
+++ b/internal/client/compute_iaas_opensource_storage_repository.go
@@ -11,20 +11,20 @@ func (c *ComputeOpenIaaSClient) StorageRepository() *OpenIaaSStorageRepositoryCl
 }
 
 type OpenIaaSStorageRepository struct {
-	ID                string
-	InternalId        string
-	Name              string
-	Description       string
-	MaintenanceStatus bool
-	MaxCapacity       int
-	FreeCapacity      int
-	StorageType       string
-	VirtualDisks      []string
-	Shared            bool
-	Accessible        int
-	Host              BaseObject
-	Pool              BaseObject
-	MachineManager    BaseObject
+	ID              string
+	InternalId      string
+	Name            string
+	Description     string
+	MaintenanceMode bool
+	MaxCapacity     int
+	FreeCapacity    int
+	StorageType     string
+	VirtualDisks    []string
+	Shared          bool
+	Accessible      int
+	Host            BaseObject
+	Pool            BaseObject
+	MachineManager  BaseObject
 }
 
 type StorageRepositoryFilter struct {

--- a/internal/client/compute_iaas_opensource_virtual_disk.go
+++ b/internal/client/compute_iaas_opensource_virtual_disk.go
@@ -20,9 +20,10 @@ type OpenIaaSVirtualDisk struct {
 	IsSnapshot        bool
 	StorageRepository BaseObject
 	VirtualMachines   []struct {
-		ID       string
-		Name     string
-		ReadOnly bool
+		ID        string
+		Name      string
+		ReadOnly  bool
+		Connected bool
 	}
 	Templates []struct {
 		ID       string
@@ -93,6 +94,27 @@ func (v *OpenIaaSVirtualDiskClient) List(ctx context.Context, filter *OpenIaaSVi
 	return out, nil
 }
 
+type OpenIaaSVirtualDiskUpdateRequest struct {
+	Name string `json:"name,omitempty"`
+	Size int    `json:"size,omitempty"`
+}
+
+func (v *OpenIaaSVirtualDiskClient) Update(ctx context.Context, id string, req *OpenIaaSVirtualDiskUpdateRequest) (string, error) {
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s", id)
+	r.obj = req
+	return v.c.doRequestAndReturnActivity(ctx, r)
+}
+
+type OpenIaaSVirtualDiskRelocateRequest struct {
+	StorageRepositoryID string `json:"storageRepositoryId"`
+}
+
+func (v *OpenIaaSVirtualDiskClient) Relocate(ctx context.Context, id string, req *OpenIaaSVirtualDiskRelocateRequest) (string, error) {
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s/relocate", id)
+	r.obj = req
+	return v.c.doRequestAndReturnActivity(ctx, r)
+}
+
 type OpenIaaSVirtualDiskAttachRequest struct {
 	VirtualMachineID string `json:"virtualMachineId"`
 	Bootable         bool   `json:"bootable,omitempty"`
@@ -101,7 +123,37 @@ type OpenIaaSVirtualDiskAttachRequest struct {
 }
 
 func (v *OpenIaaSVirtualDiskClient) Attach(ctx context.Context, id string, req *OpenIaaSVirtualDiskAttachRequest) (string, error) {
-	r := v.c.newRequest("POST", "/compute/v1/open_iaas/virtual_disks/%s/attach", id)
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s/attach", id)
+	r.obj = req
+	return v.c.doRequestAndReturnActivity(ctx, r)
+}
+
+type OpenIaaSVirtualDiskDetachRequest struct {
+	VirtualMachineID string `json:"virtualMachineId"`
+}
+
+func (v *OpenIaaSVirtualDiskClient) Detach(ctx context.Context, id string, req *OpenIaaSVirtualDiskDetachRequest) (string, error) {
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s/detach", id)
+	r.obj = req
+	return v.c.doRequestAndReturnActivity(ctx, r)
+}
+
+type OpenIaaSVirtualDiskDisconnectRequest struct {
+	VirtualMachineID string `json:"virtualMachineId"`
+}
+
+func (v *OpenIaaSVirtualDiskClient) Disconnect(ctx context.Context, id string, req *OpenIaaSVirtualDiskDisconnectRequest) (string, error) {
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s/disconnect", id)
+	r.obj = req
+	return v.c.doRequestAndReturnActivity(ctx, r)
+}
+
+type OpenIaaSVirtualDiskConnectRequest struct {
+	VirtualMachineID string `json:"virtualMachineId"`
+}
+
+func (v *OpenIaaSVirtualDiskClient) Connect(ctx context.Context, id string, req *OpenIaaSVirtualDiskConnectRequest) (string, error) {
+	r := v.c.newRequest("PATCH", "/compute/v1/open_iaas/virtual_disks/%s/connect", id)
 	r.obj = req
 	return v.c.doRequestAndReturnActivity(ctx, r)
 }

--- a/internal/client/compute_iaas_opensource_virtual_machine.go
+++ b/internal/client/compute_iaas_opensource_virtual_machine.go
@@ -22,6 +22,7 @@ type OpenIaaSVirtualMachine struct {
 	InternalID          string
 	PowerState          string
 	SecureBoot          bool
+	HighAvailability    string
 	BootFirmware        string
 	AutoPowerOn         bool
 	DvdDrive            DvdDrive

--- a/internal/provider/data_source_compute_iaas_opensource_pool.go
+++ b/internal/provider/data_source_compute_iaas_opensource_pool.go
@@ -44,6 +44,11 @@ func dataSourceOpenIaasPool() *schema.Resource {
 			},
 
 			// Out
+			"label": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The label of the pool.",
+			},
 			"internal_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -53,6 +58,31 @@ func dataSourceOpenIaasPool() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether high availability is enabled for this pool.",
+			},
+			"master": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the master host in this pool.",
+			},
+			"memory": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Memory information for the pool.",
+
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"usage": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of memory currently in use in the pool.",
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The total size of memory in the pool.",
+						},
+					},
+				},
 			},
 			"cpu": {
 				Type:        schema.TypeList,

--- a/internal/provider/data_source_compute_iaas_opensource_storage_repository.go
+++ b/internal/provider/data_source_compute_iaas_opensource_storage_repository.go
@@ -92,7 +92,7 @@ func dataSourceOpenIaasStorageRepository() *schema.Resource {
 				Computed:    true,
 				Description: "The description of the storage repository.",
 			},
-			"maintenance_status": {
+			"maintenance_mode": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether the storage repository is in maintenance mode.",

--- a/internal/provider/data_source_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/data_source_compute_iaas_opensource_virtual_machine.go
@@ -69,6 +69,11 @@ func dataSourceOpenIaasVirtualMachine() *schema.Resource {
 				Computed:    true,
 				Description: "Whether the virtual machine is configured to automatically power on when the host starts.",
 			},
+			"high_availability": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "High Availability configuration for the virtual machine. Possible values are: 'disabled', 'restart' and 'best-effort'. For more information, refer to the documentation : https://docs.cloud-temple.com/iaas_opensource/concepts#haute-disponibilit%C3%A9",
+			},
 			"dvd_drive": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/internal/provider/helpers/helper_compute_iaas_opensource_pool.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_pool.go
@@ -14,6 +14,14 @@ func FlattenOpenIaaSPool(pool *client.OpenIaasPool) map[string]interface{} {
 		},
 	}
 
+	// Mapper la memory
+	memory := []map[string]interface{}{
+		{
+			"usage": pool.Memory.Usage,
+			"size":  pool.Memory.Size,
+		},
+	}
+
 	// Mapper le type
 	poolType := []map[string]interface{}{
 		{
@@ -25,10 +33,13 @@ func FlattenOpenIaaSPool(pool *client.OpenIaasPool) map[string]interface{} {
 	return map[string]interface{}{
 		"id":                        pool.ID,
 		"name":                      pool.Name,
+		"label":                     pool.Label,
 		"internal_id":               pool.InternalID,
 		"machine_manager_id":        pool.MachineManager.ID,
 		"high_availability_enabled": pool.HighAvailabilityEnabled,
+		"master":                    pool.Master,
 		"hosts":                     pool.Hosts,
+		"memory":                    memory,
 		"cpu":                       cpu,
 		"type":                      poolType,
 	}

--- a/internal/provider/helpers/helper_compute_iaas_opensource_storage_repository.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_storage_repository.go
@@ -11,7 +11,7 @@ func FlattenOpenIaaSStorageRepository(repository *client.OpenIaaSStorageReposito
 		"name":               repository.Name,
 		"internal_id":        repository.InternalId,
 		"description":        repository.Description,
-		"maintenance_status": repository.MaintenanceStatus,
+		"maintenance_mode":   repository.MaintenanceMode,
 		"max_capacity":       repository.MaxCapacity,
 		"free_capacity":      repository.FreeCapacity,
 		"type":               repository.StorageType,

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_disk.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_disk.go
@@ -13,6 +13,7 @@ func FlattenOpenIaaSVirtualDisk(disk *client.OpenIaaSVirtualDisk) map[string]int
 			"id":        vm.ID,
 			"name":      vm.Name,
 			"read_only": vm.ReadOnly,
+			"connected": vm.Connected,
 		}
 	}
 

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
@@ -37,6 +37,7 @@ func FlattenOpenIaaSVirtualMachine(vm *client.OpenIaaSVirtualMachine) map[string
 		"secure_boot":           vm.SecureBoot,
 		"boot_firmware":         vm.BootFirmware,
 		"auto_power_on":         vm.AutoPowerOn,
+		"high_availability":     vm.HighAvailability,
 		"dvd_drive":             dvdDrive,
 		"boot_order":            vm.BootOrder,
 		"operating_system_name": vm.OperatingSystemName,


### PR DESCRIPTION
**What changed ?**
- Added property `connected` to resource and datasource `cloudtemple_compute_iaas_opensource_virtual_disk`.
- Added the ability to relocate a `cloudtemple_compute_iaas_opensource_virtual_disk`.
- Added the ability to update the size and name of a `cloudtemple_compute_iaas_opensource_virtual_disk`.
- Added the ability to attach a `cloudtemple_compute_iaas_opensource_virtual_disk` to a `cloudtemple_compute_iaas_opensource_virtual_machine`.
- Added the ability to detach a `cloudtemple_compute_iaas_opensource_virtual_disk` from a `cloudtemple_compute_iaas_opensource_virtual_machine`.
- Added the `label`, `master` and `memory` properties to the datasource `cloudtemple_compute_iaas_opensource_pool`.
- Renamed property `maintenance_status` into `maintenance_mode` following Cloud Temple Console API breaking change.
- Added property `high_availability` in resource and datasource `cloudtemple_compute_iaas_opensource_virtual_machine` to prepare for the next feature.