### PR TITLE
OpenIaaS : retry borné des opérations VIF en échec transitoire (workers VPC muets)

### DIFF
--- a/internal/client/activity.go
+++ b/internal/client/activity.go
@@ -2,12 +2,38 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/sethvargo/go-retry"
 )
+
+// transientActivityReasons lists platform-side failure reasons known to be
+// temporary (VPC workers not responding) and safe to retry at the operation
+// level (#251). Permanent reasons (MAC conflict, insufficient space…) must
+// stay immediately fatal.
+var transientActivityReasons = []string{
+	"None of the workers were able to respond",
+}
+
+// IsTransientActivityFailure reports whether err is an activity that reached
+// the "failed" state for a reason known to be transient platform-side.
+func IsTransientActivityFailure(err error) bool {
+	var ace *ActivityCompletionError
+	if !errors.As(err, &ace) || ace.activity == nil {
+		return false
+	}
+	for _, state := range ace.activity.State {
+		for _, marker := range transientActivityReasons {
+			if strings.Contains(state.Reason, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 type ActivityClient struct {
 	c *Client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -526,6 +527,43 @@ func getWaiterOptions(ctx context.Context) *client.WaiterOptions {
 			tflog.Debug(ctx, msg)
 		},
 	}
+}
+
+// maxTransientActivityAttempts bounds the retries of an operation whose
+// activity failed for a transient platform reason (#251).
+const maxTransientActivityAttempts = 3
+
+// runActivityWithRetry starts an asynchronous operation (start returns the
+// activity id), waits for its completion and retries the WHOLE operation when
+// the activity fails for a transient platform reason ("None of the workers
+// were able to respond", #251). Permanent failures are returned immediately.
+// Only safe for operations that are idempotent or whose partial effects are
+// handled by the caller.
+func runActivityWithRetry(ctx context.Context, c *client.Client, description string, start func() (string, error)) (*client.Activity, error) {
+	var activity *client.Activity
+	var err error
+	for attempt := 1; attempt <= maxTransientActivityAttempts; attempt++ {
+		var activityId string
+		activityId, err = start()
+		if err != nil {
+			return nil, err
+		}
+		activity, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
+		if err == nil || !client.IsTransientActivityFailure(err) {
+			return activity, err
+		}
+		if attempt == maxTransientActivityAttempts {
+			break
+		}
+		tflog.Warn(ctx, fmt.Sprintf("%s: transient platform failure (attempt %d/%d), retrying: %s",
+			description, attempt, maxTransientActivityAttempts, err))
+		select {
+		case <-ctx.Done():
+			return activity, err
+		case <-time.After(time.Duration(attempt) * 10 * time.Second):
+		}
+	}
+	return activity, err
 }
 
 func setIdFromActivityState(d *schema.ResourceData, activity *client.Activity) {

--- a/internal/provider/resource_compute_iaas_opensource_network_adapter.go
+++ b/internal/provider/resource_compute_iaas_opensource_network_adapter.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -87,16 +90,52 @@ func resourceOpenIaasNetworkAdapter() *schema.Resource {
 
 func openIaasNetworkAdapterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := getClient(meta)
+	vmID := d.Get("virtual_machine_id").(string)
 
-	activityId, err := c.Compute().OpenIaaS().NetworkAdapter().Create(ctx, &client.CreateOpenIaasNetworkAdapterRequest{
-		VirtualMachineID: d.Get("virtual_machine_id").(string),
-		NetworkID:        d.Get("network_id").(string),
-		MAC:              d.Get("mac_address").(string),
-	})
-	if err != nil {
-		return diag.Errorf("the network adapter could not be created: %s", err)
+	var activity *client.Activity
+	var err error
+	for attempt := 1; attempt <= maxTransientActivityAttempts; attempt++ {
+		var activityId string
+		activityId, err = c.Compute().OpenIaaS().NetworkAdapter().Create(ctx, &client.CreateOpenIaasNetworkAdapterRequest{
+			VirtualMachineID: vmID,
+			NetworkID:        d.Get("network_id").(string),
+			MAC:              d.Get("mac_address").(string),
+		})
+		if err != nil {
+			return diag.Errorf("the network adapter could not be created: %s", err)
+		}
+		activity, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
+		if err == nil || !client.IsTransientActivityFailure(err) {
+			break
+		}
+		// Anti-duplicate guard (#251): only delete the VIF referenced by the
+		// FAILED activity itself (ConcernedItems) — never by listing diff,
+		// another actor may legitimately create VIFs on the same VM in the
+		// meantime. A half-created VIF has an uncertain VPC registration:
+		// cleaning it is safer than adopting it. If the failed activity
+		// references no adapter, nothing is deleted and the retry may leave
+		// an orphan VIF platform-side: accepted trade-off — the platform did
+		// not report what it created, and a wrong deletion would be worse.
+		if activity != nil {
+			for _, item := range activity.ConcernedItems {
+				if item.Type == "network_adapter" && item.ID != "" {
+					if delActivity, derr := c.Compute().OpenIaaS().NetworkAdapter().Delete(ctx, item.ID); derr == nil {
+						_, _ = c.Activity().WaitForCompletion(ctx, delActivity, getWaiterOptions(ctx))
+					}
+				}
+			}
+		}
+		if attempt == maxTransientActivityAttempts {
+			break
+		}
+		tflog.Warn(ctx, fmt.Sprintf("create network adapter on %s: transient platform failure (attempt %d/%d), retrying: %s",
+			vmID, attempt, maxTransientActivityAttempts, err))
+		select {
+		case <-ctx.Done():
+			return diag.Errorf("the network adapter could not be created: %s", err)
+		case <-time.After(time.Duration(attempt) * 10 * time.Second):
+		}
 	}
-	activity, err := c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions((ctx)))
 	setIdFromActivityState(d, activity)
 	if err != nil {
 		return diag.Errorf("the network adapter could not be created: %s", err)
@@ -184,12 +223,11 @@ func openIaasNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, m
 			req.TxChecksumming = &txChecksumming
 		}
 		if req.NetworkID != "" || req.MAC != "" || req.TxChecksumming != nil {
-			activityId, err := c.Compute().OpenIaaS().NetworkAdapter().Update(ctx, d.Id(), req)
-			if err != nil {
+			// PATCH idempotent : retry borne sur echec transitoire (#251).
+			if _, err := runActivityWithRetry(ctx, c, fmt.Sprintf("update network adapter %s", d.Id()), func() (string, error) {
+				return c.Compute().OpenIaaS().NetworkAdapter().Update(ctx, d.Id(), req)
+			}); err != nil {
 				return diag.Errorf("the network adapter could not be updated: %s", err)
-			}
-			if _, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx)); err != nil {
-				return diag.Errorf("failed to update network adapter, %s", err)
 			}
 		}
 	}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -1181,12 +1181,11 @@ func osNetworkAdapterUpdate(ctx context.Context, c *client.Client, networkAdapte
 	if req.NetworkID == "" && req.MAC == "" && req.TxChecksumming == nil {
 		return nil
 	}
-	activityId, err := c.Compute().OpenIaaS().NetworkAdapter().Update(ctx, networkAdapter["id"].(string), req)
-	if err != nil {
-		return diag.Errorf("failed to update os network adapter: %s", err)
-	}
-	_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
-	if err != nil {
+	adapterID := networkAdapter["id"].(string)
+	// PATCH idempotent : retry borne sur echec transitoire (#251).
+	if _, err := runActivityWithRetry(ctx, c, fmt.Sprintf("update os network adapter %s", adapterID), func() (string, error) {
+		return c.Compute().OpenIaaS().NetworkAdapter().Update(ctx, adapterID, req)
+	}); err != nil {
 		return diag.Errorf("failed to update os network adapter: %s", err)
 	}
 


### PR DESCRIPTION
Refs #251
PR **empilée sur #247** (s'appuie sur le payload sélectif des PATCHes) — à recibler sur `main` après son merge.

- `IsTransientActivityFailure` (client) : reconnaît les activités en échec pour une raison transitoire (« None of the workers were able to respond ») ; les raisons permanentes (conflit MAC, espace insuffisant…) restent immédiatement fatales.
- `runActivityWithRetry` (provider) : retry borné (3 tentatives, backoff 10 s/20 s) de l'opération complète — appliqué aux PATCHes idempotents (ressource standalone + os adapters de la VM).
- Create du VIF standalone : garde anti-doublon **précise** — seul le VIF référencé par les `ConcernedItems` de l'activité en échec est supprimé avant retry (jamais par différence de listing : un autre acteur peut créer des VIFs sur la même VM). Si l'activité ne référence rien : pas de suppression, retry direct, risque d'orphelin accepté et documenté.

Constat déclencheur : 11/06 22:26, création de VIF en échec « workers not able to respond » sur un run par ailleurs sain — transitoire récurrent (déjà vu à 16:27 sur 7/7 VMs).
3 revues croisées internes (3 findings corrigés : suppression par snapshot trop large, snapshot non fiable, sleep final inutile).