### PR TITLE
ci: platform-independent unit-test and vet safety net (minimal #264 scope)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,46 @@ jobs:
       run: |
         go build -v .
 
+  # Platform-independent safety net: formatting, static analysis and unit
+  # tests of the pure packages. Protects the state-facing paths (flatten/
+  # expand helpers, reconciliation gates, Optional+Computed handling)
+  # without requiring a live Cloud Temple platform (#264).
+  unit:
+    name: Unit tests & vet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Get dependencies
+      run: |
+        go mod download
+
+    - name: Check formatting (gofmt)
+      run: |
+        unformatted="$(gofmt -l .)"
+        if [ -n "$unformatted" ]; then
+          echo "The following files are not gofmt-formatted:"
+          echo "$unformatted"
+          exit 1
+        fi
+
+    - name: Vet (platform-independent packages)
+      run: |
+        go vet ./internal/client ./internal/provider ./internal/provider/helpers
+
+    - name: Unit tests (platform-independent packages)
+      run: |
+        go test -count=1 -cover ./internal/client ./internal/provider ./internal/provider/helpers
+
   generate:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Refs #264

Minimal first increment of the platform-independent CI safety net, prioritized ahead of the retry PRs (#249, #265) so that state-sensitive changes land with a guardrail.

## What this adds

A new `unit` job in the existing **Tests** workflow (runs on every PR and push, no platform needed):

- **gofmt check** — fails if any Go file is not formatted.
- **`go vet`** on the pure packages: `internal/client`, `internal/provider`, `internal/provider/helpers`.
- **Unit tests with coverage** (`go test -count=1 -cover`) on the same packages — this now executes the state-safety test suites merged with the rc/v1.8.0 train (`TestAdapterNeedsUpdate`, `TestOsAdapterTxConfigured`, `TestOsNetworkAdapterUpdateSkipsUnconfiguredTx`, `TestIsPlatformManagedDisk`).

The existing `build` and `generate` jobs are kept unchanged.

## Deliberately deferred (per the scoping analysis)

- `go test ./...` — the `internal/*/tests` packages contain live/acceptance-style tests (that is #8's scope).
- Race detector and `staticcheck` — second increment, after the safety net is stable.
- Plan-convergence / schema-change detection — the state-safety hardening continues under #264.

## Validation

- Locally green on the rc/v1.8.0 HEAD: gofmt clean, vet OK, `go test` OK (provider: 22 tests, helpers: 5 tests; client has no unit tests yet but is covered for the future).
- Adversarial review (`codex review`, high reasoning) on the uncommitted diff before commit: no defect found.
