### PR TITLE
OpenIaaS: gate the VM-properties and VIF PATCH payloads on real live divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES :
   * Fixed a bug causing an explicit `tx_checksumming = false` to never be sent to the API.
   * Fixed a bug causing `tx_checksumming` to be pushed from resource `cloudtemple_compute_iaas_opensource_virtual_machine` when it was not explicitly configured.
   * Fixed a bug causing the cloud-init config drive (`XO CloudConfigDrive`) to be captured as a managed `os_disk` at creation on resource `cloudtemple_compute_iaas_opensource_virtual_machine`, producing a permanent removal drift.
+  * Fixed a bug causing resource `cloudtemple_compute_iaas_opensource_virtual_machine` to send an unconditional full-properties update on every apply. Properties are now only patched when they actually diverge from the live API state, and `secure_boot` is only sent when explicitly configured.
 
 IMPROVEMENTS :
 

--- a/internal/client/compute_iaas_opensource_virtual_machine.go
+++ b/internal/client/compute_iaas_opensource_virtual_machine.go
@@ -128,13 +128,17 @@ func (v *OpenIaaSVirtualMachineClient) Read(ctx context.Context, id string) (*Op
 }
 
 type UpdateOpenIaasVirtualMachineRequest struct {
+	// All fields are optional (PATCH semantics): callers only set the
+	// fields that actually diverge from the live state. The booleans are
+	// pointers so an absent value is omitted from the payload while an
+	// explicit false stays expressible (#267).
 	Name              string `json:"name,omitempty"`
 	CPU               int    `json:"cpu,omitempty"`
 	NumCoresPerSocket int    `json:"numCoresPerSocket,omitempty"`
 	Memory            int    `json:"memory,omitempty"`
-	SecureBoot        bool   `json:"secureBoot"`
+	SecureBoot        *bool  `json:"secureBoot,omitempty"`
 	BootFirmware      string `json:"bootFirmware,omitempty"`
-	AutoPowerOn       bool   `json:"autoPowerOn"`
+	AutoPowerOn       *bool  `json:"autoPowerOn,omitempty"`
 	HighAvailability  string `json:"highAvailability,omitempty"`
 }
 

--- a/internal/provider/optional_computed_booleans_test.go
+++ b/internal/provider/optional_computed_booleans_test.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// optionalComputedBooleanGuards is the registry of every Optional+Computed
+// boolean attribute of the provider resources. This list is DELIBERATELY
+// annoying to maintain: an Optional+Computed boolean read from d.Get cannot
+// distinguish an explicit user choice from a value inherited from the live
+// API, so pushing it into a PATCH without an explicit raw-config guard
+// silently mutates production resources (#246 class, #267).
+//
+// Before adding an entry here, either:
+//   - gate the attribute on d.GetRawConfig() evidence before any API write
+//     (pattern: osAdapterTxConfigured / openIaasVMDesiredPropertiesFromResourceData), or
+//   - document below why the attribute never reaches an API request.
+var optionalComputedBooleanGuards = map[string]string{
+	"cloudtemple_compute_iaas_opensource_virtual_machine.secure_boot":                        "raw-config gated in openIaasVMDesiredPropertiesFromResourceData (#267)",
+	"cloudtemple_compute_iaas_opensource_virtual_machine.os_disk.connected":                  "UNGATED-LEGACY: reconciled against live state in handleUpdateOSDevices; connect/disconnect paths use live VBD evidence",
+	"cloudtemple_compute_iaas_opensource_virtual_machine.os_network_adapter.attached":        "deprecated attribute, never written from the VM path",
+	"cloudtemple_compute_iaas_opensource_virtual_machine.os_network_adapter.tx_checksumming": "raw-config gated through osAdapterTxConfigured (map[string]*bool)",
+	"cloudtemple_compute_iaas_opensource_network_adapter.tx_checksumming":                    "raw-config gated in openIaasNetworkAdapterUpdate (txConfigured)",
+	"cloudtemple_compute_virtual_machine.boot_options.enter_bios_setup":                      "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+	"cloudtemple_compute_virtual_machine.boot_options.boot_retry_enabled":                    "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+	"cloudtemple_compute_virtual_machine.boot_options.efi_secure_boot_enabled":               "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+	"cloudtemple_compute_virtual_machine.os_network_adapter.auto_connect":                    "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+	"cloudtemple_compute_virtual_machine.os_network_adapter.connected":                       "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+}
+
+// collectOptionalComputedBooleans walks a schema map recursively and
+// returns the dotted paths of every Optional+Computed TypeBool attribute.
+func collectOptionalComputedBooleans(prefix string, s map[string]*schema.Schema, found map[string]bool) {
+	for name, attr := range s {
+		path := fmt.Sprintf("%s.%s", prefix, name)
+		if attr.Type == schema.TypeBool && attr.Optional && attr.Computed {
+			found[path] = true
+		}
+		if nested, ok := attr.Elem.(*schema.Resource); ok {
+			collectOptionalComputedBooleans(path, nested.Schema, found)
+		}
+	}
+}
+
+func TestOptionalComputedBooleansHavePatchGuards(t *testing.T) {
+	p := New("test")()
+
+	found := map[string]bool{}
+	for resourceName, resource := range p.ResourcesMap {
+		collectOptionalComputedBooleans(resourceName, resource.Schema, found)
+	}
+
+	var paths []string
+	for path := range found {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		if _, ok := optionalComputedBooleanGuards[path]; !ok {
+			t.Errorf("Optional+Computed boolean %q is not in the guard registry: gate it on raw-config evidence before any API write, or document why it never reaches a request (see #267)", path)
+		}
+	}
+	for path := range optionalComputedBooleanGuards {
+		if !found[path] {
+			t.Errorf("guard registry entry %q no longer matches any schema attribute: remove or fix it", path)
+		}
+	}
+}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -739,20 +739,24 @@ func openIaasVirtualMachineUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	// Check if hardware-related properties have changed
-	needsReboot := d.HasChange("cpu") || d.HasChange("memory") || d.HasChange("num_cores_per_socket")
+	// PATCH only the properties that actually diverge from the live API
+	// state (#267): during the create→update chaining every HasChange is
+	// true while the deploy already applied the configuration, and values
+	// merged through Computed are not write intent (#246 class).
+	vm, err := c.Compute().OpenIaaS().VirtualMachine().Read(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("failed to read virtual machine state: %s", err)
+	}
+	if vm == nil {
+		return diag.Errorf("failed to find virtual machine: %s", d.Id())
+	}
+
+	patch, changed, needsReboot := buildOpenIaasVMPropertiesPatch(vm, openIaasVMDesiredPropertiesFromResourceData(d))
 	wasRunning := false
 
-	// If hardware-related properties have changed, we need to power off the VM first
-	if needsReboot {
-		// Get current VM state to check if it's running
-		vm, err := c.Compute().OpenIaaS().VirtualMachine().Read(ctx, d.Id())
-		if err != nil {
-			return diag.Errorf("failed to read virtual machine state: %s", err)
-		}
-
-		// Only power off if the VM is running
-		if vm.PowerState == "Running" {
+	if changed {
+		// The cpu/memory/cores divergences require a power cycle first
+		if needsReboot && vm.PowerState == "Running" {
 			wasRunning = true
 
 			if d.Get("allow_vm_restart").(bool) {
@@ -772,25 +776,16 @@ func openIaasVirtualMachineUpdate(ctx context.Context, d *schema.ResourceData, m
 				return diag.Errorf("The virtual machine %s (%s) needs to be powered off to apply changes to cpu, memory or num_cores_per_socket. Please set allow_vm_restart to true to allow the provider to power off and on the VM if necessary.", vm.Name, d.Id())
 			}
 		}
-	}
 
-	// Update the VM properties
-	activityId, err := c.Compute().OpenIaaS().VirtualMachine().Update(ctx, d.Id(), &client.UpdateOpenIaasVirtualMachineRequest{
-		Name:              d.Get("name").(string),
-		CPU:               d.Get("cpu").(int),
-		NumCoresPerSocket: d.Get("num_cores_per_socket").(int),
-		Memory:            d.Get("memory").(int),
-		BootFirmware:      d.Get("boot_firmware").(string),
-		SecureBoot:        d.Get("secure_boot").(bool),
-		AutoPowerOn:       d.Get("auto_power_on").(bool),
-		HighAvailability:  d.Get("high_availability").(string),
-	})
-	if err != nil {
-		return diag.Errorf("failed to update virtual machine: %s", err)
-	}
-	_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
-	if err != nil {
-		return diag.Errorf("failed to update virtual machine, %s", err)
+		// Update the VM properties
+		activityId, err := c.Compute().OpenIaaS().VirtualMachine().Update(ctx, d.Id(), patch)
+		if err != nil {
+			return diag.Errorf("failed to update virtual machine: %s", err)
+		}
+		_, err = c.Activity().WaitForCompletion(ctx, activityId, getWaiterOptions(ctx))
+		if err != nil {
+			return diag.Errorf("failed to update virtual machine, %s", err)
+		}
 	}
 
 	// If VM was running before and we powered it off, power it back on
@@ -966,6 +961,96 @@ func diskPendingChanges(desired map[string]interface{}, actual *client.OpenIaaSV
 		changes.relocate = true
 	}
 	return changes
+}
+
+// openIaasVMDesiredProperties carries the desired VM properties from the
+// plan. SecureBoot holds raw-config evidence: the attribute is
+// Optional+Computed, so the merged plan value is not write intent — nil
+// means "not explicitly configured, never push". AutoPowerOn is a plain
+// Optional boolean: its plan value is authoritative (absent means false by
+// the Terraform contract) and it is always set.
+type openIaasVMDesiredProperties struct {
+	Name              string
+	CPU               int
+	NumCoresPerSocket int
+	Memory            int
+	BootFirmware      string
+	HighAvailability  string
+	SecureBoot        *bool
+	AutoPowerOn       *bool
+}
+
+// openIaasVMDesiredPropertiesFromResourceData extracts the desired VM
+// properties and the raw-config evidence for secure_boot.
+func openIaasVMDesiredPropertiesFromResourceData(d *schema.ResourceData) openIaasVMDesiredProperties {
+	desired := openIaasVMDesiredProperties{
+		Name:              d.Get("name").(string),
+		CPU:               d.Get("cpu").(int),
+		NumCoresPerSocket: d.Get("num_cores_per_socket").(int),
+		Memory:            d.Get("memory").(int),
+		BootFirmware:      d.Get("boot_firmware").(string),
+		HighAvailability:  d.Get("high_availability").(string),
+	}
+	autoPowerOn := d.Get("auto_power_on").(bool)
+	desired.AutoPowerOn = &autoPowerOn
+	if raw := d.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
+		if v := raw.GetAttr("secure_boot"); !v.IsNull() && v.IsKnown() {
+			secureBoot := v.True()
+			desired.SecureBoot = &secureBoot
+		}
+	}
+	return desired
+}
+
+// buildOpenIaasVMPropertiesPatch compares the desired properties against
+// the live API state and returns the PATCH limited to the real
+// divergences. changed reports whether the PATCH carries anything;
+// needsReboot reports whether one of the included fields (cpu, memory,
+// num_cores_per_socket) requires a power cycle. Zero/empty desired values
+// never overwrite live values: a value merged through Computed is not
+// write intent (#246 class, #267).
+func buildOpenIaasVMPropertiesPatch(live *client.OpenIaaSVirtualMachine, desired openIaasVMDesiredProperties) (*client.UpdateOpenIaasVirtualMachineRequest, bool, bool) {
+	req := &client.UpdateOpenIaasVirtualMachineRequest{}
+	changed := false
+	needsReboot := false
+
+	if desired.Name != "" && desired.Name != live.Name {
+		req.Name = desired.Name
+		changed = true
+	}
+	if desired.CPU != 0 && desired.CPU != live.CPU {
+		req.CPU = desired.CPU
+		changed = true
+		needsReboot = true
+	}
+	if desired.NumCoresPerSocket != 0 && desired.NumCoresPerSocket != live.NumCoresPerSocket {
+		req.NumCoresPerSocket = desired.NumCoresPerSocket
+		changed = true
+		needsReboot = true
+	}
+	if desired.Memory != 0 && desired.Memory != live.Memory {
+		req.Memory = desired.Memory
+		changed = true
+		needsReboot = true
+	}
+	if desired.BootFirmware != "" && desired.BootFirmware != live.BootFirmware {
+		req.BootFirmware = desired.BootFirmware
+		changed = true
+	}
+	if desired.HighAvailability != "" && desired.HighAvailability != live.HighAvailability {
+		req.HighAvailability = desired.HighAvailability
+		changed = true
+	}
+	if desired.SecureBoot != nil && *desired.SecureBoot != live.SecureBoot {
+		req.SecureBoot = desired.SecureBoot
+		changed = true
+	}
+	if desired.AutoPowerOn != nil && *desired.AutoPowerOn != live.AutoPowerOn {
+		req.AutoPowerOn = desired.AutoPowerOn
+		changed = true
+	}
+
+	return req, changed, needsReboot
 }
 
 // adapterNeedsUpdate compares the desired os_network_adapter block against
@@ -1217,12 +1302,13 @@ func osDiskUpdate(ctx context.Context, c *client.Client, disk map[string]interfa
 	return nil
 }
 
-func osNetworkAdapterUpdate(ctx context.Context, c *client.Client, networkAdapter map[string]interface{}, actual *client.OpenIaaSNetworkAdapter, txWant *bool) diag.Diagnostics {
-	// Payload limited to the fields that actually diverge from the live
-	// adapter: re-sending the current networkId/mac is rejected platform-side
-	// as a VPC Static IP self-conflict (#246). tx_checksumming is only sent
-	// when explicitly configured in the block, using the raw config value
-	// (the merged map swallows explicit false on first apply).
+// buildOpenIaasVIFPatch returns the PATCH limited to the fields that
+// actually diverge from the live adapter, or nil when the adapter is
+// already converged: re-sending the current networkId/mac is rejected
+// platform-side as a VPC Static IP self-conflict (#246). tx_checksumming
+// is only sent when explicitly configured in the block, using the raw
+// config value (the merged map swallows explicit false on first apply).
+func buildOpenIaasVIFPatch(networkAdapter map[string]interface{}, actual *client.OpenIaaSNetworkAdapter, txWant *bool) *client.UpdateOpenIaasNetworkAdapterRequest {
 	req := &client.UpdateOpenIaasNetworkAdapterRequest{}
 	if networkID, _ := networkAdapter["network_id"].(string); networkID != "" && networkID != actual.Network.ID {
 		req.NetworkID = networkID
@@ -1234,6 +1320,14 @@ func osNetworkAdapterUpdate(ctx context.Context, c *client.Client, networkAdapte
 		req.TxChecksumming = txWant
 	}
 	if req.NetworkID == "" && req.MAC == "" && req.TxChecksumming == nil {
+		return nil
+	}
+	return req
+}
+
+func osNetworkAdapterUpdate(ctx context.Context, c *client.Client, networkAdapter map[string]interface{}, actual *client.OpenIaaSNetworkAdapter, txWant *bool) diag.Diagnostics {
+	req := buildOpenIaasVIFPatch(networkAdapter, actual, txWant)
+	if req == nil {
 		return nil
 	}
 	activityId, err := c.Compute().OpenIaaS().NetworkAdapter().Update(ctx, networkAdapter["id"].(string), req)

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
@@ -239,3 +239,170 @@ func TestOsNetworkAdapterUpdateSkipsUnconfiguredTx(t *testing.T) {
 		t.Fatalf("osNetworkAdapterUpdate() returned diagnostics for an equal explicit value: %v", diags)
 	}
 }
+
+func TestBuildOpenIaasVMPropertiesPatch(t *testing.T) {
+	live := &client.OpenIaaSVirtualMachine{
+		Name:              "vm-prod",
+		CPU:               4,
+		NumCoresPerSocket: 2,
+		Memory:            8589934592,
+		BootFirmware:      "uefi",
+		HighAvailability:  "disabled",
+		SecureBoot:        true,
+		AutoPowerOn:       true,
+	}
+	converged := openIaasVMDesiredProperties{
+		Name:              "vm-prod",
+		CPU:               4,
+		NumCoresPerSocket: 2,
+		Memory:            8589934592,
+		BootFirmware:      "uefi",
+		HighAvailability:  "disabled",
+		SecureBoot:        nil,
+		AutoPowerOn:       boolPtr(true),
+	}
+
+	t.Run("converged VM after create produces no PATCH", func(t *testing.T) {
+		_, changed, needsReboot := buildOpenIaasVMPropertiesPatch(live, converged)
+		if changed || needsReboot {
+			t.Fatalf("changed=%v needsReboot=%v, want false/false", changed, needsReboot)
+		}
+	})
+
+	t.Run("absent Computed values never overwrite live", func(t *testing.T) {
+		desired := converged
+		desired.BootFirmware = ""
+		desired.NumCoresPerSocket = 0
+		desired.HighAvailability = ""
+		req, changed, _ := buildOpenIaasVMPropertiesPatch(live, desired)
+		if changed {
+			t.Fatalf("changed=true for absent values, req=%+v", req)
+		}
+	})
+
+	t.Run("unconfigured secure_boot is never pushed even when diverging", func(t *testing.T) {
+		desired := converged
+		desired.SecureBoot = nil
+		liveDiverged := *live
+		liveDiverged.SecureBoot = false
+		req, changed, _ := buildOpenIaasVMPropertiesPatch(&liveDiverged, desired)
+		if changed || req.SecureBoot != nil {
+			t.Fatalf("unconfigured secure_boot produced a PATCH: %+v", req)
+		}
+	})
+
+	t.Run("explicit secure_boot=false diverging from live is pushed", func(t *testing.T) {
+		desired := converged
+		desired.SecureBoot = boolPtr(false)
+		req, changed, needsReboot := buildOpenIaasVMPropertiesPatch(live, desired)
+		if !changed || req.SecureBoot == nil || *req.SecureBoot != false {
+			t.Fatalf("explicit secure_boot=false not pushed: %+v", req)
+		}
+		if needsReboot {
+			t.Fatal("secure_boot change must not require a reboot")
+		}
+	})
+
+	t.Run("explicit secure_boot equal to live is a no-op", func(t *testing.T) {
+		desired := converged
+		desired.SecureBoot = boolPtr(true)
+		_, changed, _ := buildOpenIaasVMPropertiesPatch(live, desired)
+		if changed {
+			t.Fatal("equal explicit secure_boot must not produce a PATCH")
+		}
+	})
+
+	t.Run("cpu memory cores divergences require a reboot", func(t *testing.T) {
+		desired := converged
+		desired.CPU = 8
+		desired.Memory = 17179869184
+		req, changed, needsReboot := buildOpenIaasVMPropertiesPatch(live, desired)
+		if !changed || !needsReboot {
+			t.Fatalf("changed=%v needsReboot=%v, want true/true", changed, needsReboot)
+		}
+		if req.CPU != 8 || req.Memory != 17179869184 {
+			t.Fatalf("unexpected payload: %+v", req)
+		}
+		if req.Name != "" || req.BootFirmware != "" || req.SecureBoot != nil || req.AutoPowerOn != nil {
+			t.Fatalf("payload carries non-diverging fields: %+v", req)
+		}
+	})
+
+	t.Run("name change alone does not require a reboot", func(t *testing.T) {
+		desired := converged
+		desired.Name = "vm-renamed"
+		req, changed, needsReboot := buildOpenIaasVMPropertiesPatch(live, desired)
+		if !changed || needsReboot {
+			t.Fatalf("changed=%v needsReboot=%v, want true/false", changed, needsReboot)
+		}
+		if req.Name != "vm-renamed" || req.CPU != 0 {
+			t.Fatalf("unexpected payload: %+v", req)
+		}
+	})
+
+	t.Run("auto_power_on false diverging from live true is pushed", func(t *testing.T) {
+		desired := converged
+		desired.AutoPowerOn = boolPtr(false)
+		req, changed, _ := buildOpenIaasVMPropertiesPatch(live, desired)
+		if !changed || req.AutoPowerOn == nil || *req.AutoPowerOn != false {
+			t.Fatalf("diverging auto_power_on not pushed: %+v", req)
+		}
+	})
+}
+
+func TestBuildOpenIaasVIFPatch(t *testing.T) {
+	actual := &client.OpenIaaSNetworkAdapter{
+		MacAddress:     "aa:bb:cc:dd:ee:ff",
+		TxChecksumming: true,
+		Network:        client.BaseObject{ID: "net-1"},
+	}
+
+	t.Run("converged adapter returns nil", func(t *testing.T) {
+		adapter := map[string]interface{}{
+			"network_id":  "net-1",
+			"mac_address": "AA:BB:CC:DD:EE:FF",
+		}
+		if req := buildOpenIaasVIFPatch(adapter, actual, nil); req != nil {
+			t.Fatalf("converged adapter produced a PATCH: %+v", req)
+		}
+	})
+
+	t.Run("mac comparison is case-insensitive", func(t *testing.T) {
+		adapter := map[string]interface{}{"mac_address": "Aa:Bb:Cc:Dd:Ee:Ff"}
+		if req := buildOpenIaasVIFPatch(adapter, actual, nil); req != nil {
+			t.Fatalf("cosmetic mac case drift produced a PATCH: %+v", req)
+		}
+	})
+
+	t.Run("only diverging fields are carried", func(t *testing.T) {
+		adapter := map[string]interface{}{
+			"network_id":  "net-2",
+			"mac_address": "AA:BB:CC:DD:EE:FF",
+		}
+		req := buildOpenIaasVIFPatch(adapter, actual, nil)
+		if req == nil || req.NetworkID != "net-2" || req.MAC != "" || req.TxChecksumming != nil {
+			t.Fatalf("unexpected payload: %+v", req)
+		}
+	})
+
+	t.Run("explicit tx false diverging is carried alone", func(t *testing.T) {
+		adapter := map[string]interface{}{
+			"network_id":  "net-1",
+			"mac_address": "aa:bb:cc:dd:ee:ff",
+		}
+		req := buildOpenIaasVIFPatch(adapter, actual, boolPtr(false))
+		if req == nil || req.TxChecksumming == nil || *req.TxChecksumming != false {
+			t.Fatalf("explicit tx=false not carried: %+v", req)
+		}
+		if req.NetworkID != "" || req.MAC != "" {
+			t.Fatalf("payload carries converged fields: %+v", req)
+		}
+	})
+
+	t.Run("unconfigured tx diverging is not carried", func(t *testing.T) {
+		adapter := map[string]interface{}{"tx_checksumming": false}
+		if req := buildOpenIaasVIFPatch(adapter, actual, nil); req != nil {
+			t.Fatalf("unconfigured tx produced a PATCH: %+v", req)
+		}
+	})
+}


### PR DESCRIPTION
Refs #267

State-safety P0 batch (Lot A) of the non-complacent test plan (#264).

## Changes

1. **`buildOpenIaasVMPropertiesPatch(live, desired)` → `(req, changed, needsReboot)`** — pure and unit-testable. Each property is included in the PATCH only when it actually diverges from the live API state; the unconditional full-properties PATCH (same class as the #246 VIF incident) is gone. The reboot requirement now derives from the real cpu/memory/cores divergence instead of `HasChange`.
2. **`secure_boot` raw-config gating** — Optional+Computed: the merged plan value is not write intent; only an explicit configuration can produce a write (pattern: `tx_checksumming`). `SecureBoot`/`AutoPowerOn` become `*bool,omitempty` in `UpdateOpenIaasVirtualMachineRequest` (absent = omitted from the payload, explicit `false` expressible).
3. **`buildOpenIaasVIFPatch(desired, actual, txWant)`** — extracts the VIF payload construction (nil when converged) from `osNetworkAdapterUpdate`; payloads are now inspected directly by tests.
4. **Registry test `TestOptionalComputedBooleansHavePatchGuards`** — walks every resource schema and fails when an Optional+Computed boolean is not in the documented guard registry (5 gated, 5 documented UNGATED-LEGACY pending the VMware parity batch, Lot D).

## Behavior notes

- A converged VM after a marketplace deploy now produces **zero** properties PATCH during the create→update chaining.
- `auto_power_on` (plain Optional) keeps its Terraform contract (absent = false) but is only sent when diverging from live — previous behavior always serialized it.
- No schema change, no state encoding change.

## Validation

- 17 new test cases (`TestBuildOpenIaasVMPropertiesPatch`, `TestBuildOpenIaasVIFPatch`, registry) + existing suites green; `go build`/`go vet` OK.
- Adversarial review (`codex review`, default gpt-5.5 high config) on the uncommitted diff before commit: no actionable bug (the `internal/*/tests` build failure is pre-existing and outside this diff).
- The new CI `unit` job runs all of this on the PR.