### PR TITLE
Datasources: schema-vs-flatten walker and the five runtime-broken datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES :
   * Fixed a bug causing the cloud-init config drive (`XO CloudConfigDrive`) to be captured as a managed `os_disk` at creation on resource `cloudtemple_compute_iaas_opensource_virtual_machine`, producing a permanent removal drift.
   * Fixed a bug causing resource `cloudtemple_compute_iaas_opensource_virtual_machine` to send an unconditional full-properties update on every apply. Properties are now only patched when they actually diverge from the live API state, and `secure_boot` is only sent when explicitly configured.
   * Fixed a bug causing an in-progress operation to be reported as failed when a transient error (429, 5xx or a transport failure) occurred while polling its activity status. Transient read failures are now retried with a bounded consecutive budget.
+  * Fixed datasources `cloudtemple_compute_iaas_opensource_pools`, `cloudtemple_compute_iaas_opensource_virtual_machine`, `cloudtemple_compute_iaas_opensource_virtual_machines`, `cloudtemple_compute_iaas_opensource_virtual_disk` and `cloudtemple_compute_iaas_opensource_virtual_disks` failing at read time with an `Invalid address to set` error: the schemas now declare every attribute emitted by the flatten helpers.
 
 IMPROVEMENTS :
 

--- a/docs/data-sources/compute_iaas_opensource_pools.md
+++ b/docs/data-sources/compute_iaas_opensource_pools.md
@@ -59,7 +59,10 @@ Read-Only:
 - `hosts` (List of String)
 - `id` (String)
 - `internal_id` (String)
+- `label` (String)
 - `machine_manager_id` (String)
+- `master` (String)
+- `memory` (List of Object) (see [below for nested schema](#nestedobjatt--pools--memory))
 - `name` (String)
 - `type` (List of Object) (see [below for nested schema](#nestedobjatt--pools--type))
 
@@ -70,6 +73,15 @@ Read-Only:
 
 - `cores` (Number)
 - `sockets` (Number)
+
+
+<a id="nestedobjatt--pools--memory"></a>
+### Nested Schema for `pools.memory`
+
+Read-Only:
+
+- `size` (Number)
+- `usage` (Number)
 
 
 <a id="nestedobjatt--pools--type"></a>

--- a/docs/data-sources/compute_iaas_opensource_virtual_disk.md
+++ b/docs/data-sources/compute_iaas_opensource_virtual_disk.md
@@ -81,6 +81,7 @@ Read-Only:
 
 Read-Only:
 
+- `connected` (Boolean)
 - `id` (String)
 - `name` (String)
 - `read_only` (Boolean)

--- a/docs/data-sources/compute_iaas_opensource_virtual_disks.md
+++ b/docs/data-sources/compute_iaas_opensource_virtual_disks.md
@@ -101,6 +101,7 @@ Read-Only:
 
 Read-Only:
 
+- `connected` (Boolean)
 - `id` (String)
 - `name` (String)
 - `read_only` (Boolean)

--- a/docs/data-sources/compute_iaas_opensource_virtual_machine.md
+++ b/docs/data-sources/compute_iaas_opensource_virtual_machine.md
@@ -64,11 +64,13 @@ output "virtual_machine-2" {
 - `high_availability` (String) High Availability configuration for the virtual machine (Default: disabled). Possible values are: 'disabled', 'restart' and 'best-effort'. For more informations, refer to the documentation : https://docs.cloud-temple.com/iaas_opensource/concepts#haute-disponibilit%C3%A9
 - `host_id` (String) The ID of the host the virtual machine is running on.
 - `internal_id` (String) The internal identifier of the virtual machine in the Open IaaS system.
+- `management_agent` (List of Object) Information about the management agent of the virtual machine. (see [below for nested schema](#nestedatt--management_agent))
 - `memory` (Number) The amount of memory allocated to the virtual machine in Bytes.
 - `num_cores_per_socket` (Number) The number of cores per CPU socket in the virtual machine.
 - `operating_system_name` (String) The name of the operating system installed on the virtual machine.
 - `pool_id` (String) The ID of the resource pool the virtual machine belongs to.
 - `power_state` (String) The current power state of the virtual machine (e.g., Running, Halted, Paused, etc...).
+- `pv_drivers` (List of Object) Information about the paravirtualization drivers of the virtual machine. (see [below for nested schema](#nestedatt--pv_drivers))
 - `secure_boot` (Boolean) Whether secure boot is enabled for the virtual machine.
 - `tools` (List of Object) Information about the virtualization tools installed in the virtual machine. (see [below for nested schema](#nestedatt--tools))
 
@@ -88,6 +90,24 @@ Read-Only:
 
 - `attached` (Boolean)
 - `name` (String)
+
+
+<a id="nestedatt--management_agent"></a>
+### Nested Schema for `management_agent`
+
+Read-Only:
+
+- `detected` (Boolean)
+
+
+<a id="nestedatt--pv_drivers"></a>
+### Nested Schema for `pv_drivers`
+
+Read-Only:
+
+- `are_up_to_date` (Boolean)
+- `detected` (Boolean)
+- `version` (String)
 
 
 <a id="nestedatt--tools"></a>

--- a/docs/data-sources/compute_iaas_opensource_virtual_machines.md
+++ b/docs/data-sources/compute_iaas_opensource_virtual_machines.md
@@ -67,16 +67,19 @@ Read-Only:
 - `boot_order` (List of String)
 - `cpu` (Number)
 - `dvd_drive` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--dvd_drive))
+- `high_availability` (String)
 - `host_id` (String)
 - `id` (String)
 - `internal_id` (String)
 - `machine_manager_id` (String)
+- `management_agent` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--management_agent))
 - `memory` (Number)
 - `name` (String)
 - `num_cores_per_socket` (Number)
 - `operating_system_name` (String)
 - `pool_id` (String)
 - `power_state` (String)
+- `pv_drivers` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--pv_drivers))
 - `secure_boot` (Boolean)
 - `tools` (List of Object) (see [below for nested schema](#nestedobjatt--virtual_machines--tools))
 
@@ -96,6 +99,24 @@ Read-Only:
 
 - `attached` (Boolean)
 - `name` (String)
+
+
+<a id="nestedobjatt--virtual_machines--management_agent"></a>
+### Nested Schema for `virtual_machines.management_agent`
+
+Read-Only:
+
+- `detected` (Boolean)
+
+
+<a id="nestedobjatt--virtual_machines--pv_drivers"></a>
+### Nested Schema for `virtual_machines.pv_drivers`
+
+Read-Only:
+
+- `are_up_to_date` (Boolean)
+- `detected` (Boolean)
+- `version` (String)
 
 
 <a id="nestedobjatt--virtual_machines--tools"></a>

--- a/internal/provider/data_source_compute_iaas_opensource_pools.go
+++ b/internal/provider/data_source_compute_iaas_opensource_pools.go
@@ -49,6 +49,35 @@ func dataSourceOpenIaasPools() *schema.Resource {
 							Computed:    true,
 							Description: "The internal identifier of the pool in the Open IaaS system.",
 						},
+						"label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The label of the pool.",
+						},
+						"master": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the pool master host.",
+						},
+						"memory": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Memory information for the pool.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"usage": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The memory usage of the pool in bytes.",
+									},
+									"size": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The memory size of the pool in bytes.",
+									},
+								},
+							},
+						},
 						"machine_manager_id": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/internal/provider/data_source_compute_iaas_opensource_virtual_disk.go
+++ b/internal/provider/data_source_compute_iaas_opensource_virtual_disk.go
@@ -109,6 +109,11 @@ func dataSourceOpenIaasVirtualDisk() *schema.Resource {
 							Computed:    true,
 							Description: "Whether the disk is attached in read-only mode to this virtual machine.",
 						},
+						"connected": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the disk is connected to this virtual machine.",
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_compute_iaas_opensource_virtual_disks.go
+++ b/internal/provider/data_source_compute_iaas_opensource_virtual_disks.go
@@ -113,6 +113,11 @@ func dataSourceOpenIaasVirtualDisks() *schema.Resource {
 										Computed:    true,
 										Description: "Whether the disk is attached in read-only mode to this virtual machine.",
 									},
+									"connected": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Whether the disk is connected to this virtual machine.",
+									},
 								},
 							},
 						},

--- a/internal/provider/data_source_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/data_source_compute_iaas_opensource_virtual_machine.go
@@ -112,6 +112,44 @@ func dataSourceOpenIaasVirtualMachine() *schema.Resource {
 					},
 				},
 			},
+			"pv_drivers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Information about the paravirtualization drivers of the virtual machine.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"detected": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the PV drivers are detected in the virtual machine.",
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version of the PV drivers.",
+						},
+						"are_up_to_date": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the PV drivers are up to date.",
+						},
+					},
+				},
+			},
+			"management_agent": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Information about the management agent of the virtual machine.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"detected": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the management agent is detected in the virtual machine.",
+						},
+					},
+				},
+			},
 			"boot_order": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/internal/provider/data_source_compute_iaas_opensource_virtual_machines.go
+++ b/internal/provider/data_source_compute_iaas_opensource_virtual_machines.go
@@ -74,6 +74,11 @@ func dataSourceOpenIaasVirtualMachines() *schema.Resource {
 							Computed:    true,
 							Description: "Whether the virtual machine is configured to automatically power on when the host starts.",
 						},
+						"high_availability": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The high availability configuration of the virtual machine.",
+						},
 						"dvd_drive": {
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -108,6 +113,44 @@ func dataSourceOpenIaasVirtualMachines() *schema.Resource {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The version of the virtualization tools installed in the virtual machine.",
+									},
+								},
+							},
+						},
+						"pv_drivers": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Information about the paravirtualization drivers of the virtual machine.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"detected": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Whether the PV drivers are detected in the virtual machine.",
+									},
+									"version": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The version of the PV drivers.",
+									},
+									"are_up_to_date": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Whether the PV drivers are up to date.",
+									},
+								},
+							},
+						},
+						"management_agent": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Information about the management agent of the virtual machine.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"detected": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Whether the management agent is detected in the virtual machine.",
 									},
 								},
 							},

--- a/internal/provider/datasource_flatten_schema_test.go
+++ b/internal/provider/datasource_flatten_schema_test.go
@@ -1,0 +1,352 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// datasourceFlattenCheck registers a datasource whose flatten output must
+// fit its declared schema. When a flatten helper emits a key the schema
+// does not declare (or with an incompatible shape), d.Set fails at runtime
+// with "Invalid address to set" and the datasource becomes unusable — the
+// #243 class. Adding an entry here is a one-liner: coverage must grow with
+// every new datasource.
+type datasourceFlattenCheck struct {
+	name       string
+	datasource *schema.Resource
+	// rootKey is the computed list attribute for list datasources; empty
+	// for single-object datasources whose Read sets the flatten map per key.
+	rootKey   string
+	flattened map[string]interface{}
+}
+
+// assertFlattenFitsSchema validates the flatten output against the schema
+// through the real schema writer, reporting the exact offending address.
+func assertFlattenFitsSchema(t *testing.T, check datasourceFlattenCheck) {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, check.datasource.Schema, map[string]interface{}{})
+
+	if check.rootKey != "" {
+		if _, declared := check.datasource.Schema[check.rootKey]; !declared {
+			t.Errorf("%s: root key %q is not declared in the schema", check.name, check.rootKey)
+			return
+		}
+		if err := d.Set(check.rootKey, []interface{}{check.flattened}); err != nil {
+			t.Errorf("%s: the flatten output does not fit the %q schema: %s", check.name, check.rootKey, err)
+		}
+		return
+	}
+
+	for key, value := range check.flattened {
+		if _, declared := check.datasource.Schema[key]; !declared {
+			t.Errorf("%s: the flatten helper emits %q which the schema does not declare", check.name, key)
+			continue
+		}
+		if err := d.Set(key, value); err != nil {
+			t.Errorf("%s: the flatten output does not fit the schema at %q: %s", check.name, key, err)
+		}
+	}
+}
+
+// Fully-populated client fixtures: every field carries a non-zero value so
+// that type and shape mismatches cannot hide behind zero values.
+
+func fixtureOpenIaasPool() *client.OpenIaasPool {
+	pool := &client.OpenIaasPool{
+		ID:                      "pool-1",
+		MachineManager:          client.BaseObject{ID: "mm-1", Name: "xoa"},
+		InternalID:              "internal-1",
+		Name:                    "pool-name",
+		Label:                   "pool-label",
+		HighAvailabilityEnabled: true,
+		Master:                  "host-master",
+		Hosts:                   []string{"host-1", "host-2"},
+	}
+	pool.Memory.Usage = 10
+	pool.Memory.Size = 100
+	pool.Cpu.Cores = 8
+	pool.Cpu.Sockets = 2
+	pool.Type.Key = "xcp-ng"
+	pool.Type.Description = "XCP-ng pool"
+	return pool
+}
+
+func fixtureOpenIaasHost() *client.OpenIaaSHost {
+	host := &client.OpenIaaSHost{
+		ID:              "host-1",
+		MachineManager:  client.BaseObject{ID: "mm-1", Name: "xoa"},
+		InternalId:      "internal-1",
+		Name:            "host-name",
+		Master:          true,
+		Uptime:          3600,
+		PowerState:      "Running",
+		RebootRequired:  true,
+		VirtualMachines: []string{"vm-1"},
+	}
+	host.Pool.ID = "pool-1"
+	host.Pool.Name = "pool-name"
+	host.Pool.Type.Key = "xcp-ng"
+	host.Pool.Type.Description = "XCP-ng pool"
+	host.UpdateData.MaintenanceMode = true
+	host.UpdateData.Status = "ok"
+	host.Metrics.XOA.Version = "5.0"
+	host.Metrics.XOA.FullName = "XOA 5.0"
+	host.Metrics.XOA.Build = "build-1"
+	host.Metrics.Memory.Usage = 10
+	host.Metrics.Memory.Size = 100
+	host.Metrics.Cpu.Sockets = 2
+	host.Metrics.Cpu.Cores = 8
+	host.Metrics.Cpu.Model = "EPYC"
+	host.Metrics.Cpu.ModelName = "AMD EPYC"
+	return host
+}
+
+func fixtureOpenIaasNetwork() *client.OpenIaaSNetwork {
+	return &client.OpenIaaSNetwork{
+		ID:                         "net-1",
+		MachineManager:             client.BaseObject{ID: "mm-1", Name: "xoa"},
+		InternalID:                 "internal-1",
+		Name:                       "net-name",
+		Pool:                       client.BaseObject{ID: "pool-1", Name: "pool-name"},
+		MaximumTransmissionUnit:    1500,
+		NetworkAdapters:            []string{"vif-1"},
+		NetworkBlockDevice:         true,
+		InsecureNetworkBlockDevice: true,
+	}
+}
+
+func fixtureOpenIaasNetworkAdapter() *client.OpenIaaSNetworkAdapter {
+	return &client.OpenIaaSNetworkAdapter{
+		ID:               "vif-1",
+		Name:             "vif-name",
+		InternalID:       "internal-1",
+		VirtualMachineID: "vm-1",
+		MacAddress:       "aa:bb:cc:dd:ee:ff",
+		MTU:              1500,
+		Attached:         true,
+		TxChecksumming:   true,
+		Network:          client.BaseObject{ID: "net-1", Name: "net-name"},
+		MachineManager:   client.BaseObject{ID: "mm-1", Name: "xoa"},
+	}
+}
+
+func fixtureOpenIaasSnapshot() *client.OpenIaaSSnapshot {
+	return &client.OpenIaaSSnapshot{
+		ID:               "snap-1",
+		Description:      "snapshot description",
+		VirtualMachineID: "vm-1",
+		Name:             "snap-name",
+		CreateTime:       1700000000,
+	}
+}
+
+func fixtureOpenIaasReplicationPolicy() *client.OpenIaaSReplicationPolicy {
+	policy := &client.OpenIaaSReplicationPolicy{
+		ID:   "rp-1",
+		Name: "rp-name",
+	}
+	policy.StorageRepository.ID = "sr-1"
+	policy.StorageRepository.Name = "sr-name"
+	policy.Pool.ID = "pool-1"
+	policy.Pool.Name = "pool-name"
+	policy.Pool.Label = "pool-label"
+	policy.MachineManager.ID = "mm-1"
+	policy.MachineManager.Name = "xoa"
+	policy.LastRun.Start = 1700000000
+	policy.LastRun.End = 1700000100
+	policy.LastRun.Status = "success"
+	policy.Interval.Hours = 1
+	policy.Interval.Minutes = 30
+	return policy
+}
+
+func fixtureOpenIaasStorageRepository() *client.OpenIaaSStorageRepository {
+	return &client.OpenIaaSStorageRepository{
+		ID:              "sr-1",
+		InternalId:      "internal-1",
+		Name:            "sr-name",
+		Description:     "sr description",
+		MaintenanceMode: true,
+		MaxCapacity:     1000,
+		FreeCapacity:    500,
+		StorageType:     "lvm",
+		VirtualDisks:    []string{"disk-1"},
+		Shared:          true,
+		Accessible:      1,
+		Host:            client.BaseObject{ID: "host-1", Name: "host-name"},
+		Pool:            client.BaseObject{ID: "pool-1", Name: "pool-name"},
+		MachineManager:  client.BaseObject{ID: "mm-1", Name: "xoa"},
+	}
+}
+
+func fixtureOpenIaasTemplate() *client.OpenIaasTemplate {
+	return &client.OpenIaasTemplate{
+		ID:                "tpl-1",
+		MachineManager:    client.BaseObject{ID: "mm-1", Name: "xoa"},
+		InternalID:        "internal-1",
+		Name:              "tpl-name",
+		CPU:               4,
+		NumCoresPerSocket: 2,
+		Memory:            8589934592,
+		PowerState:        "Halted",
+		Snapshots:         []string{"snap-1"},
+		SLAPolicies:       []string{"sla-1"},
+		Disks: []client.TemplateDisk{{
+			ID:                "disk-1",
+			Name:              "disk-name",
+			Description:       "disk description",
+			Size:              1024,
+			StorageRepository: client.BaseObject{ID: "sr-1", Name: "sr-name"},
+		}},
+		NetworkAdapters: []client.TemplateNetworkAdapter{{
+			Name:       "vif-name",
+			MacAddress: "aa:bb:cc:dd:ee:ff",
+			MTU:        1500,
+			Attached:   true,
+			Network:    client.BaseObject{ID: "net-1", Name: "net-name"},
+		}},
+	}
+}
+
+func fixtureOpenIaasVirtualDisk() *client.OpenIaaSVirtualDisk {
+	disk := &client.OpenIaaSVirtualDisk{
+		ID:          "disk-1",
+		InternalID:  "internal-1",
+		Name:        "disk-name",
+		Description: "disk description",
+		Size:        1024,
+		Usage:       512,
+		IsSnapshot:  true,
+		StorageRepository: client.BaseObject{
+			ID:   "sr-1",
+			Name: "sr-name",
+		},
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{{
+			ID:        "vm-1",
+			Name:      "vm-name",
+			ReadOnly:  true,
+			Connected: true,
+		}},
+	}
+	disk.Templates = append(disk.Templates, struct {
+		ID       string
+		Name     string
+		ReadOnly bool
+	}{ID: "tpl-1", Name: "tpl-name", ReadOnly: true})
+	return disk
+}
+
+func fixtureOpenIaasVirtualMachine() *client.OpenIaaSVirtualMachine {
+	vm := &client.OpenIaaSVirtualMachine{
+		ID:                  "vm-1",
+		Name:                "vm-name",
+		InternalID:          "internal-1",
+		PowerState:          "Running",
+		SecureBoot:          true,
+		HighAvailability:    "restart",
+		BootFirmware:        "uefi",
+		AutoPowerOn:         true,
+		BootOrder:           []string{"Hard-Drive"},
+		OperatingSystemName: "Ubuntu",
+		CPU:                 4,
+		NumCoresPerSocket:   2,
+		Memory:              8589934592,
+		MachineManager:      client.BaseObject{ID: "mm-1", Name: "xoa"},
+		Host:                client.BaseObject{ID: "host-1", Name: "host-name"},
+		Pool:                client.BaseObject{ID: "pool-1", Name: "pool-name"},
+	}
+	vm.DvdDrive.Name = "dvd-1"
+	vm.DvdDrive.Attached = true
+	vm.Tools.Detected = true
+	vm.Tools.Version = "1.0"
+	vm.PVDrivers.Detected = true
+	vm.PVDrivers.Version = "1.0"
+	vm.PVDrivers.AreUpToDate = true
+	vm.ManagementAgent.Detected = true
+	vm.Addresses.IPv6 = "fe80::1"
+	vm.Addresses.IPv4 = "10.0.0.1"
+	return vm
+}
+
+func fixtureOpenIaasMachineManager() *client.OpenIaaSMachineManager {
+	return &client.OpenIaaSMachineManager{
+		ID:        "mm-1",
+		Name:      "xoa",
+		OSVersion: "8.3",
+		OSName:    "XCP-ng",
+	}
+}
+
+func fixtureBackupOpenIaasBackup() *client.Backup {
+	return &client.Backup{
+		ID:                      "backup-1",
+		InternalID:              "internal-1",
+		Mode:                    "delta",
+		IsVirtualMachineDeleted: true,
+		Size:                    2048,
+		Timestamp:               1700000000,
+		VirtualMachine:          client.BaseObject{ID: "vm-1", Name: "vm-name"},
+		Policy:                  client.BaseObject{ID: "policy-1", Name: "policy-name"},
+	}
+}
+
+func fixtureBackupOpenIaasPolicy() *client.BackupOpenIaasPolicy {
+	policy := &client.BackupOpenIaasPolicy{
+		ID:              "policy-1",
+		Name:            "policy-name",
+		InternalID:      "internal-1",
+		Running:         true,
+		Mode:            "delta",
+		MachineManager:  client.BaseObject{ID: "mm-1", Name: "xoa"},
+		VirtualMachines: []string{"vm-1"},
+	}
+	policy.Schedulers = append(policy.Schedulers, struct {
+		TemporarilyDisabled bool
+		Retention           int
+		Cron                string
+		Timezone            string
+	}{TemporarilyDisabled: true, Retention: 7, Cron: "0 2 * * *", Timezone: "Europe/Paris"})
+	return policy
+}
+
+func TestDatasourceFlattenOutputsFitTheirSchemas(t *testing.T) {
+	checks := []datasourceFlattenCheck{
+		// OpenIaaS singles (Read sets the flatten map per key)
+		{"iaas_opensource_pool", dataSourceOpenIaasPool(), "", helpers.FlattenOpenIaaSPool(fixtureOpenIaasPool())},
+		{"iaas_opensource_host", dataSourceOpenIaasHost(), "", helpers.FlattenOpenIaaSHost(fixtureOpenIaasHost())},
+		{"iaas_opensource_network", dataSourceOpenIaasNetwork(), "", helpers.FlattenOpenIaaSNetwork(fixtureOpenIaasNetwork())},
+		{"iaas_opensource_network_adapter", dataSourceOpenIaasNetworkAdapter(), "", helpers.FlattenOpenIaaSNetworkAdapter(fixtureOpenIaasNetworkAdapter())},
+		{"iaas_opensource_snapshot", dataSourceOpenIaasSnapshot(), "", helpers.FlattenOpenIaaSSnapshot(fixtureOpenIaasSnapshot())},
+		{"iaas_opensource_replication_policy", dataSourceOpenIaasReplicationPolicy(), "", helpers.FlattenOpenIaaSReplicationPolicy(fixtureOpenIaasReplicationPolicy())},
+		{"iaas_opensource_storage_repository", dataSourceOpenIaasStorageRepository(), "", helpers.FlattenOpenIaaSStorageRepository(fixtureOpenIaasStorageRepository())},
+		{"iaas_opensource_template", dataSourceOpenIaasTemplate(), "", helpers.FlattenOpenIaaSTemplate(fixtureOpenIaasTemplate())},
+		{"iaas_opensource_virtual_disk", dataSourceOpenIaasVirtualDisk(), "", helpers.FlattenOpenIaaSVirtualDisk(fixtureOpenIaasVirtualDisk(), "")},
+		{"iaas_opensource_virtual_machine", dataSourceOpenIaasVirtualMachine(), "", helpers.FlattenOpenIaaSVirtualMachine(fixtureOpenIaasVirtualMachine())},
+		{"iaas_opensource_availability_zone", dataSourceOpenIaasMachineManager(), "", helpers.FlattenOpenIaaSMachineManager(fixtureOpenIaasMachineManager())},
+		{"backup_iaas_opensource_backup", dataSourceOpenIaasBackup(), "", helpers.FlattenBackupOpenIaasBackup(fixtureBackupOpenIaasBackup())},
+		{"backup_iaas_opensource_policy", dataSourceOpenIaasBackupPolicy(), "", helpers.FlattenBackupOpenIaasPolicy(fixtureBackupOpenIaasPolicy())},
+
+		// OpenIaaS lists (Read sets one computed root list)
+		{"iaas_opensource_pools", dataSourceOpenIaasPools(), "pools", helpers.FlattenOpenIaaSPool(fixtureOpenIaasPool())},
+		{"iaas_opensource_hosts", dataSourceOpenIaasHosts(), "hosts", helpers.FlattenOpenIaaSHost(fixtureOpenIaasHost())},
+		{"iaas_opensource_networks", dataSourceOpenIaasNetworks(), "networks", helpers.FlattenOpenIaaSNetwork(fixtureOpenIaasNetwork())},
+		{"iaas_opensource_network_adapters", dataSourceOpenIaasNetworkAdapters(), "network_adapters", helpers.FlattenOpenIaaSNetworkAdapter(fixtureOpenIaasNetworkAdapter())},
+		{"iaas_opensource_snapshots", dataSourceOpenIaasSnapshots(), "snapshots", helpers.FlattenOpenIaaSSnapshot(fixtureOpenIaasSnapshot())},
+		{"iaas_opensource_replication_policies", dataSourceOpenIaasReplicationPolicies(), "policies", helpers.FlattenOpenIaaSReplicationPolicy(fixtureOpenIaasReplicationPolicy())},
+		{"iaas_opensource_storage_repositories", dataSourceOpenIaasStorageRepositories(), "storage_repositories", helpers.FlattenOpenIaaSStorageRepository(fixtureOpenIaasStorageRepository())},
+		{"iaas_opensource_templates", dataSourceOpenIaasTemplates(), "templates", helpers.FlattenOpenIaaSTemplate(fixtureOpenIaasTemplate())},
+		{"iaas_opensource_virtual_disks", dataSourceOpenIaasVirtualDisks(), "virtual_disks", helpers.FlattenOpenIaaSVirtualDisk(fixtureOpenIaasVirtualDisk(), "")},
+		{"iaas_opensource_virtual_machines", dataSourceOpenIaasVirtualMachines(), "virtual_machines", helpers.FlattenOpenIaaSVirtualMachine(fixtureOpenIaasVirtualMachine())},
+		{"backup_iaas_opensource_backups", dataSourceOpenIaasBackups(), "backups", helpers.FlattenBackupOpenIaasBackup(fixtureBackupOpenIaasBackup())},
+		{"backup_iaas_opensource_policies", dataSourceOpenIaasBackupPolicies(), "policies", helpers.FlattenBackupOpenIaasPolicy(fixtureBackupOpenIaasPolicy())},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			assertFlattenFitsSchema(t, check)
+		})
+	}
+}

--- a/internal/provider/helpers/helper_update_map_items_test.go
+++ b/internal/provider/helpers/helper_update_map_items_test.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestUpdateMapItemsDoesNotRetainExplicitZeroValues PINS the known
+// limitation of the GetOk-based merge (#246 class): GetOk cannot
+// distinguish an explicit zero value (false, "", 0) from an absent
+// attribute, so an explicit user false is NOT overlaid onto the API-seeded
+// map and the live value silently wins.
+//
+// This is why any boolean whose explicit false must reach an API request
+// is gated on raw-config evidence (d.GetRawConfig()) instead of trusting
+// the merged map — see osAdapterTxConfigured and the
+// TestOptionalComputedBooleansHavePatchGuards registry in the provider
+// package. If this test ever fails because UpdateMapItems starts retaining
+// explicit zero values, revisit every raw-config gating site before
+// relying on the new behavior.
+func TestUpdateMapItemsDoesNotRetainExplicitZeroValues(t *testing.T) {
+	s := map[string]*schema.Schema{
+		"os_network_adapter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {Type: schema.TypeBool, Optional: true},
+					"name":    {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"os_network_adapter": []interface{}{
+			map[string]interface{}{
+				"enabled": false,       // explicit user false
+				"name":    "user-name", // explicit non-zero value
+			},
+		},
+	})
+
+	apiSeeded := map[string]interface{}{
+		"enabled": true, // live API value
+		"name":    "api-name",
+	}
+	merged, ok := UpdateMapItems(d, apiSeeded, "os_network_adapter", 0).(map[string]interface{})
+	if !ok {
+		t.Fatal("UpdateMapItems did not return a map")
+	}
+
+	// Non-zero explicit values are overlaid onto the API-seeded map.
+	if merged["name"] != "user-name" {
+		t.Errorf("explicit non-zero value lost: name=%v, want user-name", merged["name"])
+	}
+
+	// Explicit zero values are swallowed: the API-seeded value wins. This
+	// assertion documents the CURRENT behavior, it does not endorse it.
+	if merged["enabled"] != true {
+		t.Errorf("the GetOk swallowing behavior changed: enabled=%v (was: API value retained) — revisit the raw-config gating sites before relying on this", merged["enabled"])
+	}
+}


### PR DESCRIPTION
Refs #269, refs #243

Lot C of the non-complacent test plan (#264).

## The walker

`assertFlattenFitsSchema` writes the flatten output of every registered datasource (built from fully-populated client fixtures) through the real schema writer: any undeclared address, type mismatch or shape drift fails the CI `unit` job with the exact offending path — the `Invalid address to set` class that made #243 possible. 26 OpenIaaS datasources are registered; adding one is a one-liner.

## What it caught immediately (5 datasources broken at read time)

| Datasource | Missing in schema |
|---|---|
| `iaas_opensource_pools` | `label`, `master`, `memory` (**= #243**) |
| `iaas_opensource_virtual_disk` / `_disks` | `connected` in the nested `virtual_machines` block |
| `iaas_opensource_virtual_machine` / `_machines` | `pv_drivers`, `management_agent` (+ `high_availability` on the list) |

All fixed **additively** in the schemas (new computed attributes — no behavior change for existing configurations).

## Also

- Pins the `UpdateMapItems`/`GetOk` limitation (explicit zero values are swallowed by the merge): the test documents WHY booleans reaching API requests are raw-config gated, and alerts if the semantics silently change.

## Validation

- Walker green on the 26 registered datasources after the fixes; full unit suites green; `go build`/`go vet` OK.
- Adversarial review (`codex review`, default high config) before commit: no actionable regression.