### PR TITLE
State-safety: VMware boot_options gating, secrets preserved on refresh, read errors are not deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ BUG FIXES :
   * Fixed a bug causing resource `cloudtemple_compute_iaas_opensource_virtual_machine` to send an unconditional full-properties update on every apply. Properties are now only patched when they actually diverge from the live API state, and `secure_boot` is only sent when explicitly configured.
   * Fixed a bug causing an in-progress operation to be reported as failed when a transient error (429, 5xx or a transport failure) occurred while polling its activity status. Transient read failures are now retried with a bounded consecutive budget.
   * Fixed datasources `cloudtemple_compute_iaas_opensource_pools`, `cloudtemple_compute_iaas_opensource_virtual_machine`, `cloudtemple_compute_iaas_opensource_virtual_machines`, `cloudtemple_compute_iaas_opensource_virtual_disk` and `cloudtemple_compute_iaas_opensource_virtual_disks` failing at read time with an `Invalid address to set` error: the schemas now declare every attribute emitted by the flatten helpers.
+  * Fixed resource `cloudtemple_compute_virtual_machine` re-sending the full `boot_options` block (including values merely inherited from the live state) on every update. The block is now only sent when explicitly configured, and its booleans only when explicitly set.
+  * Fixed resource `cloudtemple_iam_personal_access_token` erasing `secret_id` from the state on refresh (the API only returns the secret at creation).
+  * Fixed resources `cloudtemple_compute_iaas_opensource_replication_policy` and `cloudtemple_compute_iaas_opensource_virtual_disk` being dropped from the Terraform state when a transient API error occurred during refresh, which made the next apply create a duplicate.
 
 IMPROVEMENTS :
 

--- a/internal/client/compute_virtual_machine.go
+++ b/internal/client/compute_virtual_machine.go
@@ -93,12 +93,16 @@ type VirtualMachineBootOptions struct {
 }
 
 type BootOptions struct {
+	// The booleans are pointers so an absent value is omitted from the
+	// payload while an explicit false stays expressible: the matching
+	// schema attributes are Optional+Computed and a merged value is not
+	// write intent (#264 plan, Lot D).
 	BootDelay            int    `json:"bootDelay"`
 	BootRetryDelay       int    `json:"bootRetryDelay"`
-	BootRetryEnabled     bool   `json:"bootRetryEnabled"`
-	EnterBIOSSetup       bool   `json:"enterBIOSSetup"`
+	BootRetryEnabled     *bool  `json:"bootRetryEnabled,omitempty"`
+	EnterBIOSSetup       *bool  `json:"enterBIOSSetup,omitempty"`
 	Firmware             string `json:"firmware"`
-	EFISecureBootEnabled bool   `json:"efiSecureBootEnabled"`
+	EFISecureBootEnabled *bool  `json:"efiSecureBootEnabled,omitempty"`
 }
 
 type PowerRequest struct {

--- a/internal/client/tests/compute_virtual_machine_test.go
+++ b/internal/client/tests/compute_virtual_machine_test.go
@@ -123,8 +123,8 @@ func TestCompute_UpdateAndPower(t *testing.T) {
 		BootOptions: &clientpkg.BootOptions{
 			BootDelay:        0,
 			BootRetryDelay:   10000,
-			BootRetryEnabled: false,
-			EnterBIOSSetup:   false,
+			BootRetryEnabled: boolPtr(false),
+			EnterBIOSSetup:   boolPtr(false),
 			Firmware:         "bios",
 		},
 	})
@@ -301,3 +301,5 @@ func TestVirtualMachineClient_Guest(t *testing.T) {
 	_, err = client.Activity().WaitForCompletion(ctx, activityId, nil)
 	require.NoError(t, err)
 }
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/provider/optional_computed_booleans_test.go
+++ b/internal/provider/optional_computed_booleans_test.go
@@ -25,11 +25,11 @@ var optionalComputedBooleanGuards = map[string]string{
 	"cloudtemple_compute_iaas_opensource_virtual_machine.os_network_adapter.attached":        "deprecated attribute, never written from the VM path",
 	"cloudtemple_compute_iaas_opensource_virtual_machine.os_network_adapter.tx_checksumming": "raw-config gated through osAdapterTxConfigured (map[string]*bool)",
 	"cloudtemple_compute_iaas_opensource_network_adapter.tx_checksumming":                    "raw-config gated in openIaasNetworkAdapterUpdate (txConfigured)",
-	"cloudtemple_compute_virtual_machine.boot_options.enter_bios_setup":                      "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
-	"cloudtemple_compute_virtual_machine.boot_options.boot_retry_enabled":                    "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
-	"cloudtemple_compute_virtual_machine.boot_options.efi_secure_boot_enabled":               "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
-	"cloudtemple_compute_virtual_machine.os_network_adapter.auto_connect":                    "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
-	"cloudtemple_compute_virtual_machine.os_network_adapter.connected":                       "UNGATED-LEGACY: VMware parity batch (Lot D of the #264 plan)",
+	"cloudtemple_compute_virtual_machine.boot_options.enter_bios_setup":                      "raw-config gated in buildVMwareBootOptionsFromRaw (Lot D)",
+	"cloudtemple_compute_virtual_machine.boot_options.boot_retry_enabled":                    "raw-config gated in buildVMwareBootOptionsFromRaw (Lot D)",
+	"cloudtemple_compute_virtual_machine.boot_options.efi_secure_boot_enabled":               "raw-config gated in buildVMwareBootOptionsFromRaw (Lot D)",
+	"cloudtemple_compute_virtual_machine.os_network_adapter.auto_connect":                    "UNGATED-LEGACY: write guarded by per-index HasChange in updateVirtualMachine; merged value still pushed when any adapter field changes — full raw-config gating tracked in the #264 plan",
+	"cloudtemple_compute_virtual_machine.os_network_adapter.connected":                       "UNGATED-LEGACY: connect/disconnect guarded by per-index HasChange on the attribute itself — full raw-config gating tracked in the #264 plan",
 }
 
 // collectOptionalComputedBooleans walks a schema map recursively and

--- a/internal/provider/resource_compute_iaas_opensource_replication_policy.go
+++ b/internal/provider/resource_compute_iaas_opensource_replication_policy.go
@@ -128,7 +128,13 @@ func openIaasReplicationPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	var diags diag.Diagnostics
 
 	replicationPolicy, err := c.Compute().OpenIaaS().Replication().Policy().Read(ctx, d.Id())
-	if replicationPolicy == nil || err != nil {
+	// A read error is NOT a deletion: clearing the id on a transient
+	// failure would drop the resource from the state and the next apply
+	// would create a duplicate (#264 plan, Lot D).
+	if err != nil {
+		return diag.Errorf("failed to read replication policy: %s", err)
+	}
+	if replicationPolicy == nil {
 		d.SetId("")
 		return nil
 	}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_disk.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_disk.go
@@ -184,9 +184,14 @@ func openIaasVirtualDiskRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	// Récupérer le disque virtuel par son ID
 	virtualDisk, err := c.Compute().OpenIaaS().VirtualDisk().Read(ctx, d.Id())
-	if virtualDisk == nil || err != nil {
-		// Si le disque virtuel n'existe pas, on définit l'ID à une chaîne vide
-		// pour indiquer à Terraform que la ressource n'existe plus
+	// A read error is NOT a deletion: clearing the id on a transient
+	// failure would drop the resource from the state and the next apply
+	// would create a duplicate (#264 plan, Lot D).
+	if err != nil {
+		return diag.Errorf("failed to read virtual disk: %s", err)
+	}
+	if virtualDisk == nil {
+		// The virtual disk no longer exists: remove it from the state.
 		d.SetId("")
 		return nil
 	}

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1190,6 +1191,49 @@ func computeVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
+// buildVMwareBootOptionsFromRaw builds the boot options payload from the
+// merged block values and the raw-config block. The three Optional+Computed
+// booleans are only carried when the raw configuration explicitly sets
+// them: a value merged through Computed is not write intent (#246 class,
+// #264 plan Lot D).
+func buildVMwareBootOptionsFromRaw(rawBlock cty.Value, block map[string]interface{}) *client.BootOptions {
+	opts := &client.BootOptions{
+		BootDelay:      block["boot_delay"].(int),
+		BootRetryDelay: block["boot_retry_delay"].(int),
+		Firmware:       strings.ToLower(block["firmware"].(string)),
+	}
+	setIfConfigured := func(attr string, target **bool) {
+		if v := rawBlock.GetAttr(attr); v.IsKnown() && !v.IsNull() {
+			b := v.True()
+			*target = &b
+		}
+	}
+	setIfConfigured("boot_retry_enabled", &opts.BootRetryEnabled)
+	setIfConfigured("enter_bios_setup", &opts.EnterBIOSSetup)
+	setIfConfigured("efi_secure_boot_enabled", &opts.EFISecureBootEnabled)
+	return opts
+}
+
+// buildVMwareBootOptions returns the boot options payload only when the
+// boot_options block is explicitly present in the raw configuration: the
+// block is Optional+Computed, so the merged d.Get value re-pushed live
+// values on every update (the create chains into update).
+func buildVMwareBootOptions(d *schema.ResourceData) *client.BootOptions {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return nil
+	}
+	rawList := raw.GetAttr("boot_options")
+	if rawList.IsNull() || !rawList.IsKnown() || rawList.LengthInt() == 0 {
+		return nil
+	}
+	merged := d.Get("boot_options").([]interface{})
+	if len(merged) == 0 || merged[0] == nil {
+		return nil
+	}
+	return buildVMwareBootOptionsFromRaw(rawList.Index(cty.NumberIntVal(0)), merged[0].(map[string]interface{}))
+}
+
 func computeVirtualMachineUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return updateVirtualMachine(ctx, d, meta, d.HasChange("power_state"), false)
 }
@@ -1209,17 +1253,7 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 		ExposeHardwareVirtualization: d.Get("expose_hardware_virtualization").(bool),
 	}
 
-	if len(d.Get("boot_options").([]interface{})) > 0 {
-		bootOptions := d.Get("boot_options").([]interface{})[0]
-		req.BootOptions = &client.BootOptions{
-			BootDelay:            bootOptions.(map[string]interface{})["boot_delay"].(int),
-			BootRetryDelay:       bootOptions.(map[string]interface{})["boot_retry_delay"].(int),
-			BootRetryEnabled:     bootOptions.(map[string]interface{})["boot_retry_enabled"].(bool),
-			EnterBIOSSetup:       bootOptions.(map[string]interface{})["enter_bios_setup"].(bool),
-			Firmware:             strings.ToLower(bootOptions.(map[string]interface{})["firmware"].(string)),
-			EFISecureBootEnabled: bootOptions.(map[string]interface{})["efi_secure_boot_enabled"].(bool),
-		}
-	}
+	req.BootOptions = buildVMwareBootOptions(d)
 
 	activityId, err := c.Compute().VirtualMachine().Update(ctx, req)
 	if err != nil {

--- a/internal/provider/resource_compute_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_virtual_machine_unit_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+var bootOptionsRawType = cty.Object(map[string]cty.Type{
+	"boot_delay":              cty.Number,
+	"boot_retry_delay":        cty.Number,
+	"boot_retry_enabled":      cty.Bool,
+	"enter_bios_setup":        cty.Bool,
+	"firmware":                cty.String,
+	"efi_secure_boot_enabled": cty.Bool,
+})
+
+func TestBuildVMwareBootOptionsFromRaw(t *testing.T) {
+	merged := map[string]interface{}{
+		"boot_delay":              5,
+		"boot_retry_delay":        10,
+		"boot_retry_enabled":      true, // merged from live, NOT configured
+		"enter_bios_setup":        true, // merged from live, NOT configured
+		"firmware":                "EFI",
+		"efi_secure_boot_enabled": true, // merged from live, NOT configured
+	}
+
+	t.Run("unconfigured booleans are omitted even when merged true", func(t *testing.T) {
+		rawBlock := cty.ObjectVal(map[string]cty.Value{
+			"boot_delay":              cty.NumberIntVal(5),
+			"boot_retry_delay":        cty.NumberIntVal(10),
+			"boot_retry_enabled":      cty.NullVal(cty.Bool),
+			"enter_bios_setup":        cty.NullVal(cty.Bool),
+			"firmware":                cty.StringVal("EFI"),
+			"efi_secure_boot_enabled": cty.NullVal(cty.Bool),
+		})
+		opts := buildVMwareBootOptionsFromRaw(rawBlock, merged)
+		if opts.BootRetryEnabled != nil || opts.EnterBIOSSetup != nil || opts.EFISecureBootEnabled != nil {
+			t.Fatalf("unconfigured booleans must be omitted: %+v", opts)
+		}
+		if opts.BootDelay != 5 || opts.BootRetryDelay != 10 || opts.Firmware != "efi" {
+			t.Fatalf("non-boolean fields not carried: %+v", opts)
+		}
+	})
+
+	t.Run("explicit false is carried", func(t *testing.T) {
+		rawBlock := cty.ObjectVal(map[string]cty.Value{
+			"boot_delay":              cty.NumberIntVal(5),
+			"boot_retry_delay":        cty.NumberIntVal(10),
+			"boot_retry_enabled":      cty.False,
+			"enter_bios_setup":        cty.NullVal(cty.Bool),
+			"firmware":                cty.StringVal("EFI"),
+			"efi_secure_boot_enabled": cty.False,
+		})
+		opts := buildVMwareBootOptionsFromRaw(rawBlock, merged)
+		if opts.BootRetryEnabled == nil || *opts.BootRetryEnabled != false {
+			t.Fatalf("explicit false boot_retry_enabled not carried: %+v", opts)
+		}
+		if opts.EFISecureBootEnabled == nil || *opts.EFISecureBootEnabled != false {
+			t.Fatalf("explicit false efi_secure_boot_enabled not carried: %+v", opts)
+		}
+		if opts.EnterBIOSSetup != nil {
+			t.Fatalf("unconfigured enter_bios_setup must stay omitted: %+v", opts)
+		}
+	})
+}

--- a/internal/provider/resource_iam_personal_access_token.go
+++ b/internal/provider/resource_iam_personal_access_token.go
@@ -129,7 +129,11 @@ func resourcePersonalAccessTokenRead(ctx context.Context, d *schema.ResourceData
 	sw.set("roles", stringSliceToInterfaceSlice(token.Roles))
 	sw.set("expiration_date", expirationDate.Format(time.RFC3339))
 	sw.set("client_id", token.ID)
-	sw.set("secret_id", token.Secret)
+	// The API only returns the secret at creation: overwriting it on
+	// refresh would erase the only copy from the state (#264 plan, Lot D).
+	if token.Secret != "" {
+		sw.set("secret_id", token.Secret)
+	}
 
 	return sw.diags
 }


### PR DESCRIPTION
Refs #271

Lot D (final batch) of the non-complacent test plan (#264).

## Changes

| Fix | Class |
|---|---|
| `boot_options` only sent when explicitly configured; its three Optional+Computed booleans become `*bool,omitempty` and are only carried when explicitly set (`buildVMwareBootOptionsFromRaw`, pure and unit-tested) | Unrequested PATCH (#246 class) — the VMware create chains into update |
| `cloudtemple_iam_personal_access_token` Read no longer erases `secret_id` (API returns the secret only at creation) | Secret destroyed on refresh |
| `cloudtemple_compute_iaas_opensource_replication_policy` and `..._virtual_disk` Reads: a transient API error is an error, not a deletion — only a genuine not-found clears the id | State destruction → duplicate creation |
| Registry: 3 `boot_options` booleans now gated; the 2 remaining `os_network_adapter` legacy entries get precise guard documentation | Guard registry hygiene |

## Validation

- New `TestBuildVMwareBootOptionsFromRaw` (unconfigured booleans omitted even when merged true; explicit false carried); registry test green; full unit suites green; `go build`/`go vet` OK; docs unchanged (no schema change).
- Adversarial review (`codex review`, default high config) before commit — its first pass caught a compile break in `internal/client/tests` (BootOptions literal), fixed; second pass: no regression.

With this, the four batches (A: OpenIaaS PATCH gating, B: activity retry invariants, C: datasource walker, D: VMware parity + secrets + read errors) of the #264 state-safety plan are delivered. Remaining on the plan: the full `os_network_adapter` raw-config gating (documented legacy) and the #265 bounded VIF retry, rebased on this final shape.