### PR TITLE
OpenIaaS: clean the legacy config-drive pollution on refresh, stop crashing on deleted devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ BUG FIXES :
   * Fixed resource `cloudtemple_iam_personal_access_token` erasing `secret_id` from the state on refresh (the API only returns the secret at creation).
   * Fixed resource `cloudtemple_compute_virtual_machine` re-sending the full `boot_options` block (including values merely inherited from the live state) on every update. The block is now only sent when explicitly configured, and its booleans only when explicitly set.
   * Fixed datasources `cloudtemple_compute_iaas_opensource_pools`, `cloudtemple_compute_iaas_opensource_virtual_machine`, `cloudtemple_compute_iaas_opensource_virtual_machines`, `cloudtemple_compute_iaas_opensource_virtual_disk` and `cloudtemple_compute_iaas_opensource_virtual_disks` failing at read time with an `Invalid address to set` error: the schemas now declare every attribute emitted by the flatten helpers.
+  * Fixed Terraform states polluted by pre-1.8.0 creations that captured the cloud-init config drive (`XO CloudConfigDrive`) as a managed `os_disk`: the refresh now drops the drive from the state — with an explicit warning and only under strict live evidence (exact XO name and read-only attachment to this virtual machine) — which stops the permanent removal drift for existing clients. Ambiguous disks stay in the state. No platform-side change is ever made.
+  * Fixed a crash (nil dereference) during refresh when an `os_disk` or `os_network_adapter` referenced in the state no longer exists platform-side: the deleted device is now dropped from the state so the next plan reflects reality.
 
 IMPROVEMENTS :
 

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
@@ -72,7 +72,7 @@ func FlattenOpenIaaSVirtualMachine(vm *client.OpenIaaSVirtualMachine) map[string
 // it attaches at deploy time.
 const cloudConfigDriveName = "XO CloudConfigDrive"
 
-// isPlatformManagedDisk reports whether the disk is managed by the platform
+// IsPlatformManagedDisk reports whether the disk is managed by the platform
 // (cloud-init config drive, attached read-only by XO at deploy time) and must
 // never be reconciled as an os_disk: capturing it — which is timing dependent
 // at create — produces a permanent removal drift in every subsequent plan.
@@ -82,7 +82,7 @@ const cloudConfigDriveName = "XO CloudConfigDrive"
 // invariant. Only a disk attached read-only to this VM under the exact XO
 // platform naming is excluded; when the VBD is absent Find returns a zero
 // value, so the default stays fail-safe (the disk remains managed).
-func isPlatformManagedDisk(osDisk *client.OpenIaaSVirtualDisk, virtualMachineId string) bool {
+func IsPlatformManagedDisk(osDisk *client.OpenIaaSVirtualDisk, virtualMachineId string) bool {
 	if osDisk.Name != cloudConfigDriveName {
 		return false
 	}
@@ -96,7 +96,7 @@ func FlattenOpenIaaSOSDisksData(osDisks []*client.OpenIaaSVirtualDisk, virtualMa
 	disks := make([]interface{}, 0, len(osDisks))
 
 	for _, osDisk := range osDisks {
-		if isPlatformManagedDisk(osDisk, virtualMachineId) {
+		if IsPlatformManagedDisk(osDisk, virtualMachineId) {
 			continue
 		}
 		disks = append(disks, FlattenOpenIaaSOSDiskData(osDisk, virtualMachineId))

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
@@ -65,8 +65,8 @@ func TestIsPlatformManagedDisk(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isPlatformManagedDisk(tt.disk, vmID); got != tt.want {
-				t.Errorf("isPlatformManagedDisk() = %v, want %v", got, tt.want)
+			if got := IsPlatformManagedDisk(tt.disk, vmID); got != tt.want {
+				t.Errorf("IsPlatformManagedDisk() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -631,12 +631,33 @@ func openIaasVirtualMachineRead(ctx context.Context, d *schema.ResourceData, met
 			continue
 		}
 		osDiskId := osDisk.(map[string]interface{})["id"].(string)
-		if osDiskId != "" {
-			disk, err := c.Compute().OpenIaaS().VirtualDisk().Read(ctx, osDiskId)
-			if err != nil {
-				return diag.Errorf("failed to read os disk: %s", err)
-			}
+		if osDiskId == "" {
+			continue
+		}
+		disk, err := c.Compute().OpenIaaS().VirtualDisk().Read(ctx, osDiskId)
+		if err != nil {
+			return diag.Errorf("failed to read os disk: %s", err)
+		}
+		switch classifyOSDiskOnRead(disk, d.Id()) {
+		case osDiskReadKeep:
 			osDisks = append(osDisks, helpers.FlattenOpenIaaSOSDiskData(disk, d.Id()))
+		case osDiskReadDropGone:
+			// The disk no longer exists platform-side: reflect reality in
+			// the state instead of crashing on the stale entry (#234 class).
+		case osDiskReadDropPlatformManaged:
+			// Legacy state pollution (#255): pre-1.8.0 creations could
+			// capture the cloud-init config drive as a managed os_disk,
+			// leaving a permanent removal drift. The strict live evidence
+			// (exact XO name AND read-only VBD on this VM) allows the
+			// cleanup; ambiguous disks stay in the state and require the
+			// documented manual remediation. No platform-side change is
+			// ever made: this is a state-shape correction only.
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Platform-managed cloud-init config drive removed from os_disk",
+				Detail: fmt.Sprintf("The disk %s (%q) is the XO cloud-init config drive, attached read-only by the platform at deploy time. It was captured in the Terraform state by a pre-1.8.0 creation and is now dropped from os_disk to stop the permanent removal drift. No platform-side change was made.",
+					osDiskId, disk.Name),
+			})
 		}
 	}
 	vmData["os_disk"] = osDisks
@@ -648,13 +669,19 @@ func openIaasVirtualMachineRead(ctx context.Context, d *schema.ResourceData, met
 			continue
 		}
 		osNetworkAdapterId := osNetworkAdapter.(map[string]interface{})["id"].(string)
-		if osNetworkAdapterId != "" {
-			networkAdapter, err := c.Compute().OpenIaaS().NetworkAdapter().Read(ctx, osNetworkAdapterId)
-			if err != nil {
-				return diag.Errorf("failed to read os network adapter: %s", err)
-			}
-			osNetworkAdapters = append(osNetworkAdapters, helpers.FlattenOpenIaaSOSNetworkAdapterData(networkAdapter))
+		if osNetworkAdapterId == "" {
+			continue
 		}
+		networkAdapter, err := c.Compute().OpenIaaS().NetworkAdapter().Read(ctx, osNetworkAdapterId)
+		if err != nil {
+			return diag.Errorf("failed to read os network adapter: %s", err)
+		}
+		if networkAdapter == nil {
+			// The adapter no longer exists platform-side: reflect reality
+			// instead of crashing on the stale entry (#234 class).
+			continue
+		}
+		osNetworkAdapters = append(osNetworkAdapters, helpers.FlattenOpenIaaSOSNetworkAdapterData(networkAdapter))
 	}
 	vmData["os_network_adapter"] = osNetworkAdapters
 
@@ -961,6 +988,36 @@ func diskPendingChanges(desired map[string]interface{}, actual *client.OpenIaaSV
 		changes.relocate = true
 	}
 	return changes
+}
+
+// osDiskReadAction is the decision of classifyOSDiskOnRead for one os_disk
+// entry of the state during a refresh.
+type osDiskReadAction int
+
+const (
+	// osDiskReadKeep: the disk exists and is user-managed — keep it.
+	osDiskReadKeep osDiskReadAction = iota
+	// osDiskReadDropGone: the disk no longer exists platform-side — drop
+	// the stale entry instead of crashing on the nil API answer.
+	osDiskReadDropGone
+	// osDiskReadDropPlatformManaged: the disk is the XO cloud-init config
+	// drive (strict live evidence: exact name AND read-only VBD on this
+	// VM) captured by a pre-1.8.0 creation — drop it with a warning.
+	osDiskReadDropPlatformManaged
+)
+
+// classifyOSDiskOnRead decides what the refresh does with an os_disk entry
+// of the state, based exclusively on the live API answer. Ambiguity is
+// conservative: a disk that merely shares the XO config drive name (writable,
+// read-only on another VM, or without a VBD on this VM) stays managed.
+func classifyOSDiskOnRead(disk *client.OpenIaaSVirtualDisk, virtualMachineID string) osDiskReadAction {
+	if disk == nil {
+		return osDiskReadDropGone
+	}
+	if helpers.IsPlatformManagedDisk(disk, virtualMachineID) {
+		return osDiskReadDropPlatformManaged
+	}
+	return osDiskReadKeep
 }
 
 // openIaasVMDesiredProperties carries the desired VM properties from the

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
@@ -406,3 +406,82 @@ func TestBuildOpenIaasVIFPatch(t *testing.T) {
 		}
 	})
 }
+
+func TestClassifyOSDiskOnRead(t *testing.T) {
+	const vmID = "vm-1"
+
+	tests := []struct {
+		name string
+		disk *client.OpenIaaSVirtualDisk
+		want osDiskReadAction
+	}{
+		{
+			name: "deleted disk is dropped instead of crashing",
+			disk: nil,
+			want: osDiskReadDropGone,
+		},
+		{
+			name: "read-only XO config drive on this VM is cleaned up",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "XO CloudConfigDrive",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: true},
+				},
+			},
+			want: osDiskReadDropPlatformManaged,
+		},
+		{
+			name: "writable user disk with the colliding name stays managed (ambiguous)",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "XO CloudConfigDrive",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false},
+				},
+			},
+			want: osDiskReadKeep,
+		},
+		{
+			name: "XO-named disk read-only on another VM stays managed (ambiguous)",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "XO CloudConfigDrive",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: "vm-other", ReadOnly: true},
+				},
+			},
+			want: osDiskReadKeep,
+		},
+		{
+			name: "XO-named disk without any VBD stays managed (ambiguous, fail-safe)",
+			disk: &client.OpenIaaSVirtualDisk{Name: "XO CloudConfigDrive"},
+			want: osDiskReadKeep,
+		},
+		{
+			name: "ordinary user disk stays managed",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "data-disk",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false, Connected: true},
+				},
+			},
+			want: osDiskReadKeep,
+		},
+		{
+			name: "legitimate read-only disk with another name stays managed",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "shared-iso",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: true},
+				},
+			},
+			want: osDiskReadKeep,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyOSDiskOnRead(tt.disk, vmID); got != tt.want {
+				t.Errorf("classifyOSDiskOnRead() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #273, refs #255

Remediation series on `rc/v1.8.0` — P1 of the #264 plan (the only drift existing clients still suffer today).

## Changes

1. **Legacy config-drive cleanup on refresh** — `classifyOSDiskOnRead` drops a state `os_disk` entry only under the strict live evidence already used at creation (exact `XO CloudConfigDrive` name AND read-only VBD on this VM): the permanent removal drift stops for clients polluted by pre-1.8.0 creations. An explicit **warning diagnostic** surfaces every cleanup. Ambiguous disks (writable, read-only elsewhere, no VBD) stay managed. **No platform-side change is ever made** — state-shape correction only.
2. **No more crash on deleted devices** — an `os_disk` or `os_network_adapter` referenced in the state but deleted platform-side made the refresh panic on the nil API answer (#234 class); the stale entry is now dropped so the next plan reflects reality.

## Validation

- 7 adversarial cases for `classifyOSDiskOnRead` (the P1 matrix of the #264 plan: deleted, cleaned, and the four ambiguous keep-cases) + the existing 5-case `IsPlatformManagedDisk` matrix — all green; full unit suites green.
- Adversarial review (`codex review`, default high config) before commit: no actionable regression.