### PR TITLE
Fix acceptance-test PATClient.List signature drift and guard it with go vet ./... in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,13 @@ jobs:
           exit 1
         fi
 
-    - name: Vet (platform-independent packages)
+    - name: Vet (whole module — compiles every _test.go without running it)
       run: |
-        go vet ./internal/client ./internal/provider ./internal/provider/helpers
+        # `go vet ./...` type-checks and compiles every package, including the
+        # acceptance-test packages (internal/client/tests, internal/provider/tests).
+        # It does NOT execute the tests, so no live Cloud Temple platform is needed.
+        # This is what catches client/test signature drift that the build job misses.
+        go vet ./...
 
     - name: Unit tests (platform-independent packages)
       run: |

--- a/internal/client/tests/api_test.go
+++ b/internal/client/tests/api_test.go
@@ -111,13 +111,15 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)
 	}
-	tokens, err := client.IAM().PAT().List(ctx, lt.UserID(), lt.TenantID())
+	tokens, err := client.IAM().PAT().List(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)
 	}
 	for _, token := range tokens {
-		if _, found := names[token.Name]; found {
+		// PAT().List is no longer scoped server-side (see #226), so restrict
+		// this destructive cleanup to the authenticated principal's own tokens.
+		if _, found := names[token.Name]; found && token.UserId == lt.UserID() && token.TenantId == lt.TenantID() {
 			err := client.IAM().PAT().Delete(ctx, token.ID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err.Error())

--- a/internal/client/tests/iam_pat_test.go
+++ b/internal/client/tests/iam_pat_test.go
@@ -15,12 +15,15 @@ const (
 
 func TestIAM_PATList(t *testing.T) {
 	ctx := context.Background()
-	tokens, err := client.IAM().PAT().List(ctx, testUserID(t), testTenantID(t))
+	lt, err := client.Token(ctx)
+	require.NoError(t, err)
+	tokens, err := client.IAM().PAT().List(ctx)
 	require.NoError(t, err)
 
 	found := false
 	for _, token := range tokens {
-		if token.Name == os.Getenv(PatName) {
+		// List(ctx) is unscoped (see #226); match the principal's own token.
+		if token.Name == os.Getenv(PatName) && token.UserId == lt.UserID() && token.TenantId == lt.TenantID() {
 			found = true
 			break
 		}
@@ -30,12 +33,15 @@ func TestIAM_PATList(t *testing.T) {
 
 func TestIAM_PATRead(t *testing.T) {
 	ctx := context.Background()
-	tokens, err := client.IAM().PAT().List(ctx, testUserID(t), testTenantID(t))
+	lt, err := client.Token(ctx)
+	require.NoError(t, err)
+	tokens, err := client.IAM().PAT().List(ctx)
 	require.NoError(t, err)
 
 	var id string
 	for _, token := range tokens {
-		if token.Name == os.Getenv(PatName) {
+		// List(ctx) is unscoped (see #226); match the principal's own token.
+		if token.Name == os.Getenv(PatName) && token.UserId == lt.UserID() && token.TenantId == lt.TenantID() {
 			id = token.ID
 			break
 		}
@@ -44,7 +50,7 @@ func TestIAM_PATRead(t *testing.T) {
 		t.Fatalf(`failed to find token named "Terraform"`)
 	}
 
-	token, err := client.IAM().PAT().Read(ctx, tokens[0].ID)
+	token, err := client.IAM().PAT().Read(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, os.Getenv(PatName), token.Name)
 	require.Equal(t, "", token.Secret)

--- a/internal/provider/tests/provider_test.go
+++ b/internal/provider/tests/provider_test.go
@@ -124,13 +124,15 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)
 	}
-	tokens, err := c.IAM().PAT().List(ctx, lt.UserID(), lt.TenantID())
+	tokens, err := c.IAM().PAT().List(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)
 	}
 	for _, token := range tokens {
-		if _, found := names[token.Name]; found {
+		// PAT().List is no longer scoped server-side (see #226), so restrict
+		// this destructive cleanup to the authenticated principal's own tokens.
+		if _, found := names[token.Name]; found && token.UserId == lt.UserID() && token.TenantId == lt.TenantID() {
 			err := c.IAM().PAT().Delete(ctx, token.ID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err.Error())


### PR DESCRIPTION
## What

The acceptance-test packages `internal/client/tests` and `internal/provider/tests` no longer compiled: they called `PATClient.List(ctx, userId, tenantId)` while the method signature is now `List(ctx)`.

The signature was changed in #226 (commit `f4988b1`): the server-side `userId`/`tenantId` query parameters were removed and the `Token` struct gained `UserId`, `TenantId` and `TenantName` instead. The test call sites were never updated.

The break stayed invisible in CI because the `unit` job only vetted `internal/client`, `internal/provider` and `internal/provider/helpers` — never the acceptance-test packages (which require a live platform to *run*, but not to *compile*).

## Changes

**`test:` align the acceptance-test call sites**
- Align every `PATClient.List` call site to `List(ctx)` (3 sites in `internal/client/tests`, 1 in `internal/provider/tests`).
- `List(ctx)` is no longer scoped to a single user/tenant, so restrict the PAT lookups to the authenticated principal **client-side** (`token.UserId/TenantId == lt.UserID()/TenantID()`):
  - in the two `TestMain` cleanups, before deleting `client-test` tokens;
  - in `TestIAM_PATList` / `TestIAM_PATRead`, so a same-named token from another visible tenant cannot satisfy the assertions.
- Fix `TestIAM_PATRead` to `Read` the token id matched by name instead of `tokens[0].ID`.

**`chore(ci):` close the blind spot**
- Replace the narrow `go vet ./internal/client ./internal/provider ./internal/provider/helpers` step with `go vet ./...`. This type-checks and compiles every package, including all `_test.go` files, **without executing** the acceptance tests (no platform access). This is the check that would have caught the drift.

## Verification
- `gofmt -l .` — clean
- `go vet ./...` — green (the new CI guard, run locally)
- `go build ./...` — green

No CHANGELOG entry: test-infra / CI only, no user-facing behaviour change.

Refs #264
