### PR TITLE
fix(#288): bound iam_features flatten to the schema's declared depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ BUG FIXES :
   * Fixed error paths that could leave a virtual machine powered off after a provider-initiated shutdown on resource `cloudtemple_compute_iaas_opensource_virtual_machine`: the provider now restores the power state on failure (best effort, targeting the pre-shutdown host) and reports the outcome in the error.
   * Fixed Terraform states polluted by pre-1.8.0 creations that captured the cloud-init config drive (`XO CloudConfigDrive`) as a managed `os_disk`: the refresh now drops the drive from the state — with an explicit warning and only under strict live evidence (exact XO name and read-only attachment to this virtual machine) — which stops the permanent removal drift for existing clients. Ambiguous disks stay in the state. No platform-side change is ever made.
   * Fixed a crash (nil dereference) during refresh when an `os_disk` or `os_network_adapter` referenced in the state no longer exists platform-side: the deleted device is now dropped from the state so the next plan reflects reality. The deletion is confirmed by a second independent read (the VM-scoped device listing) before any state entry is dropped, so an access-denied answer can never silently shrink the state.
+  * Fixed datasource `cloudtemple_iam_features` being able to fail at read time with an `Invalid address to set` error, which would make the whole datasource unusable, if the feature tree were ever nested deeper than the schema declares (a sub-feature below the deepest declared level emitting a `subfeatures` key the schema does not declare). The flatten is now bounded to the schema's declared nesting depth: any deeper sub-features are truncated — the datasource stays readable — and a warning is emitted, instead of breaking the read. The real feature catalog is only two levels deep, so current outputs are unchanged.
 
 IMPROVEMENTS :
 
@@ -37,7 +38,7 @@ MISCELLANEOUS :
 
   * The provider is now built with Go 1.24 (required by the updated dependencies).
   * The continuous integration now runs a platform-independent safety net on every pull request: formatting and static-analysis checks, the state-safety unit-test suites, a datasource schema-vs-flatten validation and a write-guard registry for the `Optional`+`Computed` booleans.
-  * The datasource schema-vs-flatten CI validation now covers every datasource except `cloudtemple_iam_features` (a self-referential schema whose API contract is being resolved separately). It is driven by a reflection-based non-zero object filler and a coverage registry checked against the provider's datasource map: a newly added datasource must be either covered or explicitly listed as a known gap, so the read-breaking class behind #241/#243 cannot silently regain ground.
+  * The datasource schema-vs-flatten CI validation now covers every datasource. It is driven by a reflection-based non-zero object filler and a coverage registry checked against the provider's datasource map: a newly added datasource must be either covered or explicitly listed as a known gap, so the read-breaking class behind #241/#243 cannot silently regain ground.
   * Refreshed the repository README (build requirements, Terraform Registry links, usage example).
   * Removed a broken CI workflow left over from the provider template.
 

--- a/internal/client/tests/iam_feature_test.go
+++ b/internal/client/tests/iam_feature_test.go
@@ -29,6 +29,16 @@ func TestIAM_Features(t *testing.T) {
 	require.Equal(t, os.Getenv(FeatureName), rtms.Name)
 	require.Equal(t, os.Getenv(FeatureId), rtms.ID)
 	require.Len(t, rtms.SubFeatures, 2)
+
+	// The sub-features of rtms are leaves: the real IAM feature tree depth is 2.
+	// This locks the depth assumption the datasource schema/flatten rely on
+	// (see internal/provider/helpers/helper_iam_feature.go). If the platform
+	// ever nests sub-features deeper, this fails loudly so the schema depth is
+	// revisited before a deeper tree silently gets truncated.
+	for _, sf := range rtms.SubFeatures {
+		require.NotNil(t, sf)
+		require.Empty(t, sf.SubFeatures, "sub-feature %q is expected to be a leaf (observed IAM feature tree depth is 2)", sf.Name)
+	}
 }
 
 func TestIAM_FeatureAssignments(t *testing.T) {

--- a/internal/provider/data_source_iam_features.go
+++ b/internal/provider/data_source_iam_features.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -95,10 +96,26 @@ func dataSourceFeaturesRead(ctx context.Context, d *schema.ResourceData, meta an
 	// Définir l'ID de la datasource
 	d.SetId("features")
 
-	// Mapper les données en utilisant la fonction helper
-	tfFeatures := make([]map[string]interface{}, len(features))
-	for i, feature := range features {
-		tfFeatures[i] = helpers.FlattenFeature(feature)
+	// Mapper les données en utilisant la fonction helper. La forme imbriquée des
+	// sous-features est bornée à la profondeur déclarée par le schéma ci-dessus
+	// (cf. helpers.FlattenFeature) : un arbre plus profond est tronqué — la
+	// datasource reste lisible — et signalé par un warning, plutôt que de casser
+	// la lecture avec "Invalid address to set" (classe #243).
+	tfFeatures := make([]map[string]interface{}, 0, len(features))
+	for _, feature := range features {
+		if feature == nil {
+			continue // un élément null renvoyé par l'API ne doit pas faire paniquer le flatten
+		}
+		tfFeatures = append(tfFeatures, helpers.FlattenFeature(feature))
+		if helpers.FeatureExceedsDeclaredDepth(feature) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Feature sub-tree deeper than the schema can represent; truncated",
+				Detail: fmt.Sprintf(
+					"Feature %q (id %s) has sub-features nested deeper than the cloudtemple_iam_features schema represents; the deepest levels were truncated from the datasource output. Please report this to the provider maintainers so the schema can be extended.",
+					feature.Name, feature.ID),
+			})
+		}
 	}
 
 	// Définir les données dans le state

--- a/internal/provider/datasource_flatten_schema_test.go
+++ b/internal/provider/datasource_flatten_schema_test.go
@@ -314,9 +314,20 @@ var datasourceCoverage = map[string]dsCoverage{
 
 	// --- IAM --------------------------------------------------------------
 	"cloudtemple_iam_company": {"", flat(helpers.FlattenCompany)},
-	// cloudtemple_iam_features is a declared known gap (datasourceKnownGaps): its
-	// self-referential schema, the FlattenFeature emit depth and the API contract
-	// are inconsistent, and the correct fix is being resolved separately.
+	// Feature is self-referential and the schema declares a fixed nesting depth
+	// (features -> subfeatures -> subfeatures). The generic filler stops one
+	// level deep, so build a depth-4 tree by hand: a node AT the deepest declared
+	// level (level 2) that itself has a child. A correct FlattenFeature must
+	// truncate it so the flatten output still fits the schema; an unbounded one
+	// emits an undeclared "subfeatures" key and d.Set fails (#243 class). See
+	// TestIAMFeaturesFlattenIsDepthBounded for the non-complacent proof.
+	"cloudtemple_iam_features": {"features", func() map[string]interface{} {
+		l3 := &client.Feature{ID: "f3", Name: "x"}
+		l2 := &client.Feature{ID: "f2", Name: "x", SubFeatures: []*client.Feature{l3}}
+		l1 := &client.Feature{ID: "f1", Name: "x", SubFeatures: []*client.Feature{l2}}
+		l0 := &client.Feature{ID: "f0", Name: "x", SubFeatures: []*client.Feature{l1}}
+		return helpers.FlattenFeature(l0)
+	}},
 	"cloudtemple_iam_personal_access_token":  {"", flat(helpers.FlattenToken)},
 	"cloudtemple_iam_personal_access_tokens": {"tokens", flat(helpers.FlattenToken)},
 	"cloudtemple_iam_role":                   {"", flat(helpers.FlattenRole)},
@@ -336,7 +347,9 @@ var datasourceCoverage = map[string]dsCoverage{
 // must NOT also appear in datasourceCoverage. Keep this map as small as
 // possible; an entry is a debt to close, not a resting place.
 var datasourceKnownGaps = map[string]string{
-	"cloudtemple_iam_features": "self-referential Feature schema vs FlattenFeature emit depth vs swagger (flat /v2/features) are inconsistent; the real API contract and the coherent fix (schema/model/flatten/test) are being resolved separately before non-complacent coverage can be added",
+	// Empty: every registered datasource is covered by datasourceCoverage.
+	// cloudtemple_iam_features graduated from a known gap to full coverage once
+	// FlattenFeature was made depth-bounded (see TestIAMFeaturesFlattenIsDepthBounded).
 }
 
 // TestDatasourceFlattenOutputsFitTheirSchemas drives the schema-vs-flatten
@@ -384,5 +397,117 @@ func TestEveryDatasourceIsCoveredByTheFlattenWalker(t *testing.T) {
 		if _, ok := datasources[name]; !ok {
 			t.Errorf("datasourceKnownGaps references %q which is not a registered datasource", name)
 		}
+	}
+}
+
+// TestIAMFeaturesFlattenIsDepthBounded proves FlattenFeature never breaks the
+// cloudtemple_iam_features read, even when the feature tree is deeper than the
+// schema declares. The schema declares "subfeatures" at two nesting levels; its
+// deepest element declares only {id,name}. An unbounded flatten (the historical
+// helper) emits a "subfeatures" key on a node at that deepest level as soon as
+// the node has children, and d.Set then fails with "Invalid address to set"
+// (#243 class), making the WHOLE datasource unusable.
+//
+// Depth 4 is the first discriminating case: at depth 3 the deepest node is a
+// leaf and the historical helper only writes an empty list under the undeclared
+// key, which the SDK writer tolerates; depth 4 forces a NON-empty list there.
+// This test fails (panics/errors in d.Set) with an unbounded FlattenFeature and
+// passes with the depth-bounded one.
+func TestIAMFeaturesFlattenIsDepthBounded(t *testing.T) {
+	// root -> child -> grandchild -> great-grandchild (4 node levels).
+	l3 := &client.Feature{ID: "f3", Name: "great-grandchild"}
+	l2 := &client.Feature{ID: "f2", Name: "grandchild", SubFeatures: []*client.Feature{l3}}
+	l1 := &client.Feature{ID: "f1", Name: "child", SubFeatures: []*client.Feature{l2}}
+	l0 := &client.Feature{ID: "f0", Name: "root", SubFeatures: []*client.Feature{l1}}
+
+	flattened := helpers.FlattenFeature(l0)
+
+	// (1) The flatten output must fit the real schema (no read-breaking crash).
+	d := schema.TestResourceDataRaw(t, dataSourceFeatures().Schema, map[string]interface{}{})
+	if err := d.Set("features", []interface{}{flattened}); err != nil {
+		t.Fatalf("depth-4 flatten output does not fit the iam_features schema: %s", err)
+	}
+
+	// (2) Every representable level (0, 1, 2) is preserved.
+	for path, want := range map[string]string{
+		"features.0.id":                             "f0",
+		"features.0.subfeatures.0.id":               "f1",
+		"features.0.subfeatures.0.subfeatures.0.id": "f2",
+	} {
+		if got := d.Get(path); got != want {
+			t.Errorf("%s = %v, want %q", path, got, want)
+		}
+	}
+
+	// (3) The deepest declared level must NOT carry a "subfeatures" key: the
+	// great-grandchild (level 3) is truncated. Emitting it is exactly the bug.
+	level1 := flattened["subfeatures"].([]map[string]interface{})[0]
+	level2 := level1["subfeatures"].([]map[string]interface{})[0]
+	if _, present := level2["subfeatures"]; present {
+		t.Errorf("level-2 node must not carry a 'subfeatures' key (it would break d.Set); got %#v", level2)
+	}
+}
+
+// schemaSubfeatureNesting returns how many nested "subfeatures" levels the
+// cloudtemple_iam_features schema declares under "features".
+func schemaSubfeatureNesting(res *schema.Resource) int {
+	depth := 0
+	cur := res.Schema["features"]
+	for cur != nil {
+		elem, ok := cur.Elem.(*schema.Resource)
+		if !ok {
+			break
+		}
+		sub, ok := elem.Schema["subfeatures"]
+		if !ok {
+			break
+		}
+		depth++
+		cur = sub
+	}
+	return depth
+}
+
+// TestIAMFeaturesSchemaAndFlattenDepthAgree ties the FlattenFeature emission
+// depth to the SCHEMA itself (introspected), not to a hardcoded constant. If a
+// future change extends the schema's "subfeatures" nesting without bumping the
+// flatten bound (or the reverse), the flatten would silently truncate too early
+// or overflow and crash; this test catches that drift instead of letting the
+// hand-maintained coupling rot.
+func TestIAMFeaturesSchemaAndFlattenDepthAgree(t *testing.T) {
+	schemaDepth := schemaSubfeatureNesting(dataSourceFeatures())
+	if schemaDepth < 1 {
+		t.Fatalf("expected the iam_features schema to declare nested subfeatures, got depth %d", schemaDepth)
+	}
+
+	// A chain deeper than the schema, so the flatten bound is what limits it.
+	var build func(n int) *client.Feature
+	build = func(n int) *client.Feature {
+		f := &client.Feature{ID: "x", Name: "x"}
+		if n > 0 {
+			f.SubFeatures = []*client.Feature{build(n - 1)}
+		}
+		return f
+	}
+	flattened := helpers.FlattenFeature(build(schemaDepth + 2))
+
+	// Count the "subfeatures" levels the flatten actually emits.
+	emitted := 0
+	for node := flattened; ; {
+		subs, ok := node["subfeatures"].([]map[string]interface{})
+		if !ok || len(subs) == 0 {
+			break
+		}
+		emitted++
+		node = subs[0]
+	}
+	if emitted != schemaDepth {
+		t.Errorf("flatten emits subfeatures at %d levels but the schema declares %d; the flatten bound (maxFeatureSubNesting) and the schema disagree", emitted, schemaDepth)
+	}
+
+	// The deep flatten must also fit the schema without crashing.
+	d := schema.TestResourceDataRaw(t, dataSourceFeatures().Schema, map[string]interface{}{})
+	if err := d.Set("features", []interface{}{flattened}); err != nil {
+		t.Errorf("deep flatten output does not fit the iam_features schema: %s", err)
 	}
 }

--- a/internal/provider/helpers/helper_iam_feature.go
+++ b/internal/provider/helpers/helper_iam_feature.go
@@ -4,23 +4,92 @@ import (
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
 
-// FlattenFeature convertit un objet Feature en une map compatible avec le schéma Terraform
+// maxFeatureSubNesting est le nombre de niveaux d'imbrication "subfeatures" que
+// le schéma de data_source_iam_features déclare (features -> subfeatures ->
+// subfeatures) : 2 arêtes "subfeatures", donc 3 niveaux de nœuds. Le niveau le
+// plus profond ne déclare PAS "subfeatures" : y émettre la clé — même une liste
+// vide n'est tolérée par le writer SDK que tant qu'elle reste vide, une liste
+// non vide casse — déclenche "Invalid address to set" (classe #243) et rend
+// TOUTE la datasource inutilisable.
+//
+// La profondeur réelle du catalogue de features est 2 (un seul niveau de
+// sous-features, observé sur GET /iam/v2/features, IAM API v2.47.0) ; cette
+// borne garde donc une marge. Si l'API renvoyait un arbre plus profond, les
+// sous-features au-delà sont TRONQUÉES (la datasource reste lisible) au lieu de
+// provoquer un crash, et dataSourceFeaturesRead émet alors un warning. NB : le
+// swagger IAM est incomplet (il ne documente pas "subFeatures", pourtant
+// renvoyé par l'API).
+//
+// Cette borne et la profondeur déclarée par le schéma DOIVENT rester cohérentes :
+// toute modification de l'une exige la mise à jour de l'autre.
+const maxFeatureSubNesting = 2
+
+// FlattenFeature convertit un objet Feature en une map compatible avec le schéma
+// Terraform de la datasource cloudtemple_iam_features. Un feature nil (élément
+// null renvoyé par l'API) donne nil plutôt que de paniquer ; les appelants
+// (dataSourceFeaturesRead, récursion interne) ignorent déjà les nil en amont.
 func FlattenFeature(feature *client.Feature) map[string]interface{} {
+	if feature == nil {
+		return nil
+	}
+	return flattenFeature(feature, maxFeatureSubNesting)
+}
+
+// flattenFeature aplatit récursivement un Feature en respectant strictement la
+// profondeur d'imbrication "subfeatures" déclarée par le schéma. remaining est
+// le nombre de niveaux "subfeatures" encore déclarés sous le nœud courant.
+func flattenFeature(feature *client.Feature, remaining int) map[string]interface{} {
 	result := map[string]interface{}{
 		"id":   feature.ID,
 		"name": feature.Name,
 	}
 
-	// Traiter les sous-features de manière récursive
-	if len(feature.SubFeatures) > 0 {
-		subfeatures := make([]map[string]interface{}, len(feature.SubFeatures))
-		for i, subfeature := range feature.SubFeatures {
-			subfeatures[i] = FlattenFeature(subfeature)
+	// On n'émet "subfeatures" que tant que le schéma le déclare à ce niveau, en
+	// conservant une liste vide lorsqu'il n'y a pas d'enfant (forme du state
+	// inchangée par rapport à l'historique). À remaining == 0 (niveau le plus
+	// profond), on n'émet pas la clé : d'éventuels enfants y sont tronqués plutôt
+	// que de casser la lecture de la datasource.
+	if remaining > 0 {
+		subfeatures := make([]map[string]interface{}, 0, len(feature.SubFeatures))
+		for _, subfeature := range feature.SubFeatures {
+			if subfeature == nil {
+				continue // un élément null ne doit pas faire paniquer le flatten
+			}
+			subfeatures = append(subfeatures, flattenFeature(subfeature, remaining-1))
 		}
 		result["subfeatures"] = subfeatures
-	} else {
-		result["subfeatures"] = []map[string]interface{}{}
 	}
 
 	return result
+}
+
+// FeatureExceedsDeclaredDepth indique si l'arbre de sous-features enraciné en
+// feature est plus profond que ce que le schéma de la datasource peut
+// représenter (maxFeatureSubNesting niveaux d'imbrication "subfeatures"). Au-delà,
+// FlattenFeature tronque silencieusement ; le Read s'appuie sur ce détecteur
+// déterministe pour émettre un warning de troncature.
+func FeatureExceedsDeclaredDepth(feature *client.Feature) bool {
+	return featureDepthExceeds(feature, maxFeatureSubNesting)
+}
+
+// featureDepthExceeds renvoie true dès qu'une sous-feature RÉELLE existe à un
+// niveau où le schéma ne déclare plus "subfeatures" (remaining == 0). Les
+// éléments nil sont ignorés, exactement comme FlattenFeature les ignore : le
+// détecteur de troncature reflète ainsi précisément ce que le flatten émet.
+func featureDepthExceeds(feature *client.Feature, remaining int) bool {
+	if feature == nil {
+		return false
+	}
+	for _, subfeature := range feature.SubFeatures {
+		if subfeature == nil {
+			continue // ignoré par le flatten : ne compte pas comme profondeur
+		}
+		if remaining <= 0 {
+			return true // une sous-feature réelle existe à un niveau non représentable
+		}
+		if featureDepthExceeds(subfeature, remaining-1) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/helpers/helper_iam_feature_test.go
+++ b/internal/provider/helpers/helper_iam_feature_test.go
@@ -1,0 +1,115 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenFeaturePreservesShapeAtRealDepth locks the state shape for the real
+// API depth (2): a root with leaf children still emits an empty "subfeatures"
+// list on the leaves, exactly like the historical helper. This guards against a
+// silent state-shape change for existing consumers.
+func TestFlattenFeaturePreservesShapeAtRealDepth(t *testing.T) {
+	root := &client.Feature{ID: "r", Name: "root", SubFeatures: []*client.Feature{
+		{ID: "c", Name: "child"},
+	}}
+	out := FlattenFeature(root)
+
+	subs, ok := out["subfeatures"].([]map[string]interface{})
+	if !ok || len(subs) != 1 {
+		t.Fatalf("root must emit one subfeature, got %#v", out["subfeatures"])
+	}
+	child := subs[0]
+	leaf, ok := child["subfeatures"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("a leaf at a declared level must still emit an (empty) subfeatures list, got %#v", child["subfeatures"])
+	}
+	if len(leaf) != 0 {
+		t.Errorf("leaf subfeatures must be empty, got %#v", leaf)
+	}
+}
+
+// TestFlattenFeatureIsDepthBounded proves the flatten output never carries a
+// "subfeatures" key beyond the deepest declared level, whatever the tree depth.
+func TestFlattenFeatureIsDepthBounded(t *testing.T) {
+	l3 := &client.Feature{ID: "f3", Name: "x"}
+	l2 := &client.Feature{ID: "f2", Name: "x", SubFeatures: []*client.Feature{l3}}
+	l1 := &client.Feature{ID: "f1", Name: "x", SubFeatures: []*client.Feature{l2}}
+	l0 := &client.Feature{ID: "f0", Name: "x", SubFeatures: []*client.Feature{l1}}
+
+	out := FlattenFeature(l0)
+	lvl1 := out["subfeatures"].([]map[string]interface{})[0]
+	lvl2 := lvl1["subfeatures"].([]map[string]interface{})[0]
+	if _, present := lvl2["subfeatures"]; present {
+		t.Errorf("level-2 node must not carry a subfeatures key (truncation), got %#v", lvl2)
+	}
+	if lvl2["id"] != "f2" {
+		t.Errorf("level-2 id = %v, want f2", lvl2["id"])
+	}
+}
+
+// TestFlattenFeatureNilGuard ensures a nil sub-feature (a JSON null element) is
+// skipped instead of panicking.
+func TestFlattenFeatureNilGuard(t *testing.T) {
+	root := &client.Feature{ID: "r", Name: "root", SubFeatures: []*client.Feature{
+		nil,
+		{ID: "c", Name: "child"},
+		nil,
+	}}
+	out := FlattenFeature(root) // must not panic
+	subs := out["subfeatures"].([]map[string]interface{})
+	if len(subs) != 1 {
+		t.Fatalf("nil sub-features must be skipped, expected 1 child, got %d (%#v)", len(subs), subs)
+	}
+	if subs[0]["id"] != "c" {
+		t.Errorf("kept child id = %v, want c", subs[0]["id"])
+	}
+}
+
+// TestFlattenFeatureNilRoot ensures the exported helper is nil-safe: a nil
+// feature returns nil instead of panicking.
+func TestFlattenFeatureNilRoot(t *testing.T) {
+	if got := FlattenFeature(nil); got != nil {
+		t.Errorf("FlattenFeature(nil) must return nil, got %#v", got)
+	}
+}
+
+// TestFeatureExceedsDeclaredDepth locks the truncation detector that drives the
+// Read warning: depth <= 3 fits, depth 4 overflows.
+func TestFeatureExceedsDeclaredDepth(t *testing.T) {
+	flat := &client.Feature{ID: "a", Name: "a"}
+	depth2 := &client.Feature{ID: "a", SubFeatures: []*client.Feature{{ID: "b"}}}
+	depth3 := &client.Feature{ID: "a", SubFeatures: []*client.Feature{
+		{ID: "b", SubFeatures: []*client.Feature{{ID: "c"}}},
+	}}
+	depth4 := &client.Feature{ID: "a", SubFeatures: []*client.Feature{
+		{ID: "b", SubFeatures: []*client.Feature{
+			{ID: "c", SubFeatures: []*client.Feature{{ID: "d"}}},
+		}},
+	}}
+	// A node at the deepest representable level whose only "children" are nil:
+	// the flatten skips them, so this must NOT be flagged as a deeper tree.
+	nilAtDepth := &client.Feature{ID: "a", SubFeatures: []*client.Feature{
+		{ID: "b", SubFeatures: []*client.Feature{
+			{ID: "c", SubFeatures: []*client.Feature{nil, nil}},
+		}},
+	}}
+
+	for _, tc := range []struct {
+		name string
+		in   *client.Feature
+		want bool
+	}{
+		{"nil", nil, false},
+		{"flat", flat, false},
+		{"depth2", depth2, false},
+		{"depth3", depth3, false},
+		{"depth4", depth4, true},
+		{"nil children at deepest level", nilAtDepth, false},
+	} {
+		if got := FeatureExceedsDeclaredDepth(tc.in); got != tc.want {
+			t.Errorf("%s: FeatureExceedsDeclaredDepth = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #288, #243

## Problem

The `cloudtemple_iam_features` datasource carried a latent #243-class bug. `FlattenFeature` always emitted a `subfeatures` key, but the schema declares a finite `subfeatures` nesting whose deepest element declares only `{id, name}`. A feature tree deeper than that depth — a node at the deepest declared level that itself has children, i.e. a **non-empty** list under an undeclared key — made `d.Set` fail with `Invalid address to set`, which makes the **whole datasource unusable** (read-breaking, TF prod breaker class).

The real catalog depth is **2** (verified live against `GET /iam/v2/features`, IAM API v2.47.0: only `rtms` has sub-features, both leaves), so current outputs are unaffected; this closes the crash for any deeper tree the API might return. The IAM swagger is incomplete — it does not document `subFeatures` although the API returns it.

## Fix

- `FlattenFeature` is now **depth-bounded** to the schema's declared nesting: it emits `subfeatures` only while the schema declares it (keeping the empty list at declared levels, so the **state shape is unchanged** for existing data), and **truncates** beyond the deepest declared level instead of crashing. Nil sub-features are skipped; a nil feature returns nil.
- `dataSourceFeaturesRead` emits a `Warning` (with the feature name/id) when a sub-tree is truncated, so deeper data is never dropped silently.
- The schema is **unchanged** (3 levels), so the generated docs are unchanged.

## Tests (non-complacent)

- The schema-vs-flatten walker now **covers** `cloudtemple_iam_features` (graduated from a known gap) with a hand-built depth-4 tree.
- `TestIAMFeaturesFlattenIsDepthBounded` and the helper tests prove the read no longer breaks; they **fail** on the unbounded helper with the exact `Invalid address to set: features.0.subfeatures.0.subfeatures.0.subfeatures`.
- `TestIAMFeaturesSchemaAndFlattenDepthAgree` introspects the schema and asserts the flatten bound matches the declared nesting, guarding against future drift.
- The acceptance test `TestIAM_Features` is enriched to lock the observed depth (sub-features of `rtms` are leaves) without weakening it.

CHANGELOG updated (BUG FIXES); the MISCELLANEOUS walker line no longer excludes `cloudtemple_iam_features`.
