### PR TITLE
ci(#264): gate the unit job on staticcheck and the race detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,20 @@ jobs:
         # This is what catches client/test signature drift that the build job misses.
         go vet ./...
 
+    - name: Static analysis (staticcheck)
+      run: |
+        # Pinned staticcheck (supports Go 1.24). Analyses the whole module,
+        # including the acceptance-test packages — which are compiled but not
+        # run — without any live Cloud Temple platform. Catches unused code,
+        # dead stores and suspicious constructs that build/vet miss (#264).
+        go run honnef.co/go/tools/cmd/staticcheck@2025.1.1 ./...
+
     - name: Unit tests (platform-independent packages)
       run: |
-        go test -count=1 -cover ./internal/client ./internal/provider ./internal/provider/helpers
+        # -race future-proofs the pure packages (token cache, httptest servers,
+        # timers); it is a guard, not state-safety coverage. CGO is available on
+        # the GitHub ubuntu runners.
+        go test -race -count=1 -cover ./internal/client ./internal/provider ./internal/provider/helpers
 
   generate:
     runs-on: ubuntu-latest

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -363,7 +363,7 @@ func requireNotFoundOrOK(resp *http.Response, notFoundCode int) (bool, error) {
 	case 404, notFoundCode:
 		return false, nil
 	case 403:
-		return false, fmt.Errorf("Access denied: %s", resp.Status)
+		return false, fmt.Errorf("access denied: %s", resp.Status)
 	default:
 		return false, generateUnexpectedResponseCodeError(resp)
 	}

--- a/internal/client/tests/compute_virtual_machine_test.go
+++ b/internal/client/tests/compute_virtual_machine_test.go
@@ -108,7 +108,7 @@ func TestCompute_UpdateAndPower(t *testing.T) {
 	_, err = client.Backup().Job().WaitForCompletion(ctx, jobs[0].ID, nil)
 	require.NoError(t, err)
 
-	activityId, err = client.Backup().SLAPolicy().AssignVirtualMachine(ctx, &clientpkg.BackupAssignVirtualMachineRequest{
+	_, err = client.Backup().SLAPolicy().AssignVirtualMachine(ctx, &clientpkg.BackupAssignVirtualMachineRequest{
 		VirtualMachineIds: []string{instanceId},
 		SLAPolicies:       []string{os.Getenv(PolicyId)},
 	})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -255,20 +255,6 @@ func getClient(meta any) *client.Client {
 	return meta.(*client.Client)
 }
 
-func getUserID(ctx context.Context, client *client.Client, d *schema.ResourceData) (string, error) {
-	userID, ok := d.Get("user_id").(string)
-	if ok && userID != "" {
-		return userID, nil
-	}
-
-	l, err := client.Token(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get token: %s", err)
-	}
-
-	return l.UserID(), nil
-}
-
 func getTenantID(ctx context.Context, client *client.Client, d *schema.ResourceData) (string, error) {
 	userID, ok := d.Get("tenant_id").(string)
 	if ok && userID != "" {

--- a/internal/provider/resource_compute_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_virtual_machine_unit_test.go
@@ -6,15 +6,6 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 )
 
-var bootOptionsRawType = cty.Object(map[string]cty.Type{
-	"boot_delay":              cty.Number,
-	"boot_retry_delay":        cty.Number,
-	"boot_retry_enabled":      cty.Bool,
-	"enter_bios_setup":        cty.Bool,
-	"firmware":                cty.String,
-	"efi_secure_boot_enabled": cty.Bool,
-})
-
 func TestBuildVMwareBootOptionsFromRaw(t *testing.T) {
 	merged := map[string]interface{}{
 		"boot_delay":              5,

--- a/internal/provider/tags.go
+++ b/internal/provider/tags.go
@@ -8,19 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func readTags(ctx context.Context, sw *stateWriter, client *client.Client, id string) {
-	tags, err := client.Tag().Resource().Read(ctx, id)
-	if err != nil {
-		sw.diags = append(sw.diags, diag.Errorf("failed to read resource %q tags: %s", id, err)...)
-	}
-
-	mTags := map[string]interface{}{}
-	for _, tag := range tags {
-		mTags[tag.Key] = tag.Value
-	}
-	sw.set("tags", mTags)
-}
-
 func updateTags(ctx context.Context, c *client.Client, d *schema.ResourceData, id, typ, source string) diag.Diagnostics {
 	if !d.HasChange("tags") {
 		return nil

--- a/internal/provider/tests/data_source_compute_guest_operating_system_test.go
+++ b/internal/provider/tests/data_source_compute_guest_operating_system_test.go
@@ -27,8 +27,8 @@ func TestAccDataSourceGuestOperatingSystem(t *testing.T) {
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccDataSourceGuestOperatingSystemMissing),
-				ExpectError: regexp.MustCompile("Access denied: 403 Forbidden"),
+				Config:      testAccDataSourceGuestOperatingSystemMissing,
+				ExpectError: regexp.MustCompile("access denied: 403 Forbidden"),
 			},
 		},
 	})


### PR DESCRIPTION
## What

Increment 2 of the platform-independent CI safety net (#264). The minimal net (#266) already runs gofmt + `go vet ./...` + unit tests with coverage. This PR adds two static guards to the `unit` job, both running **without any live platform**:

- **staticcheck** — pinned: `go run honnef.co/go/tools/cmd/staticcheck@2025.1.1 ./...` (supports Go 1.24; analyses the whole module, incl. the acceptance-test packages that are compiled but not run).
- **race detector** — the pure unit tests now run under `-race`.

## staticcheck findings cleared (6, none state-shape)

| Check | Location | Fix |
|---|---|---|
| ST1005 | `internal/client/api.go` | lowercase the `access denied` error string; the acceptance test pinning it is updated to match |
| SA1006 | `…/data_source_compute_guest_operating_system_test.go` | drop the pointless `fmt.Sprintf` around a constant |
| U1000 | `internal/provider/provider.go` | remove unused `getUserID` |
| U1000 | `internal/provider/tags.go` | remove unused `readTags` |
| U1000 | `…/resource_compute_virtual_machine_unit_test.go` | remove unused `bootOptionsRawType` var |
| SA4006 | `internal/client/tests/compute_virtual_machine_test.go` | discard the dead `activityId` store |

## State safety

None of the 6 fixes change Terraform-state semantics. The `api.go` change is **case-only** in the human-facing error text; no retry/error-classification logic compares that string (classification uses typed errors). The three removed symbols are unreferenced across the module.

## Honest scoping

- `-race` is framed as a **future-proofing guard** (token cache, httptest servers, timers), not state-safety coverage. staticcheck is the main win here.
- **Known follow-up (not in this PR):** the SA4006 site reveals a latent acceptance-test defect — `AssignVirtualMachine`'s activity is never `WaitForCompletion`'d (analogous call sites do). Discard is the faithful minimal CI-gate fix; the wait is tracked separately.

## Out of scope (later #264 increments)

Marketplace datasource tests, broader pure-logic unit layer, schema-change detection, plan-convergence checks.

## Local verification

`gofmt -l .` empty · `go vet ./...` clean · `staticcheck ./...` **0 findings** · `go build ./...` ok · `go test -race -count=1 -cover ./internal/client ./internal/provider ./internal/provider/helpers` green (cov 10.8 / 8.5 / 12.9 %).

Refs #264