### PR TITLE
test(#264): await the SLA-policy assignment activity in the VM acceptance test

### DIFF
--- a/internal/client/tests/compute_virtual_machine_test.go
+++ b/internal/client/tests/compute_virtual_machine_test.go
@@ -108,10 +108,12 @@ func TestCompute_UpdateAndPower(t *testing.T) {
 	_, err = client.Backup().Job().WaitForCompletion(ctx, jobs[0].ID, nil)
 	require.NoError(t, err)
 
-	_, err = client.Backup().SLAPolicy().AssignVirtualMachine(ctx, &clientpkg.BackupAssignVirtualMachineRequest{
+	activityId, err = client.Backup().SLAPolicy().AssignVirtualMachine(ctx, &clientpkg.BackupAssignVirtualMachineRequest{
 		VirtualMachineIds: []string{instanceId},
 		SLAPolicies:       []string{os.Getenv(PolicyId)},
 	})
+	require.NoError(t, err)
+	_, err = client.Activity().WaitForCompletion(ctx, activityId, nil)
 	require.NoError(t, err)
 
 	vm, err := client.Compute().VirtualMachine().Read(ctx, instanceId)


### PR DESCRIPTION
## What

`TestCompute_UpdateAndPower` in `internal/client/tests/compute_virtual_machine_test.go`
called `client.Backup().SLAPolicy().AssignVirtualMachine(...)` but discarded the
returned activity id and never awaited the activity. This change captures the
activity id and waits for its completion, matching the surrounding pattern:

```go
activityId, err = client.Backup().SLAPolicy().AssignVirtualMachine(ctx, &clientpkg.BackupAssignVirtualMachineRequest{
    VirtualMachineIds: []string{instanceId},
    SLAPolicies:       []string{os.Getenv(PolicyId)},
})
require.NoError(t, err)
_, err = client.Activity().WaitForCompletion(ctx, activityId, nil)
require.NoError(t, err)
```

## Why

Every analogous call site awaits the activity it triggers, and so does the
production code:
- `internal/client/tests/backup_sla_policy_test.go:93`
- `internal/client/tests/compute_network_adapter_test.go:91`
- `internal/provider/resource_compute_virtual_machine.go:1442`

Without the wait, the test moves on before the SLA-policy assignment is
confirmed applied, which can race the subsequent `VirtualMachine().Read`.

This supersedes the SA4006 dead-store discard introduced in 22f2cc5 (#292):
the activity id is now used rather than thrown away, so `staticcheck ./...`
stays clean.

## Scope / risk

- Touches a single acceptance test (`TF_ACC=1`, requires a live Cloud Temple
  platform); it does not run in CI. No state-shape change, no production code
  change.
- `go vet ./...` and `staticcheck ./...` (pinned 2025.1.1) are clean locally.

Refs #264
