### PR TITLE
ci(#293): coverage ratchet for the pure packages (Increment 0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,12 +89,15 @@ jobs:
         # dead stores and suspicious constructs that build/vet miss (#264).
         go run honnef.co/go/tools/cmd/staticcheck@2025.1.1 ./...
 
-    - name: Unit tests (platform-independent packages)
+    - name: Unit tests + coverage ratchet (platform-independent packages)
       run: |
+        # Runs the pure packages under -race with coverage and fails if any
+        # package drops below its recorded floor (scripts/coverage_floor.txt).
         # -race future-proofs the pure packages (token cache, httptest servers,
-        # timers); it is a guard, not state-safety coverage. CGO is available on
-        # the GitHub ubuntu runners.
-        go test -race -count=1 -cover ./internal/client ./internal/provider ./internal/provider/helpers
+        # timers); the ratchet makes "tests where they are missing" a systemic
+        # guard, not a discretionary habit (#264, #293). CGO is available on the
+        # GitHub ubuntu runners.
+        ./scripts/coverage_ratchet.sh
 
   generate:
     runs-on: ubuntu-latest

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -1,0 +1,6 @@
+# Per-package statement-coverage floor (percent) for the pure packages.
+# Raised as coverage improves (scripts/coverage_ratchet.sh --update);
+# CI fails if coverage drops below these values. Never lower by hand.
+internal/client 10.8
+internal/provider 8.5
+internal/provider/helpers 12.9

--- a/scripts/coverage_ratchet.sh
+++ b/scripts/coverage_ratchet.sh
@@ -9,6 +9,10 @@
 # must never be lowered by hand. This makes "add tests where they are missing"
 # a systemic CI guard rather than a discretionary habit (issue #293).
 #
+# A package listed below with NO recorded floor is a FAIL in gate mode (a
+# missing/typo'd floor line must not silently disable the gate); use --update
+# to bootstrap it deliberately.
+#
 # Usage:
 #   scripts/coverage_ratchet.sh            # run + gate (used by CI)
 #   scripts/coverage_ratchet.sh --update   # run + rewrite the floor to current
@@ -24,9 +28,13 @@ PKGS="internal/client internal/provider internal/provider/helpers"
 # Tolerance (percentage points) absorbing float-formatting noise only.
 EPS="0.05"
 
+UPDATE=0
+[[ "${1:-}" == "--update" ]] && UPDATE=1
+
+# Prints the recorded floor for a package, or nothing if absent.
 floor_for() {
-  [[ -f "$FLOOR_FILE" ]] || { echo "0"; return; }
-  awk -v p="$1" '$1==p {print $2; found=1} END {if (!found) print "0"}' "$FLOOR_FILE"
+  [[ -f "$FLOOR_FILE" ]] || return 0
+  awk -v p="$1" '$1==p {print $2}' "$FLOOR_FILE"
 }
 
 fail=0
@@ -44,7 +52,18 @@ for pkg in $PKGS; do
   pct="$(go tool cover -func="$prof" | tail -1 | awk '{print $NF}' | tr -d '%')"
   rm -f "$prof"
   printf '%s %s\n' "$pkg" "$pct" >> "$tmp_floor"
+
   floor="$(floor_for "$pkg")"
+  if [[ -z "$floor" ]]; then
+    if [[ "$UPDATE" -eq 1 ]]; then
+      floor="0"
+    else
+      printf 'RATCHET FAIL  %-32s no recorded floor (bootstrap with --update)\n' "$pkg"
+      fail=1
+      continue
+    fi
+  fi
+
   if awk -v p="$pct" -v f="$floor" -v e="$EPS" 'BEGIN{exit !(p + e < f)}'; then
     printf 'RATCHET FAIL  %-32s %s%% < floor %s%%\n' "$pkg" "$pct" "$floor"
     fail=1
@@ -53,7 +72,7 @@ for pkg in $PKGS; do
   fi
 done
 
-if [[ "${1:-}" == "--update" ]]; then
+if [[ "$UPDATE" -eq 1 ]]; then
   mv "$tmp_floor" "$FLOOR_FILE"
   echo "floor updated -> $FLOOR_FILE"
 else

--- a/scripts/coverage_ratchet.sh
+++ b/scripts/coverage_ratchet.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Coverage ratchet for the platform-independent (pure) packages.
+#
+# Runs the pure-package unit tests under the race detector with coverage and
+# FAILS if any package's statement coverage drops below its recorded floor in
+# scripts/coverage_floor.txt. The floor is raised as the test suite grows
+# (run with --update after coverage improves, then commit the new floor); it
+# must never be lowered by hand. This makes "add tests where they are missing"
+# a systemic CI guard rather than a discretionary habit (issue #293).
+#
+# Usage:
+#   scripts/coverage_ratchet.sh            # run + gate (used by CI)
+#   scripts/coverage_ratchet.sh --update   # run + rewrite the floor to current
+#
+# Portable bash 3.2+ (no associative arrays): macOS and CI behave the same.
+# No live Cloud Temple platform is required: only the pure packages are run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FLOOR_FILE="scripts/coverage_floor.txt"
+PKGS="internal/client internal/provider internal/provider/helpers"
+# Tolerance (percentage points) absorbing float-formatting noise only.
+EPS="0.05"
+
+floor_for() {
+  [[ -f "$FLOOR_FILE" ]] || { echo "0"; return; }
+  awk -v p="$1" '$1==p {print $2; found=1} END {if (!found) print "0"}' "$FLOOR_FILE"
+}
+
+fail=0
+tmp_floor="$(mktemp)"
+{
+  echo "# Per-package statement-coverage floor (percent) for the pure packages."
+  echo "# Raised as coverage improves (scripts/coverage_ratchet.sh --update);"
+  echo "# CI fails if coverage drops below these values. Never lower by hand."
+} > "$tmp_floor"
+
+for pkg in $PKGS; do
+  prof="$(mktemp)"
+  # -covermode=atomic is required together with -race.
+  go test -race -covermode=atomic -coverprofile="$prof" -count=1 "./$pkg"
+  pct="$(go tool cover -func="$prof" | tail -1 | awk '{print $NF}' | tr -d '%')"
+  rm -f "$prof"
+  printf '%s %s\n' "$pkg" "$pct" >> "$tmp_floor"
+  floor="$(floor_for "$pkg")"
+  if awk -v p="$pct" -v f="$floor" -v e="$EPS" 'BEGIN{exit !(p + e < f)}'; then
+    printf 'RATCHET FAIL  %-32s %s%% < floor %s%%\n' "$pkg" "$pct" "$floor"
+    fail=1
+  else
+    printf 'ratchet ok    %-32s %s%% (floor %s%%)\n' "$pkg" "$pct" "$floor"
+  fi
+done
+
+if [[ "${1:-}" == "--update" ]]; then
+  mv "$tmp_floor" "$FLOOR_FILE"
+  echo "floor updated -> $FLOOR_FILE"
+else
+  rm -f "$tmp_floor"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Coverage dropped below the floor. Add tests or, if intentional, justify and re-baseline with --update." >&2
+  exit 1
+fi


### PR DESCRIPTION
## What

Increment 0 of the **S7 test-coverage** program (#293): a coverage ratchet that makes "add tests where they are missing" a **systemic CI guard** instead of a discretionary habit.

- `scripts/coverage_ratchet.sh` runs the pure packages (`internal/client`, `internal/provider`, `internal/provider/helpers`) under `-race` with coverage, and **fails if any package drops below its recorded floor**.
- `scripts/coverage_floor.txt` holds the per-package floor, locked at today's baseline. It is raised via `--update` as the suite grows, and **never lowered by hand**.
- The `unit` CI job now calls the script instead of the bare `go test`.

## Baseline floor (locked)

| Package | Floor |
|---|---|
| `internal/client` | 10.8% |
| `internal/provider` | 8.5% |
| `internal/provider/helpers` | 12.9% |

These rise as the S7 increments land (the in-flight helpers batch will push `helpers` well above 12.9%, after which we re-baseline).

## Non-complacency proof (the ratchet bites)

- Gate mode at the real floor → **passes** (exit 0).
- Floor artificially inflated (`helpers` → 99%) → `RATCHET FAIL … 12.9% < floor 99.0%`, **exit 1**. A ratchet that can't fail would be theater; this one does.

## Safety / scope

- **No production code touched** — only a script, a data file, and the CI wiring.
- Portable bash 3.2+ (no associative arrays) so macOS and the ubuntu CI runner behave identically.
- `-race` requires CGO, available on the GitHub ubuntu runners.

## Local verification

`gofmt -l .` empty · `go vet ./...` clean · `staticcheck ./...` 0 findings · ratchet gate green (10.8 / 8.5 / 12.9 vs floor).

Refs #293