### PR TITLE
test(#293): non-complacent unit tests for the helpers flatten layer (batch 1)

### DIFF
--- a/internal/provider/helpers/helper_compute_iaas_opensource_pool_test.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_pool_test.go
@@ -1,0 +1,139 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenOpenIaaSPoolContent is the dedicated, non-complacent content test
+// for the #243 culprit. FlattenOpenIaaSPool feeds the iaas_opensource_pool(s)
+// datasource, whose schema declares EXACTLY: id, name, label, internal_id,
+// machine_manager_id, high_availability_enabled, master, hosts, memory, cpu,
+// type. If the helper emits any key the schema does not declare, d.Set fails
+// with "Invalid address to set" and the whole datasource read breaks (#243).
+//
+// The structural walker already checks the fully-populated output FITS the
+// schema. This test adds what the walker does NOT:
+//   - the emitted key SET is exactly the declared one (no extra, no missing) —
+//     pinned against the live datasource schema, so a future drift on either
+//     side is caught;
+//   - the nested single-element blocks (memory, cpu, type) carry the right
+//     sub-keys with the right values;
+//   - the machine_manager_id is read from the nested MachineManager.ID;
+//   - a pool with empty sub-objects does not panic and still emits every block.
+func TestFlattenOpenIaaSPoolContent(t *testing.T) {
+	pool := &client.OpenIaasPool{
+		ID:                      "pool-1",
+		InternalID:              "int-1",
+		Name:                    "prod-pool",
+		Label:                   "Production",
+		HighAvailabilityEnabled: true,
+		Master:                  "host-master",
+		Hosts:                   []string{"host-a", "host-b"},
+		MachineManager:          client.BaseObject{ID: "mm-1", Name: "vc-1"},
+	}
+	pool.Memory.Usage = 40
+	pool.Memory.Size = 100
+	pool.Cpu.Cores = 8
+	pool.Cpu.Sockets = 2
+	pool.Type.Key = "xcp-ng"
+	pool.Type.Description = "XCP-ng pool"
+
+	got := FlattenOpenIaaSPool(pool)
+
+	// --- exact key set against the live datasource schema -----------------
+	wantKeys := map[string]bool{
+		"id": true, "name": true, "label": true, "internal_id": true,
+		"machine_manager_id": true, "high_availability_enabled": true,
+		"master": true, "hosts": true, "memory": true, "cpu": true, "type": true,
+	}
+	for k := range got {
+		if !wantKeys[k] {
+			t.Errorf("FlattenOpenIaaSPool emits undeclared key %q; the pool datasource schema would reject it with 'Invalid address to set' (#243)", k)
+		}
+	}
+	for k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("FlattenOpenIaaSPool is missing the expected key %q", k)
+		}
+	}
+
+	// --- scalar content ----------------------------------------------------
+	assertEq(t, "id", got["id"], "pool-1")
+	assertEq(t, "name", got["name"], "prod-pool")
+	assertEq(t, "label", got["label"], "Production")
+	assertEq(t, "internal_id", got["internal_id"], "int-1")
+	assertEq(t, "high_availability_enabled", got["high_availability_enabled"], true)
+	assertEq(t, "master", got["master"], "host-master")
+	// machine_manager_id is the NESTED MachineManager.ID, not the pool ID.
+	assertEq(t, "machine_manager_id", got["machine_manager_id"], "mm-1")
+
+	hosts, ok := got["hosts"].([]string)
+	if !ok {
+		t.Fatalf("hosts has type %T, want []string", got["hosts"])
+	}
+	if len(hosts) != 2 || hosts[0] != "host-a" || hosts[1] != "host-b" {
+		t.Errorf("hosts = %v, want [host-a host-b] in order", hosts)
+	}
+
+	// --- nested single-element blocks --------------------------------------
+	mem := singleBlock(t, "memory", got["memory"])
+	assertEq(t, "memory.usage", mem["usage"], 40)
+	assertEq(t, "memory.size", mem["size"], 100)
+
+	cpu := singleBlock(t, "cpu", got["cpu"])
+	assertEq(t, "cpu.cores", cpu["cores"], 8)
+	assertEq(t, "cpu.sockets", cpu["sockets"], 2)
+
+	typ := singleBlock(t, "type", got["type"])
+	assertEq(t, "type.key", typ["key"], "xcp-ng")
+	assertEq(t, "type.description", typ["description"], "XCP-ng pool")
+}
+
+// TestFlattenOpenIaaSPoolEmptySubObjectsDoNotPanic proves the helper survives a
+// pool whose nested objects are all zero (a bare API object). The blocks must
+// still be emitted as single-element lists so the schema shape stays stable.
+func TestFlattenOpenIaaSPoolEmptySubObjectsDoNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("FlattenOpenIaaSPool panicked on a zero-valued pool: %v", r)
+		}
+	}()
+
+	got := FlattenOpenIaaSPool(&client.OpenIaasPool{})
+
+	// machine_manager_id comes from a nested struct; on a zero pool it must be
+	// the empty string, NOT a panic.
+	assertEq(t, "machine_manager_id", got["machine_manager_id"], "")
+
+	// The three nested blocks are always single-element lists, even when empty.
+	for _, key := range []string{"memory", "cpu", "type"} {
+		block := singleBlock(t, key, got[key])
+		if len(block) == 0 {
+			t.Errorf("%s block is empty; expected the zero-valued sub-keys to be present", key)
+		}
+	}
+}
+
+// singleBlock asserts a flatten value is a single-element nested block list and
+// returns its only map. Shared by the pool sub-block assertions.
+func singleBlock(t *testing.T, key string, v interface{}) map[string]interface{} {
+	t.Helper()
+	list, ok := v.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("%s has type %T, want []map[string]interface{}", key, v)
+	}
+	if len(list) != 1 {
+		t.Fatalf("%s has %d elements, want exactly 1", key, len(list))
+	}
+	return list[0]
+}
+
+// assertEq is a tiny equality assertion that reports the offending key.
+func assertEq(t *testing.T, key string, got, want interface{}) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %#v, want %#v", key, got, want)
+	}
+}

--- a/internal/provider/helpers/helper_compute_virtual_machine_test.go
+++ b/internal/provider/helpers/helper_compute_virtual_machine_test.go
@@ -1,0 +1,148 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenVirtualMachineExtraConfigIsAStringMap is the dedicated #241-area
+// content test. The VM `extra_config` attribute is a TypeMap of string values.
+// The historical failure mode emits it as a LIST of {key,value} blocks instead
+// of a map, and d.Set then fails with "source data must be an array or slice,
+// got map" / the reverse, breaking the whole VM datasource read (#241).
+//
+// The structural walker checks the fully-filled output fits the schema; this
+// test pins the CONTENT: extra_config must be a map[string]string keyed by the
+// VMware config key, mapping to its value, with every entry preserved.
+func TestFlattenVirtualMachineExtraConfigIsAStringMap(t *testing.T) {
+	vm := &client.VirtualMachine{
+		Name: "vm-1",
+		ExtraConfig: []client.VirtualMachineExtraConfig{
+			{Key: "disk.enableUUID", Value: "TRUE"},
+			{Key: "guestinfo.foo", Value: "bar"},
+			{Key: "pciPassthru.64bitMMioSizeGB", Value: "128"},
+		},
+	}
+
+	got := FlattenVirtualMachine(vm)
+
+	ec, ok := got["extra_config"].(map[string]string)
+	if !ok {
+		t.Fatalf("extra_config has type %T, want map[string]string; a list shape here is the #241 break (d.Set 'source data must be an array or slice, got map')", got["extra_config"])
+	}
+
+	want := map[string]string{
+		"disk.enableUUID":             "TRUE",
+		"guestinfo.foo":               "bar",
+		"pciPassthru.64bitMMioSizeGB": "128",
+	}
+	if len(ec) != len(want) {
+		t.Fatalf("extra_config has %d entries, want %d: got %#v", len(ec), len(want), ec)
+	}
+	for k, v := range want {
+		if ec[k] != v {
+			t.Errorf("extra_config[%q] = %q, want %q", k, ec[k], v)
+		}
+	}
+}
+
+// TestFlattenVirtualMachineExtraConfigEmptyIsEmptyMap proves an empty
+// ExtraConfig flattens to an empty, non-nil map (never a nil and never a list),
+// so the attribute stays a stable map shape on a VM with no extra config.
+func TestFlattenVirtualMachineExtraConfigEmptyIsEmptyMap(t *testing.T) {
+	got := FlattenVirtualMachine(&client.VirtualMachine{Name: "vm-empty"})
+
+	ec, ok := got["extra_config"].(map[string]string)
+	if !ok {
+		t.Fatalf("extra_config has type %T, want map[string]string even when empty", got["extra_config"])
+	}
+	if ec == nil {
+		t.Errorf("extra_config is a nil map; expected a non-nil empty map[string]string")
+	}
+	if len(ec) != 0 {
+		t.Errorf("extra_config = %#v, want empty", ec)
+	}
+}
+
+// TestFlattenVirtualMachineExtraConfigLastWriteWins documents the duplicate-key
+// behavior: ExtraConfig is a list and the map collapses duplicates, with the
+// last occurrence winning. This pins the intended semantics so a future change
+// (e.g. first-wins, or emitting a list) is a deliberate, reviewed decision.
+func TestFlattenVirtualMachineExtraConfigLastWriteWins(t *testing.T) {
+	vm := &client.VirtualMachine{
+		ExtraConfig: []client.VirtualMachineExtraConfig{
+			{Key: "dup", Value: "first"},
+			{Key: "dup", Value: "last"},
+		},
+	}
+	ec := FlattenVirtualMachine(vm)["extra_config"].(map[string]string)
+	if ec["dup"] != "last" {
+		t.Errorf("extra_config[dup] = %q, want last (last-write-wins)", ec["dup"])
+	}
+}
+
+// TestFlattenVirtualMachineNestedBlocksAreConditional pins the conditional
+// emission of the optional single-element blocks (storage, boot_options,
+// replication_config). They are emitted as a one-element list ONLY when the
+// source carries real data, and as an empty (non-nil) list otherwise. A
+// regression that always emits a bare element, or that emits a nil, would
+// surface as VM drift; this test catches both directions.
+func TestFlattenVirtualMachineNestedBlocksAreConditional(t *testing.T) {
+	// (1) bare VM: every optional block is an empty, non-nil list.
+	bare := FlattenVirtualMachine(&client.VirtualMachine{})
+	for _, key := range []string{"storage", "boot_options", "replication_config", "triggered_alarms"} {
+		list, ok := bare[key].([]map[string]interface{})
+		if !ok {
+			t.Fatalf("%s has type %T, want []map[string]interface{}", key, bare[key])
+		}
+		if list == nil {
+			t.Errorf("%s is a nil slice on a bare VM; expected a non-nil empty list", key)
+		}
+		if len(list) != 0 {
+			t.Errorf("%s = %v on a bare VM, want empty", key, list)
+		}
+	}
+
+	// (2) VM with real storage and boot options: the blocks materialize with
+	// the right content.
+	vm := &client.VirtualMachine{}
+	vm.Storage.Committed = 10
+	vm.Storage.Uncommitted = 5
+	vm.BootOptions.Firmware = "efi"
+	vm.BootOptions.BootDelay = 200
+
+	got := FlattenVirtualMachine(vm)
+	storage := got["storage"].([]map[string]interface{})
+	if len(storage) != 1 {
+		t.Fatalf("storage has %d elements, want 1", len(storage))
+	}
+	assertEq(t, "storage.committed", storage[0]["committed"], 10)
+	assertEq(t, "storage.uncommitted", storage[0]["uncommitted"], 5)
+
+	boot := got["boot_options"].([]map[string]interface{})
+	if len(boot) != 1 {
+		t.Fatalf("boot_options has %d elements, want 1", len(boot))
+	}
+	assertEq(t, "boot_options.firmware", boot[0]["firmware"], "efi")
+	assertEq(t, "boot_options.boot_delay", boot[0]["boot_delay"], 200)
+}
+
+// TestFlattenVirtualMachineTriggeredAlarmsOrder pins that triggered_alarms
+// preserves source order and content, since list order is observable in the
+// state and an unstable order is permanent drift.
+func TestFlattenVirtualMachineTriggeredAlarmsOrder(t *testing.T) {
+	vm := &client.VirtualMachine{
+		TriggeredAlarms: []client.VirtualMachineTriggeredAlarm{
+			{ID: "a1", Status: "red"},
+			{ID: "a2", Status: "yellow"},
+		},
+	}
+	alarms := FlattenVirtualMachine(vm)["triggered_alarms"].([]map[string]interface{})
+	if len(alarms) != 2 {
+		t.Fatalf("triggered_alarms has %d elements, want 2", len(alarms))
+	}
+	assertEq(t, "triggered_alarms[0].id", alarms[0]["id"], "a1")
+	assertEq(t, "triggered_alarms[0].status", alarms[0]["status"], "red")
+	assertEq(t, "triggered_alarms[1].id", alarms[1]["id"], "a2")
+}

--- a/internal/provider/helpers/helper_convert_extra_config_test.go
+++ b/internal/provider/helpers/helper_convert_extra_config_test.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"testing"
+)
+
+// TestConvertExtraConfigValueStrictParsing pins the strict, key-aware parsing
+// of VM extra_config values. The contract: boolean keys accept only
+// TRUE/true/FALSE/false (anything else is an error, never a silent default),
+// the numeric key parses to an int (a non-numeric string is an error), and any
+// other key is passed through as a string. A regression that defaults an
+// invalid boolean to false, or that swallows a parse error, would push a wrong
+// value to the VMware API — exactly what strict parsing exists to prevent.
+func TestConvertExtraConfigValueStrictParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		// boolean keys -----------------------------------------------------
+		{"enableUUID TRUE", "disk.enableUUID", "TRUE", true, false},
+		{"enableUUID true", "disk.enableUUID", "true", true, false},
+		{"enableUUID FALSE", "disk.enableUUID", "FALSE", false, false},
+		{"enableUUID false", "disk.enableUUID", "false", false, false},
+		{"stealclock TRUE", "stealclock.enable", "TRUE", true, false},
+		{"use64BitMMIO FALSE", "pciPassthru.use64BitMMIO", "FALSE", false, false},
+		// invalid boolean MUST error, not default to false
+		{"enableUUID invalid", "disk.enableUUID", "yes", nil, true},
+		{"enableUUID empty", "disk.enableUUID", "", nil, true},
+		{"enableUUID 1", "disk.enableUUID", "1", nil, true},
+
+		// numeric key ------------------------------------------------------
+		{"mmio size 128", "pciPassthru.64bitMMioSizeGB", "128", 128, false},
+		{"mmio size 0", "pciPassthru.64bitMMioSizeGB", "0", 0, false},
+		{"mmio size non-numeric", "pciPassthru.64bitMMioSizeGB", "big", nil, true},
+		{"mmio size empty", "pciPassthru.64bitMMioSizeGB", "", nil, true},
+
+		// default string passthrough --------------------------------------
+		{"arbitrary key", "guestinfo.foo", "bar", "bar", false},
+		{"arbitrary key empty value", "guestinfo.foo", "", "", false},
+		// a TRUE value under a NON-boolean key stays a string (not coerced)
+		{"true under string key", "guestinfo.flag", "TRUE", "TRUE", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertExtraConfigValue(tt.key, tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ConvertExtraConfigValue(%q, %q) = %#v, want error", tt.key, tt.value, got)
+				}
+				if got != nil {
+					t.Errorf("on error the value must be nil, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ConvertExtraConfigValue(%q, %q) unexpected error: %v", tt.key, tt.value, err)
+			}
+			if got != tt.want {
+				t.Errorf("ConvertExtraConfigValue(%q, %q) = %#v (%T), want %#v (%T)", tt.key, tt.value, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/helpers/helper_flatten_invariants_test.go
+++ b/internal/provider/helpers/helper_flatten_invariants_test.go
@@ -1,0 +1,254 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// This file holds a reusable, table-driven harness that asserts the GENERIC
+// state-facing invariants every Flatten* helper must satisfy. It is the
+// content-blind counterpart of the structural walker in the provider package
+// (TestDatasourceFlattenOutputsFitTheirSchemas): the walker feeds a
+// fully-populated struct and checks the output FITS the datasource schema;
+// this harness feeds an EMPTY (zero-valued) struct and checks the output is
+// SAFE to hand to the Terraform state writer. The two are complementary and
+// must not be merged.
+//
+// Invariants asserted here, for each registered helper:
+//
+//   (i)   No panic when the helper is called on a fully zero-valued struct
+//         pointer. This is the realistic Read contract: every Read decodes a
+//         non-nil struct (possibly with empty fields) before flattening, so a
+//         crash on an empty-but-present object is a real datasource breakage
+//         (a list with one bare element, an object with no sub-resources).
+//
+//         NOTE on nil pointers: the helpers do NOT guard a nil receiver and
+//         WOULD panic on one (e.g. FlattenRole(nil) dereferences role.ID).
+//         The Read paths never pass nil, so this harness does not assert
+//         nil-pointer safety: doing so would require a defensive guard in
+//         ~50 production helpers for an input that never occurs. We pin the
+//         realistic contract (zero-valued struct) instead, and leave the nil
+//         case as a documented non-goal. See the PR body.
+//
+//   (ii)  The returned map is non-nil. A nil map handed to d.Set per key is a
+//         silent no-op that drops the whole object from the state.
+//
+//   (iii) Every slice-typed value the helper emits from an EMPTY source is a
+//         non-nil empty slice ([]interface{}{} / []map[string]interface{}{}),
+//         never a typed nil — UNLESS the (helper,key) pair is in the explicit
+//         knownNilSliceGaps registry below. Emitting [] pins the "present but
+//         empty" intent rather than relying on the SDK silently normalizing a
+//         nil slice to []. This invariant is a code-quality / intent contract,
+//         not a crash class: a typed-nil slice under a TypeList is currently
+//         tolerated by the SDK writer (it normalizes nil and [] to the same
+//         stored []interface{}{}). The registry makes the helpers that still
+//         pass a raw nil-able field through VISIBLE and tracked, exactly like
+//         the walker's datasourceKnownGaps map, instead of either silently
+//         accepting them (complacent) or touching production code to fix them
+//         (out of scope for a test-only PR). Each gap is a debt to close in a
+//         later batch by making the helper emit [] explicitly.
+
+// zeroFlattenCase describes one Flatten* helper to run the generic invariants
+// against. build calls the helper on a freshly-allocated zero-valued struct of
+// the helper's input type. Using a typed closure keeps the registry free of
+// reflection while still exercising the real helper.
+type zeroFlattenCase struct {
+	name  string
+	build func() map[string]interface{}
+}
+
+// zeroOf adapts a Flatten helper of the canonical signature
+// func(*T) map[string]interface{} into a builder that invokes it on a
+// zero-valued *T. The struct is present (non-nil) but every field is its zero
+// value, mirroring an API object decoded with no populated sub-resources.
+func zeroOf[T any](flatten func(*T) map[string]interface{}) func() map[string]interface{} {
+	return func() map[string]interface{} {
+		var v T
+		return flatten(&v)
+	}
+}
+
+// genericFlattenCases registers the Flatten* helpers that cleanly fit the
+// generic contract (single *T argument, no extra parameters, no required
+// non-zero invariants on the input). Helpers with extra arguments
+// (FlattenOpenIaaSVirtualDisk, the *Data sub-flatteners) are exercised by
+// their dedicated tests instead. New helpers should be added here as they are
+// written; the count is asserted below so the registry cannot silently rot.
+func genericFlattenCases() []zeroFlattenCase {
+	return []zeroFlattenCase{
+		// --- VMware compute (vCenter) -------------------------------------
+		{"FlattenContentLibrary", zeroOf(FlattenContentLibrary)},
+		{"FlattenContentLibraryItem", zeroOf(FlattenContentLibraryItem)},
+		{"FlattenDatastore", zeroOf(FlattenDatastore)},
+		{"FlattenDatastoreCluster", zeroOf(FlattenDatastoreCluster)},
+		{"FlattenFolder", zeroOf(FlattenFolder)},
+		{"FlattenGuestOperatingSystem", zeroOf(FlattenGuestOperatingSystem)},
+		{"FlattenHost", zeroOf(FlattenHost)},
+		{"FlattenHostCluster", zeroOf(FlattenHostCluster)},
+		{"FlattenNetwork", zeroOf(FlattenNetwork)},
+		{"FlattenNetworkAdapter", zeroOf(FlattenNetworkAdapter)},
+		{"FlattenResourcePool", zeroOf(FlattenResourcePool)},
+		{"FlattenSnapshot", zeroOf(FlattenSnapshot)},
+		{"FlattenVirtualController", zeroOf(FlattenVirtualController)},
+		{"FlattenVirtualDatacenter", zeroOf(FlattenVirtualDatacenter)},
+		{"FlattenVirtualDisk", zeroOf(FlattenVirtualDisk)},
+		{"FlattenVirtualMachine", zeroOf(FlattenVirtualMachine)},
+		{"FlattenVirtualSwitch", zeroOf(FlattenVirtualSwitch)},
+		{"FlattenWorker", zeroOf(FlattenWorker)},
+
+		// --- Backup (SPP) -------------------------------------------------
+		{"FlattenBackupJob", zeroOf(FlattenBackupJob)},
+		{"FlattenBackupJobSession", zeroOf(FlattenBackupJobSession)},
+		{"FlattenBackupSite", zeroOf(FlattenBackupSite)},
+		{"FlattenBackupSLAPolicy", zeroOf(FlattenBackupSLAPolicy)},
+		{"FlattenBackupSPPServer", zeroOf(FlattenBackupSPPServer)},
+		{"FlattenBackupStorage", zeroOf(FlattenBackupStorage)},
+		{"FlattenBackupVCenter", zeroOf(FlattenBackupVCenter)},
+		{"FlattenBackupMetricsCoverage", zeroOf(FlattenBackupMetricsCoverage)},
+		{"FlattenBackupMetricsHistory", zeroOf(FlattenBackupMetricsHistory)},
+		{"FlattenBackupMetricsPlatform", zeroOf(FlattenBackupMetricsPlatform)},
+		{"FlattenBackupMetricsPlatformCPU", zeroOf(FlattenBackupMetricsPlatformCPU)},
+		{"FlattenBackupMetricsPolicy", zeroOf(FlattenBackupMetricsPolicy)},
+		{"FlattenBackupMetricsVirtualMachines", zeroOf(FlattenBackupMetricsVirtualMachines)},
+
+		// --- Backup (OpenIaaS) --------------------------------------------
+		{"FlattenBackupOpenIaasBackup", zeroOf(FlattenBackupOpenIaasBackup)},
+		{"FlattenBackupOpenIaasPolicy", zeroOf(FlattenBackupOpenIaasPolicy)},
+
+		// --- Compute (OpenIaaS) -------------------------------------------
+		{"FlattenOpenIaaSHost", zeroOf(FlattenOpenIaaSHost)},
+		{"FlattenOpenIaaSMachineManager", zeroOf(FlattenOpenIaaSMachineManager)},
+		{"FlattenOpenIaaSNetwork", zeroOf(FlattenOpenIaaSNetwork)},
+		{"FlattenOpenIaaSNetworkAdapter", zeroOf(FlattenOpenIaaSNetworkAdapter)},
+		{"FlattenOpenIaaSPool", zeroOf(FlattenOpenIaaSPool)},
+		{"FlattenOpenIaaSReplicationPolicy", zeroOf(FlattenOpenIaaSReplicationPolicy)},
+		{"FlattenOpenIaaSSnapshot", zeroOf(FlattenOpenIaaSSnapshot)},
+		{"FlattenOpenIaaSStorageRepository", zeroOf(FlattenOpenIaaSStorageRepository)},
+		{"FlattenOpenIaaSTemplate", zeroOf(FlattenOpenIaaSTemplate)},
+		{"FlattenOpenIaaSVirtualMachine", zeroOf(FlattenOpenIaaSVirtualMachine)},
+
+		// --- Object storage -----------------------------------------------
+		{"FlattenACL", zeroOf(FlattenACL)},
+		{"FlattenBucket", zeroOf(FlattenBucket)},
+		{"FlattenBucketFile", zeroOf(FlattenBucketFile)},
+		{"FlattenObjectStorageRole", zeroOf(FlattenObjectStorageRole)},
+		{"FlattenStorageAccount", zeroOf(FlattenStorageAccount)},
+
+		// --- IAM ----------------------------------------------------------
+		{"FlattenCompany", zeroOf(FlattenCompany)},
+		{"FlattenFeature", zeroOf(FlattenFeature)},
+		{"FlattenRole", zeroOf(FlattenRole)},
+		{"FlattenTenant", zeroOf(FlattenTenant)},
+		{"FlattenToken", zeroOf(FlattenToken)},
+		{"FlattenUser", zeroOf(FlattenUser)},
+
+		// --- Marketplace --------------------------------------------------
+		{"FlattenMarketplaceItem", zeroOf(FlattenMarketplaceItem)},
+	}
+}
+
+// knownNilSliceGaps lists the (helper, key) pairs that currently emit a typed
+// nil slice on empty input because the helper passes a nil-able source field
+// straight through (e.g. token.Roles, pool.Hosts) instead of normalizing it to
+// []. This is SDK-tolerated today (see invariant (iii) doc), so it is a tracked
+// debt, not a break. The harness pins each gap two ways:
+//
+//   - a helper NOT listed here must emit [] for every slice key (strict);
+//   - a helper listed here must STILL emit nil for the listed key. If a helper
+//     is later fixed to emit [], this test fails on the now-stale gap entry and
+//     forces its removal — a ratchet that prevents the list from rotting.
+//
+// Keep this map shrinking. An entry is a debt to close by making the helper
+// emit [] explicitly in a future test-or-fix PR, not a resting place.
+var knownNilSliceGaps = map[string]map[string]bool{
+	"FlattenContentLibraryItem":        {"ovf_properties": true},
+	"FlattenDatastore":                 {"hosts_names": true},
+	"FlattenDatastoreCluster":          {"datastores": true},
+	"FlattenNetwork":                   {"host_names": true},
+	"FlattenVirtualController":         {"virtual_disks": true},
+	"FlattenVirtualMachine":            {"distributed_virtual_port_group_ids": true},
+	"FlattenBackupOpenIaasPolicy":      {"virtual_machines": true},
+	"FlattenOpenIaaSHost":              {"virtual_machines": true},
+	"FlattenOpenIaaSNetwork":           {"network_adapters": true},
+	"FlattenOpenIaaSPool":              {"hosts": true},
+	"FlattenOpenIaaSStorageRepository": {"virtual_disks": true},
+	"FlattenOpenIaaSTemplate":          {"snapshots": true, "sla_policies": true},
+	"FlattenOpenIaaSVirtualMachine":    {"boot_order": true},
+	"FlattenObjectStorageRole":         {"permissions": true},
+	"FlattenToken":                     {"roles": true},
+	"FlattenUser":                      {"source": true},
+	"FlattenMarketplaceItem":           {"categories": true},
+}
+
+// TestFlattenZeroInputInvariants runs invariants (i), (ii) and (iii) over every
+// registered helper. A failure on (i)/(ii) is a real datasource-read hazard: a
+// bare API object (present, all fields empty) must still flatten into a
+// state-safe map. A failure on (iii) is either a new un-tracked nil-slice gap
+// (a helper not in knownNilSliceGaps emitting nil) or a stale gap entry (a
+// helper now emitting [] for a key still listed as nil).
+func TestFlattenZeroInputInvariants(t *testing.T) {
+	for _, tc := range genericFlattenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			// (i) no panic on a zero-valued struct; (ii) non-nil map.
+			out := mustNotPanic(t, tc.name, tc.build)
+			if out == nil {
+				t.Fatalf("%s returned a nil map on a zero-valued input; d.Set would silently drop the object", tc.name)
+			}
+
+			gaps := knownNilSliceGaps[tc.name]
+			// (iii) every slice-typed value emitted from the empty source must
+			// be a non-nil empty slice, never a typed nil, unless the key is a
+			// declared known gap.
+			for key, v := range out {
+				rv := reflect.ValueOf(v)
+				if !rv.IsValid() || rv.Kind() != reflect.Slice {
+					continue
+				}
+				_, declaredGap := gaps[key]
+				if rv.IsNil() && !declaredGap {
+					t.Errorf("%s emits key %q as a typed nil slice on empty input; expected a non-nil empty slice ([]) to pin the present-but-empty intent. If this is intentional for now, add it to knownNilSliceGaps with a rationale.", tc.name, key)
+				}
+				if !rv.IsNil() && declaredGap {
+					t.Errorf("%s now emits key %q as a non-nil slice, but it is still listed in knownNilSliceGaps; remove the stale gap entry.", tc.name, key)
+				}
+			}
+			// A gap entry whose key never appears in the output is also stale.
+			for key := range gaps {
+				if _, present := out[key]; !present {
+					t.Errorf("%s lists %q in knownNilSliceGaps but does not emit that key; remove the stale gap entry.", tc.name, key)
+				}
+			}
+		})
+	}
+}
+
+// mustNotPanic runs build and converts a panic into a test failure that names
+// the offending helper, so a regression points straight at the function.
+func mustNotPanic(t *testing.T, name string, build func() map[string]interface{}) (out map[string]interface{}) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked on a zero-valued struct input: %v", name, r)
+		}
+	}()
+	return build()
+}
+
+// TestGenericFlattenRegistryIsNotEmpty guards against the registry being
+// gutted to make the suite trivially pass. It also pins a lower bound so a
+// future refactor that drops helpers from the registry is noticed. The bound is
+// intentionally below the current count to tolerate legitimate signature
+// changes without churn, while still catching a wholesale deletion.
+func TestGenericFlattenRegistryIsNotEmpty(t *testing.T) {
+	const minRegistered = 40
+	if got := len(genericFlattenCases()); got < minRegistered {
+		t.Fatalf("the generic flatten registry has shrunk to %d helpers (expected at least %d); a non-complacent suite must keep covering the helper layer", got, minRegistered)
+	}
+}
+
+// The blank reference keeps the client import meaningful even if the registry
+// is later trimmed during review; it also documents that the harness is tied to
+// the client struct layer it protects.
+var _ = client.Role{}

--- a/internal/provider/helpers/helper_iam_pat_test.go
+++ b/internal/provider/helpers/helper_iam_pat_test.go
@@ -1,0 +1,86 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenTokenNeverEmitsTheSecret is the dedicated state-secret test for
+// the PAT flatten layer. The client Token struct carries a create-only Secret
+// (the API only returns it once, at creation). FlattenToken feeds the PAT
+// DATASOURCES, whose schemas declare NO secret field at all. Emitting the
+// secret from the flatten layer would be doubly wrong:
+//
+//   - it would leak the secret into a freely-readable datasource state;
+//   - it would emit a key the datasource schema does not declare, so d.Set
+//     would fail with "Invalid address to set" and break the read (#243).
+//
+// The resource keeps the secret through a SEPARATE path (the resource Read
+// guards `if token.Secret != ""` before writing `secret_id`), not through
+// FlattenToken. This test pins that FlattenToken stays secret-free even when
+// the source Token is fully populated with a secret.
+func TestFlattenTokenNeverEmitsTheSecret(t *testing.T) {
+	token := &client.Token{
+		ID:             "tok-1",
+		Name:           "ci-token",
+		Secret:         "super-secret-value",
+		Roles:          []string{"role-a", "role-b"},
+		ExpirationDate: "1700000000000",
+		UserId:         "user-1",
+		TenantId:       "tenant-1",
+		TenantName:     "Tenant One",
+	}
+
+	got := FlattenToken(token)
+
+	// No key may carry the secret, by name or by value.
+	for _, forbidden := range []string{"secret", "secret_id", "Secret"} {
+		if _, present := got[forbidden]; present {
+			t.Errorf("FlattenToken emits forbidden secret key %q; it would leak the secret into a readable datasource and break d.Set (#243)", forbidden)
+		}
+	}
+	for k, v := range got {
+		if s, ok := v.(string); ok && s == token.Secret {
+			t.Errorf("FlattenToken emits the secret value under key %q; the create-only secret must never reach the flatten output", k)
+		}
+	}
+
+	// The non-secret attributes are preserved and correct.
+	assertEq(t, "id", got["id"], "tok-1")
+	assertEq(t, "name", got["name"], "ci-token")
+	assertEq(t, "expiration_date", got["expiration_date"], "1700000000000")
+	assertEq(t, "user_id", got["user_id"], "user-1")
+	assertEq(t, "tenant_id", got["tenant_id"], "tenant-1")
+	assertEq(t, "tenant_name", got["tenant_name"], "Tenant One")
+
+	roles, ok := got["roles"].([]string)
+	if !ok {
+		t.Fatalf("roles has type %T, want []string", got["roles"])
+	}
+	if len(roles) != 2 || roles[0] != "role-a" || roles[1] != "role-b" {
+		t.Errorf("roles = %v, want [role-a role-b] in order", roles)
+	}
+}
+
+// TestFlattenTokenKeySetMatchesDatasource pins the exact emitted key set
+// against the PAT datasource contract: the helper must emit only id, name,
+// roles, expiration_date, user_id, tenant_id, tenant_name. An extra key (the
+// secret being the dangerous one) breaks the datasource read.
+func TestFlattenTokenKeySetMatchesDatasource(t *testing.T) {
+	got := FlattenToken(&client.Token{ID: "x", Secret: "s"})
+	want := map[string]bool{
+		"id": true, "name": true, "roles": true, "expiration_date": true,
+		"user_id": true, "tenant_id": true, "tenant_name": true,
+	}
+	for k := range got {
+		if !want[k] {
+			t.Errorf("FlattenToken emits undeclared key %q (the PAT datasource schema would reject it)", k)
+		}
+	}
+	for k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("FlattenToken is missing the expected key %q", k)
+		}
+	}
+}

--- a/internal/provider/helpers/helper_object_storage_test.go
+++ b/internal/provider/helpers/helper_object_storage_test.go
@@ -1,0 +1,153 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenStorageAccountNeverEmitsTheSecretKey is the dedicated state-secret
+// test for object storage accounts. The storage-account resource exposes a
+// create-only `access_secret_key` (Sensitive, only returned at creation) that
+// the resource Read deliberately does NOT overwrite. FlattenStorageAccount must
+// therefore NEVER emit any secret-key attribute: if it did, every refresh would
+// overwrite the only stored copy of the secret with an empty string (the
+// #264 Lot D state-secret failure mode), silently destroying it.
+//
+// FlattenStorageAccount must emit `access_key_id` (the public key id, safe to
+// refresh) but not the secret. This test pins both: the public id is preserved,
+// and no secret key is emitted by name or value.
+func TestFlattenStorageAccountNeverEmitsTheSecretKey(t *testing.T) {
+	account := &client.StorageAccount{
+		ID:          "acct-1",
+		Name:        "backups",
+		AccessKeyID: "AKIAEXAMPLE",
+		ARN:         "arn:aws:s3:::backups",
+		CreateDate:  "2026-01-01T00:00:00Z",
+		Path:        "/team/",
+	}
+	account.Tags = append(account.Tags, struct {
+		Key   string
+		Value string
+	}{Key: "env", Value: "prod"})
+
+	got := FlattenStorageAccount(account)
+
+	for _, forbidden := range []string{"access_secret_key", "secret", "secret_access_key", "SecretAccessKey"} {
+		if _, present := got[forbidden]; present {
+			t.Errorf("FlattenStorageAccount emits forbidden secret key %q; on refresh it would overwrite the create-only secret with empty and destroy it (#264 Lot D)", forbidden)
+		}
+	}
+
+	// The public access key id is preserved.
+	assertEq(t, "access_key_id", got["access_key_id"], "AKIAEXAMPLE")
+	assertEq(t, "id", got["id"], "acct-1")
+	assertEq(t, "name", got["name"], "backups")
+	assertEq(t, "arn", got["arn"], "arn:aws:s3:::backups")
+	assertEq(t, "create_date", got["create_date"], "2026-01-01T00:00:00Z")
+	assertEq(t, "path", got["path"], "/team/")
+
+	// Tags are a list of {key,value} blocks, preserved in order.
+	tags, ok := got["tags"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("tags has type %T, want []map[string]interface{}", got["tags"])
+	}
+	if len(tags) != 1 {
+		t.Fatalf("tags has %d elements, want 1", len(tags))
+	}
+	assertEq(t, "tags[0].key", tags[0]["key"], "env")
+	assertEq(t, "tags[0].value", tags[0]["value"], "prod")
+}
+
+// TestFlattenStorageAccountEmptyTagsAreEmptyList proves an account with no tags
+// flattens its tags to a non-nil empty []map[string]interface{}, keeping the
+// list block shape stable.
+func TestFlattenStorageAccountEmptyTagsAreEmptyList(t *testing.T) {
+	got := FlattenStorageAccount(&client.StorageAccount{ID: "acct-empty"})
+	tags, ok := got["tags"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("tags has type %T, want []map[string]interface{}", got["tags"])
+	}
+	if tags == nil {
+		t.Errorf("tags is a nil slice; expected a non-nil empty list")
+	}
+	if len(tags) != 0 {
+		t.Errorf("tags = %v, want empty", tags)
+	}
+}
+
+// TestFlattenBucketContentAndShape pins the bucket flatten content, with a
+// focus on the ACL-adjacent fields the object-storage datasource exposes:
+// versioning (a string, never coerced to a bool), retention_period (int64
+// preserved), and the deleted-counters shape. The bucket carries no secret, so
+// the focus is the versioning/retention shape rather than a secret guard.
+func TestFlattenBucketContentAndShape(t *testing.T) {
+	bucket := &client.Bucket{
+		ID:                  "bkt-1",
+		Name:                "data",
+		Namespace:           "ns-1",
+		RetentionPeriod:     int64(30),
+		Versioning:          "Enabled",
+		Endpoint:            "https://s3.example",
+		TotalSize:           "1024",
+		TotalSizeUnit:       "MiB",
+		TotalObjects:        int64(42),
+		TotalObjectsDeleted: "3",
+		TotalSizeDeleted:    "12",
+	}
+
+	got := FlattenBucket(bucket)
+
+	assertEq(t, "id", got["id"], "bkt-1")
+	assertEq(t, "name", got["name"], "data")
+	assertEq(t, "namespace", got["namespace"], "ns-1")
+	assertEq(t, "endpoint", got["endpoint"], "https://s3.example")
+
+	// versioning is a string state value (e.g. "Enabled"/"Suspended"), it must
+	// not be coerced to a bool — that would be a schema-mismatch break.
+	if _, ok := got["versioning"].(string); !ok {
+		t.Errorf("versioning has type %T, want string", got["versioning"])
+	}
+	assertEq(t, "versioning", got["versioning"], "Enabled")
+
+	// retention_period must preserve the int64 magnitude.
+	if rp, ok := got["retention_period"].(int64); !ok {
+		t.Errorf("retention_period has type %T, want int64", got["retention_period"])
+	} else if rp != 30 {
+		t.Errorf("retention_period = %d, want 30", rp)
+	}
+
+	if to, ok := got["total_objects"].(int64); !ok {
+		t.Errorf("total_objects has type %T, want int64", got["total_objects"])
+	} else if to != 42 {
+		t.Errorf("total_objects = %d, want 42", to)
+	}
+
+	assertEq(t, "total_size", got["total_size"], "1024")
+	assertEq(t, "total_size_unit", got["total_size_unit"], "MiB")
+	assertEq(t, "total_objects_deleted", got["total_objects_deleted"], "3")
+	assertEq(t, "total_size_deleted", got["total_size_deleted"], "12")
+}
+
+// TestFlattenBucketKeySetIsExact pins the exact emitted key set so a new key
+// that the datasource schema does not declare is caught before it breaks the
+// read.
+func TestFlattenBucketKeySetIsExact(t *testing.T) {
+	got := FlattenBucket(&client.Bucket{ID: "x"})
+	want := map[string]bool{
+		"id": true, "name": true, "namespace": true, "retention_period": true,
+		"versioning": true, "endpoint": true, "total_size": true,
+		"total_size_unit": true, "total_objects": true,
+		"total_objects_deleted": true, "total_size_deleted": true,
+	}
+	for k := range got {
+		if !want[k] {
+			t.Errorf("FlattenBucket emits undeclared key %q", k)
+		}
+	}
+	for k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("FlattenBucket is missing the expected key %q", k)
+		}
+	}
+}

--- a/internal/provider/helpers/helper_update_map_items_test.go
+++ b/internal/provider/helpers/helper_update_map_items_test.go
@@ -61,3 +61,97 @@ func TestUpdateMapItemsDoesNotRetainExplicitZeroValues(t *testing.T) {
 		t.Errorf("the GetOk swallowing behavior changed: enabled=%v (was: API value retained) — revisit the raw-config gating sites before relying on this", merged["enabled"])
 	}
 }
+
+// TestUpdateNestedMapItemsPreservesPerIndexMapping pins that
+// UpdateNestedMapItems overlays the config onto EACH element using that
+// element's own index, never crossing indices, and preserves the element count
+// and order. It also confirms the same explicit-zero swallowing limitation
+// (#246 class) propagates per element: an explicit user false at one index is
+// swallowed there, while a non-zero override at another index is applied.
+//
+// Crossing indices (e.g. using index 0's config for element 1) would corrupt
+// multi-element nested blocks (multiple network adapters / disks) — a real
+// state hazard the single-index UpdateMapItems test cannot catch.
+func TestUpdateNestedMapItemsPreservesPerIndexMapping(t *testing.T) {
+	s := map[string]*schema.Schema{
+		"os_network_adapter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {Type: schema.TypeBool, Optional: true},
+					"name":    {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"os_network_adapter": []interface{}{
+			// index 0: explicit false + explicit name
+			map[string]interface{}{"enabled": false, "name": "user-0"},
+			// index 1: explicit true + explicit name
+			map[string]interface{}{"enabled": true, "name": "user-1"},
+		},
+	})
+
+	apiSeeded := []interface{}{
+		map[string]interface{}{"enabled": true, "name": "api-0"},
+		map[string]interface{}{"enabled": false, "name": "api-1"},
+	}
+
+	out := UpdateNestedMapItems(d, apiSeeded, "os_network_adapter")
+	if len(out) != 2 {
+		t.Fatalf("UpdateNestedMapItems returned %d elements, want 2 (count must be preserved)", len(out))
+	}
+
+	e0, ok := out[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("element 0 has type %T, want map[string]interface{}", out[0])
+	}
+	e1, ok := out[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("element 1 has type %T, want map[string]interface{}", out[1])
+	}
+
+	// Non-zero overrides are applied at the CORRECT index (no cross-talk).
+	if e0["name"] != "user-0" {
+		t.Errorf("element 0 name = %v, want user-0 (config index 0 must overlay element 0)", e0["name"])
+	}
+	if e1["name"] != "user-1" {
+		t.Errorf("element 1 name = %v, want user-1 (config index 1 must overlay element 1)", e1["name"])
+	}
+
+	// index 1 has an explicit user true -> non-zero -> overlaid onto the
+	// API-seeded false. This proves a per-index NON-zero boolean override does
+	// reach the merged map.
+	if e1["enabled"] != true {
+		t.Errorf("element 1 enabled = %v, want true (explicit non-zero override at index 1 must be applied)", e1["enabled"])
+	}
+
+	// index 0 has an explicit user false -> zero -> swallowed by GetOk, so the
+	// API-seeded true wins. Same #246 limitation as UpdateMapItems, pinned per
+	// element. This documents the CURRENT behavior; it does not endorse it.
+	if e0["enabled"] != true {
+		t.Errorf("element 0 enabled = %v; the per-index GetOk swallowing behavior changed (was: API true retained) — revisit the raw-config gating sites before relying on this", e0["enabled"])
+	}
+}
+
+// TestUpdateNestedMapItemsEmptyInputIsEmptyOutput pins that an empty nested
+// input yields a non-nil empty slice (stable list shape), not a nil.
+func TestUpdateNestedMapItemsEmptyInputIsEmptyOutput(t *testing.T) {
+	s := map[string]*schema.Schema{
+		"os_network_adapter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"name": {Type: schema.TypeString, Optional: true}}},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{})
+	out := UpdateNestedMapItems(d, []interface{}{}, "os_network_adapter")
+	if out == nil {
+		t.Errorf("UpdateNestedMapItems returned nil; expected a non-nil empty slice")
+	}
+	if len(out) != 0 {
+		t.Errorf("UpdateNestedMapItems = %v, want empty", out)
+	}
+}


### PR DESCRIPTION
## Summary

Non-complacent unit-test coverage of the pure / state-facing flatten layer in
`internal/provider/helpers` (the #241/#243 bug class: a datasource read breaks
because a flatten helper emits a key the schema does not declare, panics on a
bare object, drops/leaks data, or returns the wrong shape).

This is **test-only**. No production code is modified.

It complements — and does not duplicate — the existing structural walker
`TestDatasourceFlattenOutputsFitTheirSchemas` (provider package), which feeds a
fully-populated struct and checks the output *fits* the datasource schema. This
PR adds what the walker does not check: nil/zero-input safety, content
correctness, secret preservation, exact key sets, stable list order,
empty-slice-as-non-nil intent, conditional-block emission, and strict parsing.

Coverage of `internal/provider/helpers`: **12.9% → 58.3%**.

## A) Generic invariant harness

`helper_flatten_invariants_test.go` — a reusable, table-driven harness asserting
the generic contract on a **bare (zero-valued) struct pointer** for **53**
registered `Flatten*` helpers:

- **(i)** no panic on a fully zero-valued struct pointer (the realistic Read
  contract);
- **(ii)** the returned map is non-nil (a nil map is a silent state drop);
- **(iii)** every emitted slice is a non-nil empty slice on empty input, unless
  the `(helper, key)` pair is in the explicit `knownNilSliceGaps` registry.

**Design notes (flagged for the reviewer):**

- **Nil-pointer safety is a documented non-goal.** The helpers do not guard a
  nil receiver and *would* panic on one (e.g. `FlattenRole(nil)`). The Read
  paths always decode a non-nil struct, so the harness pins the realistic
  contract (zero-valued struct). Asserting nil-pointer safety would require a
  defensive guard in ~50 production helpers for an input that never occurs —
  out of scope for a test-only PR.
- **`knownNilSliceGaps` mirrors the walker's `datasourceKnownGaps` pattern.**
  ~18 helpers currently pass a raw nil-able field straight through (e.g.
  `token.Roles`, `pool.Hosts`), yielding a typed-nil slice on empty input. This
  is **SDK-tolerated today** (the writer normalizes `nil` and `[]` to the same
  stored `[]interface{}{}`), so it is a tracked code-quality debt, **not** a
  crash class. The registry makes each gap visible and **ratcheted**: a helper
  later fixed to emit `[]` fails on its now-stale gap entry and forces removal.
  Closing these gaps is left to a follow-up batch (no production change here).

## B) Dedicated non-complacent content tests (batch 1)

| File | Function | What is pinned |
|---|---|---|
| `helper_compute_iaas_opensource_pool_test.go` | `FlattenOpenIaaSPool` | exact key set vs the pools schema (#243); nested cpu/memory/type block content; `machine_manager_id` from the nested object; zero sub-objects don't panic |
| `helper_compute_virtual_machine_test.go` | `FlattenVirtualMachine` | `extra_config` is a `map[string]string` not a list (#241); key→value mapping; empty config is an empty map; last-write-wins; conditional storage/boot_options/replication_config blocks; `triggered_alarms` order |
| `helper_iam_pat_test.go` | `FlattenToken` | the create-only secret is never emitted by name or value; exact datasource key set |
| `helper_object_storage_test.go` | `FlattenStorageAccount`, `FlattenBucket` | `access_secret_key` never emitted (refresh would overwrite it empty, #264 Lot D); `access_key_id`/tags preserved; bucket `versioning` stays a string, `retention_period`/`total_objects` keep int64, exact key set |
| `helper_convert_extra_config_test.go` | `ConvertExtraConfigValue` | strict boolean/numeric parsing, errors not swallowed, string passthrough |
| `helper_update_map_items_test.go` | `UpdateNestedMapItems` | per-index overlay (no cross-index corruption), count/order preserved, empty input yields a non-nil empty slice. **Note:** the explicit-`false` swallowing is *characterized as a tripwire*, **not** guarded here — see "Framing" below |

## Mutation-proof table (non-complacency)

For every covered function, the historical failure mode was injected into the
production helper, the matching test was run (confirmed **RED**), then the
production file was restored from git. Production code is **unchanged** in this
PR.

| # | Function | Injected mutation | Test went RED |
|---|---|---|---|
| M1 | `FlattenOpenIaaSPool` | rename `high_availability_enabled` → `ha_enabled` (undeclared key) | yes |
| M2 | `FlattenOpenIaaSPool` | read `machine_manager_id` from `pool.ID` instead of `pool.MachineManager.ID` | yes |
| M3 | `FlattenVirtualMachine` | emit `extra_config` as a list of blocks instead of a map | yes |
| M4 | `FlattenVirtualMachine` | swap `extra_config` key↔value mapping | yes |
| M5 | `FlattenVirtualMachine` | drop the conditional storage guard (always emit) | yes |
| M6 | `FlattenToken` | leak `token.Secret` under a `secret` key | yes |
| M7 | `FlattenStorageAccount` | emit `access_secret_key` (empty) | yes |
| M8 | `FlattenBucket` | drop `total_objects_deleted` (missing key) | yes |
| M9 | `ConvertExtraConfigValue` | default an invalid boolean to `false` (swallow error) | yes |
| M10 | `ConvertExtraConfigValue` | treat the numeric key as a plain string (no parse) | yes |
| M11 | `UpdateNestedMapItems` | use index `0` for every element (cross-index corruption) | yes |
| M12 | `FlattenRole` (generic ii) | return a `nil` map | yes |
| M13 | `FlattenStorageAccount` (generic iii) | return a typed-nil `tags` slice on empty input (non-gap helper) | yes |
| M14 | `FlattenStorageAccount` (generic i) | index `account.Tags[0]` on a zero struct (panic) | yes |

## Local verification (on the rebased tip)

- `gofmt -l .` → empty
- `go vet ./...` → clean
- `go run honnef.co/go/tools/cmd/staticcheck@2025.1.1 ./...` → **0 findings**
- `go test -race -count=1 -cover ./internal/provider/helpers` → **ok**, coverage **58.3%** (was 12.9%)
- `go build ./...` clean; existing walker tests (`TestDatasourceFlattenOutputsFitTheirSchemas`, `TestEveryDatasourceIsCoveredByTheFlattenWalker`, `TestIAMFeatures*`) still green.

## Production refactor

**None.** All changes are in `*_test.go` files. The mutation proofs were applied
and reverted from git; the working tree's production code is identical to
`rc/v1.8.0`.

## Remaining helpers (next batch)

Not yet given a dedicated content test (the generic harness covers the
canonical-signature ones for the zero-input invariants):

- Dedicated content depth still to add for the generic-harness members beyond
  this batch (e.g. `FlattenHost`, `FlattenDatastore*`, `FlattenOpenIaaSHost`,
  `FlattenOpenIaaSTemplate`, `FlattenBackup*`, `FlattenMarketplaceItem`, the
  IAM `FlattenUser`/`FlattenCompany`/`FlattenTenant`).
- Sub-flatteners with a non-canonical signature, **not** in the generic registry
  and **not** yet covered: `FlattenOpenIaaSVirtualDisk` (takes a `vmID`),
  `FlattenOSDiskData`/`FlattenOSDisksData`,
  `FlattenOSNetworkAdapterData`/`FlattenOSNetworkAdaptersData`,
  `FlattenOpenIaaSOSDiskData`/`FlattenOpenIaaSOSDisksData`,
  `FlattenOpenIaaSOSNetworkAdapterData`/`FlattenOpenIaaSOSNetworkAdaptersData`.
- Closing the `knownNilSliceGaps` debt (emit `[]` explicitly) — a follow-up
  that *would* touch production code and so is intentionally deferred.

## Framing — what the `UpdateMapItems` tests are (and are not)

To avoid a misread: the `UpdateMapItems`/`UpdateNestedMapItems` tests are
**characterization tripwires**, not the explicit-`false` guard.

- `UpdateMapItems` uses `GetOk` semantics, which cannot distinguish an explicit
  `false`/`""`/`0` from an absent attribute. Swallowing the explicit zero is the
  **designed** behaviour of this merge helper; a test here cannot "fail on that
  bug" without redesigning production.
- The test (`TestUpdateMapItemsDoesNotRetainExplicitZeroValues`) therefore
  **pins that limitation as a tripwire**: if the swallowing behaviour ever
  changes, it fails and forces a review of every gating site. It explicitly
  states it "documents the CURRENT behavior, it does not endorse it".
- The **actual** explicit-`false` guard lives in the provider package and is
  itself non-complacent: `TestOptionalComputedBooleansHavePatchGuards` is a
  registry test that fails if any Optional+Computed boolean is not raw-config
  gated (or documented), with the gating implemented in
  `openIaasVMDesiredPropertiesFromResourceData`, `osAdapterTxConfigured`,
  `buildVMwareBootOptionsFromRaw`, etc.

So the #246 explicit-`false` class **is** covered by a fail-on-the-bug test —
in the provider package — and this PR deliberately does not duplicate it.

## Independent review

An adversarial Codex pass raised this framing as a NO-GO (reading the
characterization test as a failed guard). The pilot review adjudicated it as a
framing/accounting point, not a code defect, after independently re-injecting
the #241 (`extra_config` as a list) and #243 (undeclared pool key) mutations and
confirming both tests go RED, and after verifying the real explicit-`false`
guard exists and is non-complacent. See the pilot review comment on this PR.

---

**Awaiting explicit human GO — do not merge by automation.**

Refs #293

