### PR TITLE
test(#298): schema golden gate freezing the state contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ MISCELLANEOUS :
   * The datasource schema-vs-flatten CI validation now covers every datasource. It is driven by a reflection-based non-zero object filler and a coverage registry checked against the provider's datasource map: a newly added datasource must be either covered or explicitly listed as a known gap, so the read-breaking class behind #241/#243 cannot silently regain ground.
   * Refreshed the repository README (build requirements, Terraform Registry links, usage example).
   * Removed a broken CI workflow left over from the provider template.
+  * Added a schema golden gate: a committed, deterministic snapshot of the full declared provider schema contract (every resource and datasource, recursively into nested blocks: types, `Required`/`Optional`/`Computed`/`ForceNew`/`Sensitive`, `MinItems`/`MaxItems`/`ConfigMode`, primitive `Default` values, the presence of state/normalization functions and validators, plan constraints, the explicit `Elem` kind, `SchemaVersion`, `StateUpgrader` versions and types, and `CustomizeDiff` presence) checked by a CI test that fails on any divergence. Any change to the contract that an existing client's Terraform state depends on must be seen and explicitly justified by a human before the golden is regenerated; the regenerate path is refused in CI. This freezes the declared contract; runtime behaviour and the live API shape stay covered by the other test layers.
 
 # 1.7.1 (April 15th, 2026)
 <img id="latest" src="https://badgen.net/badge/channel/latest/yellow" alt="Channel: latest" />

--- a/internal/provider/schema_snapshot_test.go
+++ b/internal/provider/schema_snapshot_test.go
@@ -13,8 +13,9 @@ package provider
 // What the snapshot captures, per attribute (recursively, into every nested
 // Elem block): the sorted key, the Type string, Required/Optional/Computed/
 // ForceNew/Sensitive, MinItems/MaxItems/ConfigMode, the literal Default value
-// for primitives (or has_default_func for DefaultFunc/non-primitive), the
-// PRESENCE booleans has_state_func / has_diff_suppress_func /
+// for primitives (has_non_primitive_default otherwise) recorded independently
+// of has_default_func (an attribute can carry both — DefaultValue() prefers the
+// literal), the PRESENCE booleans has_state_func / has_diff_suppress_func /
 // diff_suppress_on_refresh / has_validate_func (ValidateFunc OR ValidateDiagFunc,
 // including in a scalar Elem) / has_set_func (custom TypeSet hash), the sorted
 // plan-constraint lists ConflictsWith/ExactlyOneOf/AtLeastOneOf/RequiredWith,
@@ -300,7 +301,7 @@ func configModeString(m schema.SchemaConfigMode) string {
 }
 
 // isPrimitiveDefault reports whether a Default value is a JSON-stable primitive
-// whose literal we record. Anything else is recorded as has_default_func.
+// whose literal we record. Anything else is recorded as has_non_primitive_default.
 func isPrimitiveDefault(v interface{}) bool {
 	switch reflect.ValueOf(v).Kind() {
 	case reflect.String, reflect.Bool,

--- a/internal/provider/schema_snapshot_test.go
+++ b/internal/provider/schema_snapshot_test.go
@@ -1,0 +1,505 @@
+package provider
+
+// Schema golden gate (issue #298).
+//
+// This file freezes the externally-observable *declared schema contract* of the
+// provider into a committed golden JSON file and fails CI on any divergence.
+// The contract is what an existing client's Terraform state may legally contain
+// and whether an existing config still plans; silently changing it can break a
+// client's tfstate without any change to their HCL. Line coverage proves nothing
+// here, so this gate complements (it does not replace) the runtime schema-vs-
+// flatten walker (#288), the resource tests, and the integration suite (#8).
+//
+// What the snapshot captures, per attribute (recursively, into every nested
+// Elem block): the sorted key, the Type string, Required/Optional/Computed/
+// ForceNew/Sensitive, MinItems/MaxItems/ConfigMode, the literal Default value
+// for primitives (or has_default_func for DefaultFunc/non-primitive), the
+// PRESENCE booleans has_state_func / has_diff_suppress_func /
+// diff_suppress_on_refresh / has_validate_func (ValidateFunc OR ValidateDiagFunc,
+// including in a scalar Elem) / has_set_func (custom TypeSet hash), the sorted
+// plan-constraint lists ConflictsWith/ExactlyOneOf/AtLeastOneOf/RequiredWith,
+// and the explicit Elem kind (nil / value_type:<T> / a recursed resource).
+// Per resource/datasource it also captures SchemaVersion, each StateUpgrader's
+// Version plus a stable cty type representation, and has_customize_diff.
+//
+// What it deliberately does NOT capture: Description and other human-text/doc
+// fields (doc churn, not contract), and any func body, pointer or address. A
+// structural snapshot only locks the PRESENCE and types of functions, never
+// their behaviour: DefaultFunc/CustomizeDiff/StateFunc/Set/DiffSuppressFunc/
+// validator/StateUpgrader.Upgrade behaviour changes stay covered by behavioural
+// tests, and the live API shape stays covered by #8. "Near-certainty we don't
+// break the tfstate" is the SUM of those layers, not this gate alone.
+//
+// Backward-compatibility policy. ANY golden diff fails CI; a human must classify
+// it and write a justification adjacent to the golden change in the PR. v1 does
+// NOT auto-classify — it fails on any diff and the human decides. Guidance only:
+//   - Likely-safe (still needs a written justification, never auto-safe): a new
+//     Optional / Optional+Computed attribute, a new resource/datasource. Even an
+//     additive attribute can produce new state, noisy diffs, or expose
+//     API-derived values, so the human must confirm.
+//   - Breaking / state-shape risk (needs a StateUpgrader and/or explicit
+//     approval + CHANGELOG upgrade note): removing/renaming an attribute;
+//     changing Type or Elem kind; Optional->Required; adding Required; flipping
+//     Computed; adding ForceNew; reducing MaxItems; flipping Sensitive; changing
+//     a Default value; adding/removing/changing StateFunc/Set/DiffSuppressFunc;
+//     changing a plan-constraint; bumping SchemaVersion.
+//
+// Human update procedure. After a deliberate, justified change:
+//
+//	UPDATE_SCHEMA_SNAPSHOT=1 go test ./internal/provider -run TestSchemaSnapshot
+//
+// Regeneration is deterministic (running it twice yields no diff). The update
+// path is REFUSED in CI: if UPDATE_SCHEMA_SNAPSHOT is set while CI=true the test
+// fails hard, so an automated job can never silently rebaseline the contract.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// snapshotProviderVersion is the fixed version string passed to New(...). A
+// fixed value keeps the snapshot deterministic; the provider does not branch its
+// schema on the version, but pinning it removes any doubt.
+const snapshotProviderVersion = "schema-snapshot"
+
+// schemaSnapshotPath is the committed golden file.
+var schemaSnapshotPath = filepath.Join("testdata", "schema_snapshot.json")
+
+// --- Serialized shapes -----------------------------------------------------
+//
+// Field order in these structs is irrelevant to the output: encoding/json emits
+// struct fields in declaration order and sorts map keys lexically. We use
+// omitempty on every optional field so a default-valued attribute stays terse
+// and a future zero-valued addition does not churn every existing entry. For
+// schema flags the SDK zero value (false) and "absent" are equivalent, so
+// omitempty is correct and keeps the golden small.
+
+// attributeSnapshot is the stable projection of a single *schema.Schema.
+type attributeSnapshot struct {
+	Type string `json:"type"`
+
+	Required  bool `json:"required,omitempty"`
+	Optional  bool `json:"optional,omitempty"`
+	Computed  bool `json:"computed,omitempty"`
+	ForceNew  bool `json:"force_new,omitempty"`
+	Sensitive bool `json:"sensitive,omitempty"`
+
+	MinItems   int    `json:"min_items,omitempty"`
+	MaxItems   int    `json:"max_items,omitempty"`
+	ConfigMode string `json:"config_mode,omitempty"`
+
+	// Default carries the literal value for primitive defaults (string/bool/
+	// int/float). HasDefaultFunc is set instead when a DefaultFunc is present or
+	// the default is non-primitive. A *value* change here is breaking, so it is
+	// recorded verbatim.
+	Default        interface{} `json:"default,omitempty"`
+	HasDefaultFunc bool        `json:"has_default_func,omitempty"`
+
+	// Function PRESENCE only — never bodies, pointers or addresses.
+	HasStateFunc          bool `json:"has_state_func,omitempty"`
+	HasDiffSuppressFunc   bool `json:"has_diff_suppress_func,omitempty"`
+	DiffSuppressOnRefresh bool `json:"diff_suppress_on_refresh,omitempty"`
+	HasValidateFunc       bool `json:"has_validate_func,omitempty"`
+	HasSetFunc            bool `json:"has_set_func,omitempty"`
+
+	// Plan-constraint lists, sorted. They decide whether an existing config
+	// still plans.
+	ConflictsWith []string `json:"conflicts_with,omitempty"`
+	ExactlyOneOf  []string `json:"exactly_one_of,omitempty"`
+	AtLeastOneOf  []string `json:"at_least_one_of,omitempty"`
+	RequiredWith  []string `json:"required_with,omitempty"`
+
+	// Elem made explicit: "nil", "value_type:<T>" for a scalar *schema.Schema,
+	// or "resource" for a nested *schema.Resource (whose body is in ElemResource).
+	ElemKind     string                       `json:"elem_kind"`
+	ElemResource map[string]attributeSnapshot `json:"elem_resource,omitempty"`
+}
+
+// stateUpgraderSnapshot is the stable projection of a schema.StateUpgrader. The
+// type is rendered through cty's GoString, which sorts object attribute keys, so
+// the representation is stable across runs (verified by the twice-no-diff check).
+type stateUpgraderSnapshot struct {
+	Version int    `json:"version"`
+	Type    string `json:"type"`
+}
+
+// resourceSnapshot is the stable projection of a *schema.Resource (used for both
+// resources and datasources).
+type resourceSnapshot struct {
+	SchemaVersion    int                          `json:"schema_version,omitempty"`
+	HasCustomizeDiff bool                         `json:"has_customize_diff,omitempty"`
+	StateUpgraders   []stateUpgraderSnapshot      `json:"state_upgraders,omitempty"`
+	Schema           map[string]attributeSnapshot `json:"schema"`
+}
+
+// providerSnapshot is the whole serialized contract.
+type providerSnapshot struct {
+	ProviderSchema map[string]attributeSnapshot `json:"provider_schema"`
+	Resources      map[string]resourceSnapshot  `json:"resources"`
+	DataSources    map[string]resourceSnapshot  `json:"data_sources"`
+}
+
+// --- Serializer ------------------------------------------------------------
+
+func serializeAttribute(s *schema.Schema) attributeSnapshot {
+	a := attributeSnapshot{
+		Type:                  s.Type.String(),
+		Required:              s.Required,
+		Optional:              s.Optional,
+		Computed:              s.Computed,
+		ForceNew:              s.ForceNew,
+		Sensitive:             s.Sensitive,
+		MinItems:              s.MinItems,
+		MaxItems:              s.MaxItems,
+		ConfigMode:            configModeString(s.ConfigMode),
+		HasStateFunc:          s.StateFunc != nil,
+		HasDiffSuppressFunc:   s.DiffSuppressFunc != nil,
+		DiffSuppressOnRefresh: s.DiffSuppressOnRefresh,
+		HasValidateFunc:       s.ValidateFunc != nil || s.ValidateDiagFunc != nil,
+		HasSetFunc:            s.Set != nil,
+		ConflictsWith:         sortedCopy(s.ConflictsWith),
+		ExactlyOneOf:          sortedCopy(s.ExactlyOneOf),
+		AtLeastOneOf:          sortedCopy(s.AtLeastOneOf),
+		RequiredWith:          sortedCopy(s.RequiredWith),
+	}
+
+	// Default: literal value for primitives, otherwise presence-only.
+	if s.DefaultFunc != nil {
+		a.HasDefaultFunc = true
+	} else if s.Default != nil {
+		if isPrimitiveDefault(s.Default) {
+			a.Default = s.Default
+		} else {
+			// Non-primitive literal default (rare): record presence, never the
+			// value, to avoid serializing an opaque structure non-deterministically.
+			a.HasDefaultFunc = true
+		}
+	}
+
+	// Elem made explicit.
+	switch e := s.Elem.(type) {
+	case nil:
+		a.ElemKind = "nil"
+	case *schema.Schema:
+		a.ElemKind = "value_type:" + e.Type.String()
+		// A scalar Elem can still carry a validator; adding/removing it changes
+		// whether an existing config is valid at plan, so fold its presence into
+		// the parent attribute's has_validate_func.
+		if e.ValidateFunc != nil || e.ValidateDiagFunc != nil {
+			a.HasValidateFunc = true
+		}
+	case *schema.Resource:
+		a.ElemKind = "resource"
+		a.ElemResource = serializeSchemaMap(e.Schema)
+	default:
+		// Unknown Elem type: surface it loudly rather than silently dropping
+		// contract. The mismatch will show in the golden diff.
+		a.ElemKind = fmt.Sprintf("unknown:%T", e)
+	}
+
+	return a
+}
+
+// serializeSchemaMap serializes a schema map; keys are emitted into a Go map
+// (encoding/json sorts them), and every value is recursively serialized.
+func serializeSchemaMap(m map[string]*schema.Schema) map[string]attributeSnapshot {
+	out := make(map[string]attributeSnapshot, len(m))
+	for k, v := range m {
+		out[k] = serializeAttribute(v)
+	}
+	return out
+}
+
+func serializeResource(r *schema.Resource) resourceSnapshot {
+	rs := resourceSnapshot{
+		SchemaVersion:    r.SchemaVersion,
+		HasCustomizeDiff: r.CustomizeDiff != nil,
+		Schema:           serializeSchemaMap(r.Schema),
+	}
+	for _, su := range r.StateUpgraders {
+		rs.StateUpgraders = append(rs.StateUpgraders, stateUpgraderSnapshot{
+			Version: su.Version,
+			Type:    su.Type.GoString(),
+		})
+	}
+	// StateUpgraders are ordered by ascending Version for stability regardless of
+	// declaration order.
+	sort.Slice(rs.StateUpgraders, func(i, j int) bool {
+		return rs.StateUpgraders[i].Version < rs.StateUpgraders[j].Version
+	})
+	return rs
+}
+
+func serializeProvider(p *schema.Provider) providerSnapshot {
+	snap := providerSnapshot{
+		ProviderSchema: serializeSchemaMap(p.Schema),
+		Resources:      make(map[string]resourceSnapshot, len(p.ResourcesMap)),
+		DataSources:    make(map[string]resourceSnapshot, len(p.DataSourcesMap)),
+	}
+	for name, r := range p.ResourcesMap {
+		snap.Resources[name] = serializeResource(r)
+	}
+	for name, d := range p.DataSourcesMap {
+		snap.DataSources[name] = serializeResource(d)
+	}
+	return snap
+}
+
+// renderSnapshot produces sorted, pretty, deterministic JSON. encoding/json
+// sorts map keys lexically and emits struct fields in declaration order, so the
+// only ordering we have to impose ourselves is on the slices (constraint lists
+// and StateUpgraders), which the serializer already sorts.
+func renderSnapshot(p *schema.Provider) ([]byte, error) {
+	snap := serializeProvider(p)
+	b, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// --- Small deterministic helpers -------------------------------------------
+
+func sortedCopy(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+	return out
+}
+
+func configModeString(m schema.SchemaConfigMode) string {
+	switch m {
+	case schema.SchemaConfigModeAuto:
+		return "" // default; omitted from the golden
+	case schema.SchemaConfigModeAttr:
+		return "attr"
+	case schema.SchemaConfigModeBlock:
+		return "block"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}
+
+// isPrimitiveDefault reports whether a Default value is a JSON-stable primitive
+// whose literal we record. Anything else is recorded as has_default_func.
+func isPrimitiveDefault(v interface{}) bool {
+	switch reflect.ValueOf(v).Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// --- The gate ---------------------------------------------------------------
+
+// TestSchemaSnapshot regenerates the schema contract from the live provider and
+// compares it to the committed golden. On mismatch it fails with a readable diff
+// and remediation steps. With UPDATE_SCHEMA_SNAPSHOT=1 it rewrites the golden,
+// unless CI=true, in which case it fails hard so a CI job can never silently
+// rebaseline the contract. It also runs InternalValidate and asserts the
+// snapshot is non-empty and covers sentinel resources/datasources and a known
+// nested block, so the gate cannot pass vacuously.
+func TestSchemaSnapshot(t *testing.T) {
+	provider := New(snapshotProviderVersion)()
+
+	// The provider must be internally valid; an invalid schema would make the
+	// snapshot meaningless.
+	if err := provider.InternalValidate(); err != nil {
+		t.Fatalf("Provider().InternalValidate() failed: %s", err)
+	}
+
+	current, err := renderSnapshot(provider)
+	if err != nil {
+		t.Fatalf("failed to render schema snapshot: %s", err)
+	}
+
+	// Meta-assertions: prove the snapshot really covers the provider, so a future
+	// bug that empties it (or a vacuous serializer) is caught here, not silently.
+	assertSnapshotIsNonVacuous(t, provider, current)
+
+	update := os.Getenv("UPDATE_SCHEMA_SNAPSHOT") != ""
+	inCI := os.Getenv("CI") == "true"
+
+	if update {
+		if inCI {
+			t.Fatalf("UPDATE_SCHEMA_SNAPSHOT must never be used in CI (CI=true): the schema " +
+				"contract cannot be blindly rebaselined by an automated job. A contract change " +
+				"must be regenerated and justified by a human, locally.")
+		}
+		if err := os.MkdirAll(filepath.Dir(schemaSnapshotPath), 0o755); err != nil {
+			t.Fatalf("failed to create testdata dir: %s", err)
+		}
+		if err := os.WriteFile(schemaSnapshotPath, current, 0o644); err != nil {
+			t.Fatalf("failed to write golden snapshot: %s", err)
+		}
+		t.Logf("schema snapshot updated -> %s (%d bytes)", schemaSnapshotPath, len(current))
+		return
+	}
+
+	golden, err := os.ReadFile(schemaSnapshotPath)
+	if err != nil {
+		t.Fatalf("failed to read golden snapshot %s: %s\n\n"+
+			"If this is the first run, generate it locally with:\n"+
+			"    UPDATE_SCHEMA_SNAPSHOT=1 go test ./internal/provider -run TestSchemaSnapshot",
+			schemaSnapshotPath, err)
+	}
+
+	if !bytes.Equal(golden, current) {
+		t.Fatalf("the declared provider schema contract changed.\n\n%s\n\n"+
+			"This gate fails on ANY change to the schema that an existing client's "+
+			"Terraform state depends on. Do NOT blindly regenerate. A human must:\n"+
+			"  1. read the diff above and classify the change "+
+			"(likely-safe additive vs. breaking/state-shape — see the policy in the "+
+			"header of schema_snapshot_test.go);\n"+
+			"  2. confirm a backward-compatibility decision (a breaking change needs a "+
+			"StateUpgrader and/or explicit approval + a CHANGELOG upgrade note);\n"+
+			"  3. write that justification in the PR, adjacent to the golden change;\n"+
+			"  4. regenerate the golden locally with:\n"+
+			"         UPDATE_SCHEMA_SNAPSHOT=1 go test ./internal/provider -run TestSchemaSnapshot\n"+
+			"     (refused when CI=true).",
+			unifiedishDiff(golden, current))
+	}
+}
+
+// assertSnapshotIsNonVacuous proves the snapshot meaningfully covers the
+// provider: it is non-empty, it counts the same number of resources and
+// datasources the provider registers, and it contains sentinel entries plus a
+// known nested block. Without these checks an empty or truncated serializer
+// could "pass" against an empty golden.
+func assertSnapshotIsNonVacuous(t *testing.T, provider *schema.Provider, current []byte) {
+	t.Helper()
+
+	if len(current) == 0 {
+		t.Fatalf("rendered schema snapshot is empty")
+	}
+
+	var snap providerSnapshot
+	if err := json.Unmarshal(current, &snap); err != nil {
+		t.Fatalf("rendered snapshot is not valid JSON: %s", err)
+	}
+
+	if len(snap.ProviderSchema) == 0 {
+		t.Fatalf("snapshot provider_schema is empty; expected the provider-level config block")
+	}
+	if got, want := len(snap.Resources), len(provider.ResourcesMap); got != want {
+		t.Fatalf("snapshot covers %d resources but the provider registers %d", got, want)
+	}
+	if got, want := len(snap.DataSources), len(provider.DataSourcesMap); got != want {
+		t.Fatalf("snapshot covers %d datasources but the provider registers %d", got, want)
+	}
+	if len(snap.Resources) == 0 {
+		t.Fatalf("snapshot contains no resources")
+	}
+	if len(snap.DataSources) == 0 {
+		t.Fatalf("snapshot contains no datasources")
+	}
+
+	// Sentinel resources/datasources that must always be present. These are
+	// long-standing, central objects; if any of them vanished the change is
+	// either a real removal (which must be human-vetted through the golden diff)
+	// or a serializer regression (caught here).
+	for _, name := range []string{
+		"cloudtemple_compute_virtual_machine",
+		"cloudtemple_iam_personal_access_token",
+	} {
+		if _, ok := snap.Resources[name]; !ok {
+			t.Fatalf("sentinel resource %q is missing from the snapshot", name)
+		}
+	}
+	for _, name := range []string{
+		"cloudtemple_compute_virtual_machine",
+		"cloudtemple_iam_features",
+	} {
+		if _, ok := snap.DataSources[name]; !ok {
+			t.Fatalf("sentinel datasource %q is missing from the snapshot", name)
+		}
+	}
+
+	// Known nested block: the iam_features datasource declares a "features" list
+	// whose Elem is a nested resource (recursed). This proves the serializer
+	// actually recurses into Elem blocks rather than stopping at the top level.
+	features, ok := snap.DataSources["cloudtemple_iam_features"]
+	if !ok {
+		t.Fatalf("sentinel datasource cloudtemple_iam_features is missing")
+	}
+	featuresAttr, ok := features.Schema["features"]
+	if !ok {
+		t.Fatalf("cloudtemple_iam_features.features attribute missing from snapshot")
+	}
+	if featuresAttr.ElemKind != "resource" {
+		t.Fatalf("cloudtemple_iam_features.features should have a nested resource Elem, got elem_kind=%q", featuresAttr.ElemKind)
+	}
+	if len(featuresAttr.ElemResource) == 0 {
+		t.Fatalf("cloudtemple_iam_features.features nested block was not recursed into (empty elem_resource)")
+	}
+
+	// The virtual_machine resource is the one place that exercises SchemaVersion
+	// and a StateUpgrader. Lock that this is reflected, so a serializer that
+	// dropped StateUpgraders would be caught.
+	vm, ok := snap.Resources["cloudtemple_compute_virtual_machine"]
+	if !ok {
+		t.Fatalf("sentinel resource cloudtemple_compute_virtual_machine is missing")
+	}
+	if vm.SchemaVersion == 0 || len(vm.StateUpgraders) == 0 {
+		t.Fatalf("cloudtemple_compute_virtual_machine should carry SchemaVersion>0 and at least one StateUpgrader; "+
+			"got schema_version=%d, %d upgraders", vm.SchemaVersion, len(vm.StateUpgraders))
+	}
+}
+
+// unifiedishDiff renders a compact line-level diff between the golden and the
+// freshly rendered snapshot, enough to make a mismatch readable without pulling
+// in a diff dependency. It shows every differing line with a - (golden) / +
+// (current) prefix.
+func unifiedishDiff(golden, current []byte) string {
+	goldenLines := bytes.Split(golden, []byte("\n"))
+	currentLines := bytes.Split(current, []byte("\n"))
+
+	var buf bytes.Buffer
+	maxLines := len(goldenLines)
+	if len(currentLines) > maxLines {
+		maxLines = len(currentLines)
+	}
+	shown := 0
+	const maxShown = 200
+	for i := 0; i < maxLines; i++ {
+		var g, c []byte
+		if i < len(goldenLines) {
+			g = goldenLines[i]
+		}
+		if i < len(currentLines) {
+			c = currentLines[i]
+		}
+		if !bytes.Equal(g, c) {
+			if shown >= maxShown {
+				fmt.Fprintf(&buf, "... (diff truncated at %d differing lines)\n", maxShown)
+				break
+			}
+			if i < len(goldenLines) {
+				fmt.Fprintf(&buf, "- L%d: %s\n", i+1, g)
+			}
+			if i < len(currentLines) {
+				fmt.Fprintf(&buf, "+ L%d: %s\n", i+1, c)
+			}
+			shown++
+		}
+	}
+	if shown == 0 {
+		return "(byte-level difference with no line-level change; check trailing whitespace/newline)"
+	}
+	return buf.String()
+}

--- a/internal/provider/schema_snapshot_test.go
+++ b/internal/provider/schema_snapshot_test.go
@@ -97,11 +97,15 @@ type attributeSnapshot struct {
 	ConfigMode string `json:"config_mode,omitempty"`
 
 	// Default carries the literal value for primitive defaults (string/bool/
-	// int/float). HasDefaultFunc is set instead when a DefaultFunc is present or
-	// the default is non-primitive. A *value* change here is breaking, so it is
-	// recorded verbatim.
-	Default        interface{} `json:"default,omitempty"`
-	HasDefaultFunc bool        `json:"has_default_func,omitempty"`
+	// int/float); a *value* change here is breaking, so it is recorded verbatim.
+	// Default and DefaultFunc are INDEPENDENT: the SDK's DefaultValue() prefers
+	// Default over DefaultFunc, so an attribute can carry both (e.g. provider
+	// api_suffix). Each is captured separately so a literal-default change is
+	// never hidden by the presence of a DefaultFunc. HasNonPrimitiveDefault
+	// records a non-serializable literal default by presence only.
+	Default                interface{} `json:"default,omitempty"`
+	HasDefaultFunc         bool        `json:"has_default_func,omitempty"`
+	HasNonPrimitiveDefault bool        `json:"has_non_primitive_default,omitempty"`
 
 	// Function PRESENCE only — never bodies, pointers or addresses.
 	HasStateFunc          bool `json:"has_state_func,omitempty"`
@@ -171,17 +175,21 @@ func serializeAttribute(s *schema.Schema) attributeSnapshot {
 		RequiredWith:          sortedCopy(s.RequiredWith),
 	}
 
-	// Default: literal value for primitives, otherwise presence-only.
-	if s.DefaultFunc != nil {
-		a.HasDefaultFunc = true
-	} else if s.Default != nil {
+	// Default and DefaultFunc are independent (DefaultValue() prefers Default),
+	// so capture each on its own: a primitive Default literal must stay visible
+	// even when a DefaultFunc also exists, or a default-value change slips past
+	// the gate (provider api_suffix carries both).
+	if s.Default != nil {
 		if isPrimitiveDefault(s.Default) {
 			a.Default = s.Default
 		} else {
 			// Non-primitive literal default (rare): record presence, never the
 			// value, to avoid serializing an opaque structure non-deterministically.
-			a.HasDefaultFunc = true
+			a.HasNonPrimitiveDefault = true
 		}
+	}
+	if s.DefaultFunc != nil {
+		a.HasDefaultFunc = true
 	}
 
 	// Elem made explicit.

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -9,6 +9,7 @@
     "api_suffix": {
       "type": "TypeBool",
       "optional": true,
+      "default": true,
       "has_default_func": true,
       "elem_kind": "nil"
     },

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -1,0 +1,10349 @@
+{
+  "provider_schema": {
+    "address": {
+      "type": "TypeString",
+      "optional": true,
+      "has_default_func": true,
+      "elem_kind": "nil"
+    },
+    "api_suffix": {
+      "type": "TypeBool",
+      "optional": true,
+      "has_default_func": true,
+      "elem_kind": "nil"
+    },
+    "client_id": {
+      "type": "TypeString",
+      "required": true,
+      "has_default_func": true,
+      "elem_kind": "nil"
+    },
+    "scheme": {
+      "type": "TypeString",
+      "optional": true,
+      "has_default_func": true,
+      "elem_kind": "nil"
+    },
+    "secret_id": {
+      "type": "TypeString",
+      "required": true,
+      "sensitive": true,
+      "has_default_func": true,
+      "elem_kind": "nil"
+    }
+  },
+  "resources": {
+    "cloudtemple_compute_iaas_opensource_network_adapter": {
+      "schema": {
+        "attached": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mac_address": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mtu": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "network_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "tx_checksumming": {
+          "type": "TypeBool",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_replication_policy": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "interval": {
+          "type": "TypeList",
+          "required": true,
+          "force_new": true,
+          "max_items": 1,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "hours": {
+              "type": "TypeInt",
+              "optional": true,
+              "conflicts_with": [
+                "interval.0.minutes"
+              ],
+              "elem_kind": "nil"
+            },
+            "minutes": {
+              "type": "TypeInt",
+              "optional": true,
+              "conflicts_with": [
+                "interval.0.hours"
+              ],
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "last_run": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "end": {
+              "type": "TypeInt",
+              "optional": true,
+              "elem_kind": "nil"
+            },
+            "start": {
+              "type": "TypeInt",
+              "optional": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_disk": {
+      "schema": {
+        "bootable": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": false,
+          "elem_kind": "nil"
+        },
+        "connected": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "is_snapshot": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mode": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "size": {
+          "type": "TypeInt",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "templates": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "read_only": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "connected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "read_only": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_machine": {
+      "has_customize_diff": true,
+      "schema": {
+        "addresses": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "ipv4": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "ipv6": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "allow_vm_restart": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": true,
+          "elem_kind": "nil"
+        },
+        "auto_power_on": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "backup_sla_policies": {
+          "type": "TypeSet",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "boot_firmware": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "boot_order": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "cloud_init": {
+          "type": "TypeMap",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "cpu": {
+          "type": "TypeInt",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "dvd_drive": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "attached": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "high_availability": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "disabled",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "management_agent": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "marketplace_item_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "template_id"
+          ],
+          "at_least_one_of": [
+            "marketplace_item_id",
+            "template_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "memory": {
+          "type": "TypeInt",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "mount_iso": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "num_cores_per_socket": {
+          "type": "TypeInt",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "operating_system_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "os_disk": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "connected": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "size": {
+              "type": "TypeInt",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_repository_id": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "os_network_adapter": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "attached": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_address": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mtu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_id": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tx_checksumming": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "power_state": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "pv_drivers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "are_up_to_date": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "replication_policy_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "secure_boot": {
+          "type": "TypeBool",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "template_id"
+          ],
+          "required_with": [
+            "marketplace_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "tags": {
+          "type": "TypeMap",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "template_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "marketplace_item_id"
+          ],
+          "at_least_one_of": [
+            "marketplace_item_id",
+            "template_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "tools": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "wait_for_drivers_timeout": {
+          "type": "TypeInt",
+          "optional": true,
+          "default": 30,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_network_adapter": {
+      "schema": {
+        "auto_connect": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "connected": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "mac_address": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mac_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "network_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_controller": {
+      "schema": {
+        "connected": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "content_library_item_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "iso_path"
+          ],
+          "elem_kind": "nil"
+        },
+        "hot_add_remove": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "iso_path": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "content_library_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "label": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mounted": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "shared_bus": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "sub_type": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "summary": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_disks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_disk": {
+      "schema": {
+        "backup_sla_policies": {
+          "type": "TypeSet",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "capacity": {
+          "type": "TypeInt",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "controller_bus_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "controller_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "controller_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "datastore_id"
+          ],
+          "at_least_one_of": [
+            "datastore_cluster_id",
+            "datastore_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "datastore_cluster_id"
+          ],
+          "at_least_one_of": [
+            "datastore_cluster_id",
+            "datastore_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disk_mode": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "disk_path": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disk_unit_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "editable": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "instant_access": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "native_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "provisioning_type": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_machine": {
+      "schema_version": 1,
+      "has_customize_diff": true,
+      "state_upgraders": [
+        {
+          "version": 0,
+          "type": "cty.Object(map[string]cty.Type{\"extra_config\":cty.List(cty.Object(map[string]cty.Type{\"key\":cty.String, \"value\":cty.String})), \"id\":cty.String})"
+        }
+      ],
+      "schema": {
+        "backup_sla_policies": {
+          "type": "TypeSet",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "boot_options": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "max_items": 1,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "boot_delay": {
+              "type": "TypeInt",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_retry_delay": {
+              "type": "TypeInt",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_retry_enabled": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "efi_secure_boot_enabled": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "enter_bios_setup": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "firmware": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "has_validate_func": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "clone_virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "content_library_item_id",
+            "marketplace_item_id"
+          ],
+          "at_least_one_of": [
+            "clone_virtual_machine_id",
+            "content_library_item_id",
+            "guest_operating_system_moref",
+            "marketplace_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "cloud_init": {
+          "type": "TypeMap",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "consolidation_needed": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "content_library_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "clone_virtual_machine_id",
+            "marketplace_item_id"
+          ],
+          "required_with": [
+            "content_library_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "content_library_item_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "clone_virtual_machine_id",
+            "marketplace_item_id"
+          ],
+          "at_least_one_of": [
+            "clone_virtual_machine_id",
+            "content_library_item_id",
+            "guest_operating_system_moref",
+            "marketplace_item_id"
+          ],
+          "required_with": [
+            "content_library_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "cpu": {
+          "type": "TypeInt",
+          "optional": true,
+          "default": 1,
+          "elem_kind": "nil"
+        },
+        "cpu_hot_add_enabled": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "cpu_hot_remove_enabled": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "cpu_usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "customize": {
+          "type": "TypeList",
+          "optional": true,
+          "max_items": 1,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "network_config": {
+              "type": "TypeList",
+              "required": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "adapters": {
+                  "type": "TypeList",
+                  "optional": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "gateway": {
+                      "type": "TypeString",
+                      "required": true,
+                      "has_validate_func": true,
+                      "elem_kind": "nil"
+                    },
+                    "ip_address": {
+                      "type": "TypeString",
+                      "required": true,
+                      "has_validate_func": true,
+                      "elem_kind": "nil"
+                    },
+                    "mac_address": {
+                      "type": "TypeString",
+                      "optional": true,
+                      "has_validate_func": true,
+                      "elem_kind": "nil"
+                    },
+                    "subnet_mask": {
+                      "type": "TypeString",
+                      "required": true,
+                      "has_validate_func": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "dns_server_list": {
+                  "type": "TypeSet",
+                  "optional": true,
+                  "has_validate_func": true,
+                  "elem_kind": "value_type:TypeString"
+                },
+                "dns_suffix_list": {
+                  "type": "TypeSet",
+                  "optional": true,
+                  "elem_kind": "value_type:TypeString"
+                },
+                "domain": {
+                  "type": "TypeString",
+                  "required": true,
+                  "elem_kind": "nil"
+                },
+                "hostname": {
+                  "type": "TypeString",
+                  "required": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "windows_config": {
+              "type": "TypeList",
+              "optional": true,
+              "max_items": 1,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "auto_logon": {
+                  "type": "TypeBool",
+                  "required": true,
+                  "elem_kind": "nil"
+                },
+                "auto_logon_count": {
+                  "type": "TypeInt",
+                  "required": true,
+                  "elem_kind": "nil"
+                },
+                "domain": {
+                  "type": "TypeList",
+                  "optional": true,
+                  "max_items": 1,
+                  "conflicts_with": [
+                    "customize.0.windows_config.0.workgroup"
+                  ],
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "admin_password": {
+                      "type": "TypeString",
+                      "optional": true,
+                      "sensitive": true,
+                      "required_with": [
+                        "customize.0.windows_config.0.domain.0.admin_username",
+                        "customize.0.windows_config.0.domain.0.name"
+                      ],
+                      "elem_kind": "nil"
+                    },
+                    "admin_username": {
+                      "type": "TypeString",
+                      "optional": true,
+                      "required_with": [
+                        "customize.0.windows_config.0.domain.0.admin_password",
+                        "customize.0.windows_config.0.domain.0.name"
+                      ],
+                      "elem_kind": "nil"
+                    },
+                    "name": {
+                      "type": "TypeString",
+                      "optional": true,
+                      "required_with": [
+                        "customize.0.windows_config.0.domain.0.admin_password",
+                        "customize.0.windows_config.0.domain.0.admin_username"
+                      ],
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "password": {
+                  "type": "TypeString",
+                  "optional": true,
+                  "sensitive": true,
+                  "elem_kind": "nil"
+                },
+                "timezone": {
+                  "type": "TypeInt",
+                  "required": true,
+                  "elem_kind": "nil"
+                },
+                "workgroup": {
+                  "type": "TypeString",
+                  "optional": true,
+                  "conflicts_with": [
+                    "customize.0.windows_config.0.domain"
+                  ],
+                  "at_least_one_of": [
+                    "customize.0.windows_config.0.domain",
+                    "customize.0.windows_config.0.workgroup"
+                  ],
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "datacenter_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datacenter_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "deploy_options": {
+          "type": "TypeMap",
+          "optional": true,
+          "force_new": true,
+          "conflicts_with": [
+            "clone_virtual_machine_id"
+          ],
+          "elem_kind": "value_type:TypeString"
+        },
+        "disks_provisioning_type": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "distributed_virtual_port_group_ids": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "expose_hardware_virtualization": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": false,
+          "elem_kind": "nil"
+        },
+        "extra_config": {
+          "type": "TypeMap",
+          "optional": true,
+          "computed": true,
+          "has_diff_suppress_func": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "guest_operating_system_moref": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "at_least_one_of": [
+            "clone_virtual_machine_id",
+            "content_library_item_id",
+            "guest_operating_system_moref",
+            "marketplace_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "hardware_version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "marketplace_item_id": {
+          "type": "TypeString",
+          "optional": true,
+          "force_new": true,
+          "conflicts_with": [
+            "clone_virtual_machine_id",
+            "content_library_item_id"
+          ],
+          "at_least_one_of": [
+            "clone_virtual_machine_id",
+            "content_library_item_id",
+            "guest_operating_system_moref",
+            "marketplace_item_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "memory": {
+          "type": "TypeInt",
+          "optional": true,
+          "default": 33554432,
+          "elem_kind": "nil"
+        },
+        "memory_hot_add_enabled": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "memory_reservation": {
+          "type": "TypeInt",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "memory_usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "num_cores_per_socket": {
+          "type": "TypeInt",
+          "optional": true,
+          "default": 1,
+          "elem_kind": "nil"
+        },
+        "operating_system_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "os_disk": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "capacity": {
+              "type": "TypeInt",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "controller_bus_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_mode": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_path": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_unit_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "editable": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "instant_access": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "native_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "provisioning_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "os_network_adapter": {
+          "type": "TypeList",
+          "optional": true,
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "auto_connect": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "connected": {
+              "type": "TypeBool",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_address": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_id": {
+              "type": "TypeString",
+              "optional": true,
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "power_state": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "off",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "replication_config": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "disk": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "disk_replication_id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "key": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "encryption_destination": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "generation": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "net_compression_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "net_encryption_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "opp_updates_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "paused": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "quiesce_guest_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "rpo": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "vm_replication_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "snapshoted": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "spp_mode": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "committed": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "uncommitted": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "tags": {
+          "type": "TypeMap",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "template": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tools": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tools_version": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "triggered_alarms": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_personal_access_token": {
+      "schema": {
+        "client_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "expiration_date": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_diff_suppress_func": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "roles": {
+          "type": "TypeList",
+          "optional": true,
+          "force_new": true,
+          "min_items": 1,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "secret_id": {
+          "type": "TypeString",
+          "computed": true,
+          "sensitive": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_acl_entry": {
+      "schema": {
+        "bucket": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "role": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "storage_account": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_bucket": {
+      "has_customize_diff": true,
+      "schema": {
+        "access_type": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "acl_entry": {
+          "type": "TypeSet",
+          "optional": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "role": {
+              "type": "TypeString",
+              "required": true,
+              "elem_kind": "nil"
+            },
+            "storage_account": {
+              "type": "TypeString",
+              "required": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "endpoint": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "namespace": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "retention_period": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tags": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "value": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "total_objects": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_objects_deleted": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size_deleted": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size_unit": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "versioning": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "whitelist": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_object_storage_global_access_key": {
+      "schema": {
+        "access_key_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "access_secret_key": {
+          "type": "TypeString",
+          "computed": true,
+          "sensitive": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_storage_account": {
+      "schema": {
+        "access_key_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "access_secret_key": {
+          "type": "TypeString",
+          "computed": true,
+          "sensitive": true,
+          "elem_kind": "nil"
+        },
+        "arn": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "create_date": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "force_new": true,
+          "elem_kind": "nil"
+        },
+        "path": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tags": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "value": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    }
+  },
+  "data_sources": {
+    "cloudtemple_backup_iaas_opensource_backup": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "is_virtual_machine_deleted": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mode": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "policy": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "size": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "timestamp": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_iaas_opensource_backups": {
+      "schema": {
+        "backups": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "required": true,
+              "has_validate_func": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "is_virtual_machine_deleted": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "policy": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "timestamp": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "deleted": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_iaas_opensource_policies": {
+      "schema": {
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        },
+        "policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "running": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "schedulers": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cron": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "retention": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "temporarily_disabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "timezone": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "virtual_machines": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_iaas_opensource_policy": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mode": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "running": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "schedulers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cron": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "retention": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "temporarily_disabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "timezone": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_backup_job": {
+      "schema": {
+        "display_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "policy_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "status": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_job_sessions": {
+      "schema": {
+        "job_sessions": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "duration": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "end": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "job_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "job_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sla_policies": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "href": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "sla_policy_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "start": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "statistics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "failed": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "skipped": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "success": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "total": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_jobs": {
+      "schema": {
+        "jobs": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "display_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "policy_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_metrics": {
+      "schema": {
+        "coverage": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "failed_resources": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "protected_resources": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_resources": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "unprotected_resources": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "history": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "failed": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "running": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "success": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sucess_percent": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_runs": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "warning": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "platform": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "build": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "date": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "deployment_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "epoch": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "product": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "platform_cpu": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu_util": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "number_of_protected_vm": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "trigger_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "range": {
+          "type": "TypeInt",
+          "optional": true,
+          "default": 4,
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "in_compute": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "in_offloading_sla": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "in_sla": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "in_spp": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tsm_offloading_factor": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "with_backup": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_sites": {
+      "schema": {
+        "sites": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_sla_policies": {
+      "schema": {
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        },
+        "sla_policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sub_policies": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "retention": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "age": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "site": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "software": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "target": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "href": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "id": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "resource_type": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "trigger": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "activate_date": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "frequency": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "type": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "use_encryption": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "virtual_disk_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_sla_policy": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "sub_policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "retention": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "age": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "site": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "software": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "target": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "href": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "resource_type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "trigger": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "activate_date": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "frequency": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "use_encryption": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_spp_server": {
+      "schema": {
+        "address": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "tenant_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_spp_servers": {
+      "schema": {
+        "spp_servers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "address": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "tenant_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_backup_storages": {
+      "schema": {
+        "storages": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "capacity": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "free": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "total": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "update_time": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "host_address": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "initialize_status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "is_ready": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "port_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "resource_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "site": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "ssl_connection": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_backup_vcenters": {
+      "schema": {
+        "spp_server_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "vcenters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "instance_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "spp_server_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_content_libraries": {
+      "schema": {
+        "content_libraries": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "datastore": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_content_library": {
+      "schema": {
+        "datastore": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_content_library_item": {
+      "schema": {
+        "content_library_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "creation_time": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "last_modified_time": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "ovf_properties": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "size": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_content_library_items": {
+      "schema": {
+        "content_library_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "content_library_items": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "creation_time": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "last_modified_time": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "ovf_properties": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_datastore": {
+      "schema": {
+        "accessible": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "associated_folder": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "free_capacity": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "hosts_names": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "hosts_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "maintenance_mode": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "maintenance_status": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "max_capacity": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "unique_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machines_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_datastore_cluster": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "datacenter_id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastores": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "metrics": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "default_vm_behavior": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "free_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "io_latency_threshold": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "io_load_balance_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "io_load_imbalance_threshold": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "load_balance_interval": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "max_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "min_space_utilization_difference": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "reservable_percent_threshold": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "reservable_threshold_mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "space_threshold_mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "space_utilization_threshold": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_datastore_clusters": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_clusters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "datacenter_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastores": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "metrics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "default_vm_behavior": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "free_capacity": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "io_latency_threshold": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "io_load_balance_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "io_load_imbalance_threshold": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "load_balance_interval": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "max_capacity": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "min_space_utilization_difference": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "reservable_percent_threshold": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "reservable_threshold_mode": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "space_threshold_mode": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "space_utilization_threshold": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_datastores": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastores": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "accessible": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "associated_folder": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "free_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "hosts_names": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "hosts_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "maintenance_mode": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "maintenance_status": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "max_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "unique_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_folder": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "required_with": [
+            "datacenter_id"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_folders": {
+      "schema": {
+        "folders": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_guest_operating_system": {
+      "schema": {
+        "family": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "full_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "host_id"
+          ],
+          "at_least_one_of": [
+            "host_cluster_id",
+            "host_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "host_cluster_id"
+          ],
+          "at_least_one_of": [
+            "host_cluster_id",
+            "host_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_guest_operating_systems": {
+      "schema": {
+        "guest_operating_systems": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "family": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "full_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "at_least_one_of": [
+            "host_cluster_id",
+            "host_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "at_least_one_of": [
+            "host_cluster_id",
+            "host_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "os_family": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "version": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_host": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "metrics": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "connected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "cpu": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cpu_cores": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "cpu_mhz": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "cpu_threads": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "overall_cpu_usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "esx": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "build": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "full_name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "version": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "maintenance_mode": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "maintenance_status": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "memory_size": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "memory_usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "uptime": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_host_cluster": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "hosts": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "metrics": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu_used": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory_used": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_used": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_cpu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_memory": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_storage": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machines_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_host_clusters": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_clusters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "datacenter_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "hosts": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "metrics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cpu_used": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "memory_used": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "storage_used": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "total_cpu": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "total_memory": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "total_storage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_hosts": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "hosts": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "metrics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "connected": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "cpu": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "cpu_cores": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "cpu_mhz": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "cpu_threads": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "overall_cpu_usage": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "esx": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "build": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "full_name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "version": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "maintenance_mode": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "maintenance_status": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "memory": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "memory_size": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "memory_usage": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "uptime": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_availability_zone": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "os_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "os_version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_availability_zones": {
+      "schema": {
+        "availability_zones": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "os_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "os_version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_host": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "master": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "metrics": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cores": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "model": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "model_name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "sockets": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "memory": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "size": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "xoa": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "build": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "full_name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "version": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "pool": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "description": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "key": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "power_state": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "reboot_required": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "update_data": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "maintenance_mode": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "uptime": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_hosts": {
+      "schema": {
+        "hosts": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "master": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "metrics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cpu": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "cores": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "model": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "model_name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "sockets": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "memory": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "size": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "usage": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "xoa": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "build": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "full_name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "version": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pool": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "type": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "description": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "key": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            },
+            "power_state": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "reboot_required": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "update_data": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "maintenance_mode": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "status": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "uptime": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_network": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "machine_manager_id",
+            "name",
+            "pool_id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "insecure_network_block_device": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "maximum_transmission_unit": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "network_adapters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "network_block_device": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_network_adapter": {
+      "schema": {
+        "attached": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mac_address": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mtu": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "network_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tx_checksumming": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_network_adapters": {
+      "schema": {
+        "network_adapters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "attached": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_address": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mtu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tx_checksumming": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_networks": {
+      "schema": {
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "networks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "insecure_network_block_device": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "maximum_transmission_unit": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_adapters": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "network_block_device": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pool_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_pool": {
+      "schema": {
+        "cpu": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cores": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sockets": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "high_availability_enabled": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "hosts": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "label": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "master": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "memory": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "usage": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_pools": {
+      "schema": {
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "pools": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cores": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "sockets": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "high_availability_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "hosts": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "label": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "master": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "size": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "description": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "key": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_replication_policies": {
+      "schema": {
+        "policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "interval": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "hours": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "minutes": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "last_run": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "end": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "start": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "status": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pool_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_repository_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_replication_policy": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "interval": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "hours": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "minutes": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "last_run": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "end": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "start": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_snapshot": {
+      "schema": {
+        "create_time": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_snapshots": {
+      "schema": {
+        "snapshots": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "create_time": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_storage_repositories": {
+      "schema": {
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "shared": {
+          "type": "TypeBool",
+          "optional": true,
+          "default": false,
+          "elem_kind": "nil"
+        },
+        "storage_repositories": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "accessible": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "free_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "host_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "maintenance_mode": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "max_capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pool_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "shared": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_disks": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            }
+          }
+        },
+        "type": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_storage_repository": {
+      "schema": {
+        "accessible": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "free_capacity": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "maintenance_mode": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "max_capacity": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "shared": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_disks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_template": {
+      "schema": {
+        "cpu": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_repository": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "memory": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "network_adapters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "attached": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_address": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mtu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "num_cores_per_socket": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "power_state": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "sla_policies": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "snapshots": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_templates": {
+      "schema": {
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "templates": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disks": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "description": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "size": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "storage_repository": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "id": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_adapters": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "attached": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "mac_address": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "mtu": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "network": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "id": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            },
+            "num_cores_per_socket": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "power_state": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sla_policies": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "snapshots": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_disk": {
+      "schema": {
+        "attachable": {
+          "type": "TypeBool",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "is_snapshot": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "size": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "template_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id",
+            "virtual_machine_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "templates": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "read_only": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id",
+            "template_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "connected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "read_only": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_disks": {
+      "schema": {
+        "attachable": {
+          "type": "TypeBool",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "storage_repository_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "template_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "virtual_machine_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_disks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "is_snapshot": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage_repository_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "templates": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "read_only": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "usage": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "connected": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "read_only": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "template_id"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_machine": {
+      "schema": {
+        "addresses": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "ipv4": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "ipv6": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "auto_power_on": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "boot_firmware": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "boot_order": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "cpu": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "dvd_drive": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "attached": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "high_availability": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "management_agent": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "memory": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "num_cores_per_socket": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "operating_system_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "pool_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "power_state": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "pv_drivers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "are_up_to_date": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "secure_boot": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tools": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "detected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_iaas_opensource_virtual_machines": {
+      "schema": {
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "addresses": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "ipv4": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "ipv6": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "auto_power_on": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_firmware": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_order": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "cpu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "dvd_drive": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "attached": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "high_availability": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "host_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "management_agent": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "detected": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "memory": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "num_cores_per_socket": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "operating_system_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pool_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "power_state": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "pv_drivers": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "are_up_to_date": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "detected": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "version": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "secure_boot": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tools": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "detected": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "version": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_machine_manager": {
+      "schema": {
+        "api_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "api_version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "build": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "full_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "instance_uuid": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "license_product_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "license_product_version": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "locale_build": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "locale_version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "os_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "product_line_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tenant_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tenant_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "vendor": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_machine_managers": {
+      "schema": {
+        "machine_managers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "api_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "api_version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "build": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "full_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "instance_uuid": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "license_product_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "license_product_version": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "locale_build": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "locale_version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "os_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "product_line_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tenant_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tenant_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "vendor": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_network": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "folder_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_names": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "host_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "virtual_machines_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_switch_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_network_adapter": {
+      "schema": {
+        "auto_connect": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "connected": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "mac_address": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "mac_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "required_with": [
+            "virtual_machine_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "network_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_network_adapters": {
+      "schema": {
+        "network_adapters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "auto_connect": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "connected": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_address": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "mac_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "network_id": {
+              "type": "TypeString",
+              "required": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_networks": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "folder_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "networks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "host_names": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "host_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machines_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "type": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "virtual_switch_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_resource_pool": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "metrics": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "cpu": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "max_usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "reservation_used": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "memory": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "ballooned_memory": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "max_usage": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "reservation_used": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "parent": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_resource_pools": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "resource_pools": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "metrics": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "cpu": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "max_usage": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "reservation_used": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "memory": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "ballooned_memory": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "max_usage": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "reservation_used": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "parent": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "type": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_snapshots": {
+      "schema": {
+        "snapshots": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "create_time": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_controllers": {
+      "schema": {
+        "types": {
+          "type": "TypeList",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "virtual_controllers": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "hot_add_remove": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "label": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "sub_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "summary": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_disks": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_datacenter": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "required_with": [
+            "machine_manager_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "tenant_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_datacenters": {
+      "schema": {
+        "virtual_datacenters": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tenant_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_disk": {
+      "schema": {
+        "capacity": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "controller_bus_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "controller_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "controller_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disk_mode": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disk_path": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "disk_unit_number": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "editable": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "instant_access": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "required_with": [
+            "virtual_machine_id"
+          ],
+          "elem_kind": "nil"
+        },
+        "native_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "provisioning_type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_disks": {
+      "schema": {
+        "virtual_disks": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "capacity": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "controller_bus_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "controller_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "controller_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_path": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "disk_unit_number": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "editable": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "instant_access": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "native_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "provisioning_type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "virtual_machine_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "virtual_machine_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_machine": {
+      "schema": {
+        "boot_options": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "boot_delay": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_retry_delay": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "boot_retry_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "efi_secure_boot_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "enter_bios_setup": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "firmware": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "consolidation_needed": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "cpu": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "cpu_hot_add_enabled": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "cpu_hot_remove_enabled": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "cpu_usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datacenter_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_cluster_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "datastore_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "distributed_virtual_port_group_ids": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "expose_hardware_virtualization": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "extra_config": {
+          "type": "TypeMap",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "guest_operating_system_moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "hardware_version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "required_with": [
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "memory": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "memory_hot_add_enabled": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "memory_usage": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "num_cores_per_socket": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "operating_system_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "power_state": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "replication_config": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "disk": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "disk_replication_id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "key": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "encryption_destination": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "generation": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "net_compression_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "net_encryption_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "opp_updates_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "paused": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "quiesce_guest_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "rpo": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "vm_replication_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "snapshoted": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "spp_mode": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "storage": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "committed": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "uncommitted": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "template": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tools": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tools_version": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "triggered_alarms": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "status": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_machines": {
+      "schema": {
+        "datacenters": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "datastores": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "host_clusters": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "hosts": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        },
+        "networks": {
+          "type": "TypeList",
+          "optional": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "virtual_machines": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "boot_options": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "boot_delay": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "boot_retry_delay": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "boot_retry_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "efi_secure_boot_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "enter_bios_setup": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "firmware": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "consolidation_needed": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "cpu": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "cpu_hot_add_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "cpu_hot_remove_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "cpu_usage": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datacenter_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_cluster_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "datastore_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "distributed_virtual_port_group_ids": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "expose_hardware_virtualization": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "extra_config": {
+              "type": "TypeMap",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "guest_operating_system_moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "hardware_version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "host_cluster_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory_hot_add_enabled": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "memory_usage": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "num_cores_per_socket": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "operating_system_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "power_state": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "replication_config": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "disk": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "disk_replication_id": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "key": {
+                      "type": "TypeInt",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                },
+                "encryption_destination": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "generation": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "net_compression_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "net_encryption_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "opp_updates_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "paused": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "quiesce_guest_enabled": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "rpo": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "vm_replication_id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "snapshoted": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "spp_mode": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "storage": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "committed": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "uncommitted": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "template": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tools": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tools_version": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "triggered_alarms": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "status": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_switch": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "folder_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "moref": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_compute_virtual_switchs": {
+      "schema": {
+        "datacenter_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "host_cluster_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "machine_manager_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "elem_kind": "nil"
+        },
+        "virtual_switchs": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "folder_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "machine_manager_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "moref": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_company": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_iam_features": {
+      "schema": {
+        "features": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "subfeatures": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "subfeatures": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "id": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_personal_access_token": {
+      "schema": {
+        "expiration_date": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "roles": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "tenant_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        },
+        "tenant_name": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "user_id": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_iam_personal_access_tokens": {
+      "schema": {
+        "tokens": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "expiration_date": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "roles": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "tenant_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tenant_name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "user_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_role": {
+      "schema": {
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_iam_roles": {
+      "schema": {
+        "roles": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_tenants": {
+      "schema": {
+        "tenants": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "company_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "snc": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_iam_user": {
+      "schema": {
+        "email": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id",
+            "internal_id",
+            "name"
+          ],
+          "at_least_one_of": [
+            "email",
+            "id",
+            "internal_id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "email_verified": {
+          "type": "TypeBool",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "email",
+            "internal_id",
+            "name"
+          ],
+          "at_least_one_of": [
+            "email",
+            "id",
+            "internal_id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "internal_id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "email",
+            "id",
+            "name"
+          ],
+          "at_least_one_of": [
+            "email",
+            "id",
+            "internal_id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "email",
+            "id",
+            "internal_id"
+          ],
+          "at_least_one_of": [
+            "email",
+            "id",
+            "internal_id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "source": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "source_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_iam_users": {
+      "schema": {
+        "company_id": {
+          "type": "TypeString",
+          "required": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
+        "users": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "email": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "email_verified": {
+              "type": "TypeBool",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "internal_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "source": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "source_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_marketplace_item": {
+      "schema": {
+        "build": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "categories": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        },
+        "creation_date": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "deployment_options": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "targets": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "files": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "value_type:TypeString"
+                },
+                "key": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "skus": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "value_type:TypeString"
+                }
+              }
+            }
+          }
+        },
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "description_en": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "details": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "how_to_use": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "overview": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "support": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "terms_and_conditions": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "details_en": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "how_to_use": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "overview": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "support": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "terms_and_conditions": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "editor": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "icon": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "optional": true,
+          "has_validate_func": true,
+          "conflicts_with": [
+            "name"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "last_update": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "id"
+          ],
+          "at_least_one_of": [
+            "id",
+            "name"
+          ],
+          "elem_kind": "nil"
+        },
+        "type": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "version": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_marketplace_items": {
+      "schema": {
+        "marketplace_items": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "build": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "categories": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            },
+            "creation_date": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "deployment_options": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "targets": {
+                  "type": "TypeList",
+                  "computed": true,
+                  "elem_kind": "resource",
+                  "elem_resource": {
+                    "files": {
+                      "type": "TypeList",
+                      "computed": true,
+                      "elem_kind": "value_type:TypeString"
+                    },
+                    "key": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "name": {
+                      "type": "TypeString",
+                      "computed": true,
+                      "elem_kind": "nil"
+                    },
+                    "skus": {
+                      "type": "TypeList",
+                      "computed": true,
+                      "elem_kind": "value_type:TypeString"
+                    }
+                  }
+                }
+              }
+            },
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description_en": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "details": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "how_to_use": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "overview": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "support": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "terms_and_conditions": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "details_en": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "how_to_use": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "overview": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "support": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "terms_and_conditions": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "editor": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "icon": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "last_update": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "type": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "version": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "name": {
+          "type": "TypeString",
+          "optional": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_acl": {
+      "schema": {
+        "acls": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "role": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "bucket_name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "storage_account_name"
+          ],
+          "elem_kind": "nil"
+        },
+        "storage_account_name": {
+          "type": "TypeString",
+          "optional": true,
+          "conflicts_with": [
+            "bucket_name"
+          ],
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_bucket": {
+      "schema": {
+        "endpoint": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "namespace": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "retention_period": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tags": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "value": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        },
+        "total_objects": {
+          "type": "TypeInt",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_objects_deleted": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size_deleted": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "total_size_unit": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "versioning": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_bucket_files": {
+      "schema": {
+        "bucket_name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "files": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "last_modified": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "size": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tags": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "key": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "value": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            },
+            "versions": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "is_delete_marker": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "is_latest": {
+                  "type": "TypeBool",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "last_modified": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "size": {
+                  "type": "TypeInt",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "version_id": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        },
+        "folder_path": {
+          "type": "TypeString",
+          "optional": true,
+          "default": "",
+          "elem_kind": "nil"
+        }
+      }
+    },
+    "cloudtemple_object_storage_buckets": {
+      "schema": {
+        "buckets": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "endpoint": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "namespace": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "retention_period": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_objects": {
+              "type": "TypeInt",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_objects_deleted": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_size": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_size_deleted": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "total_size_unit": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "versioning": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_object_storage_role": {
+      "schema": {
+        "description": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "permissions": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "value_type:TypeString"
+        }
+      }
+    },
+    "cloudtemple_object_storage_roles": {
+      "schema": {
+        "roles": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "permissions": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "value_type:TypeString"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_object_storage_storage_account": {
+      "schema": {
+        "access_key_id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "arn": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "create_date": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "id": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "name": {
+          "type": "TypeString",
+          "required": true,
+          "elem_kind": "nil"
+        },
+        "path": {
+          "type": "TypeString",
+          "computed": true,
+          "elem_kind": "nil"
+        },
+        "tags": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "key": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "value": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
+        }
+      }
+    },
+    "cloudtemple_object_storage_storage_accounts": {
+      "schema": {
+        "storage_accounts": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "access_key_id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "arn": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "create_date": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "id": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "path": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "tags": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "key": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "value": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **schema golden gate** (issue #298): a deterministic, committed snapshot of the full declared provider schema contract, plus a CI test (`TestSchemaSnapshot`) that fails on any divergence. Any change to what an existing client's Terraform state may legally contain — or whether an existing config still plans — must be seen and explicitly justified by a human before the golden is regenerated.

This is **test-support and test code only**. No production resource/datasource schema is changed, and no exported helper is added.

## What the snapshot captures

Walks `New(version)()` over `ResourcesMap` and `DataSourcesMap` (sorted keys), recursively into every attribute and nested `Elem` block.

Per attribute:
- `type` (TypeString/Bool/Int/Float/List/Set/Map)
- `required` / `optional` / `computed` / `force_new` / `sensitive`
- `min_items` / `max_items` / `config_mode`
- `default` — literal value for primitive defaults (string/bool/int/float); `has_default_func` for `DefaultFunc` or a non-primitive default (a Default *value* change is recorded verbatim, since it is breaking)
- function **presence** booleans (never bodies/pointers/addresses): `has_state_func`, `has_diff_suppress_func`, `diff_suppress_on_refresh`, `has_validate_func` (`ValidateFunc` **OR** `ValidateDiagFunc`, including a validator on a scalar `Elem`), `has_set_func` (custom `TypeSet` hash)
- sorted plan-constraint lists: `conflicts_with`, `exactly_one_of`, `at_least_one_of`, `required_with`
- explicit `elem_kind`: `nil` / `value_type:<T>` (scalar `*schema.Schema`) / `resource` (nested `*schema.Resource`, recursed into `elem_resource`)

Per resource/datasource: `schema_version`, each `StateUpgrader`'s `version` plus a stable cty type representation (`cty.Type.GoString()`, which sorts object keys), and `has_customize_diff`.

Excluded by design: `Description`/doc text, and any func body, pointer or address.

**Golden file:** `internal/provider/testdata/schema_snapshot.json` — sorted, pretty JSON, committed. ~279 KB / 10,349 lines, covering **13 resources** and **90 datasources** plus the provider config block.

## The gate

`TestSchemaSnapshot`:
- runs `Provider().InternalValidate()`;
- regenerates the snapshot from the live provider and compares it byte-for-byte to the golden, failing with a readable line-level diff + remediation steps on mismatch;
- asserts the snapshot is non-empty, counts the same number of resources/datasources the provider registers, and contains sentinel resources/datasources and a **known nested block** (`cloudtemple_iam_features.features` → recursed nested resource), so the gate cannot pass vacuously;
- locks that `cloudtemple_compute_virtual_machine` carries `SchemaVersion > 0` and a `StateUpgrader`.

## Human update procedure + CI-update ban

After a deliberate, justified change:

```
UPDATE_SCHEMA_SNAPSHOT=1 go test ./internal/provider -run TestSchemaSnapshot
```

Regeneration is deterministic (running it twice yields no diff — verified). The update path is **refused in CI**: if `UPDATE_SCHEMA_SNAPSHOT` is set while `CI=true`, the test fails hard, so an automated job can never silently rebaseline the contract. The backward-compatibility policy (likely-safe additive vs. breaking/state-shape) lives in the file header and in the failure message; v1 fails on **any** diff and the human classifies it.

## Non-complacency proof (5 mutations)

Each mutation was injected one at a time into a **production** schema, `TestSchemaSnapshot` confirmed RED, then reverted byte-identical (restored from git). The working tree's production code is byte-identical to `rc/v1.8.0` at the end (verified: `git diff origin/rc/v1.8.0 -- internal/` excluding the two new test files is empty).

| # | Mutation | Target | Result | Reverted |
|---|----------|--------|--------|----------|
| a | `Optional` → `Required` | provider `address` (provider.go) | RED — `optional: true` → `required: true` | byte-identical |
| b | change `Type` (`TypeInt` → `TypeString`) | `cloudtemple_backup_metrics.range` | RED | byte-identical |
| c | change primitive `Default` (`4` → `7`) | `cloudtemple_backup_metrics.range` | RED | byte-identical |
| d | add `ForceNew` | `cloudtemple_backup_metrics.range` | RED | byte-identical |
| e | remove an existing `ValidateFunc` | `cloudtemple_compute_virtual_machine.content_library_id` (`validation.IsUUID`) | RED — `has_validate_func` line disappears | byte-identical |

(For (e), removal of an existing validator was used rather than injecting a new one, to avoid a compile error from an unrelated missing import — the gate bites on the contract change itself, not on a build break.)

## Local verification

| Check | Result |
|-------|--------|
| `gofmt -l .` | clean |
| `go vet ./...` | clean |
| `staticcheck@2025.1.1 ./...` | 0 findings |
| `go test -race -count=1 ./internal/provider` | green |
| `TestSchemaSnapshot` clean compare | PASS |
| twice `UPDATE_SCHEMA_SNAPSHOT=1` | no diff (deterministic) |
| `CI=true UPDATE_SCHEMA_SNAPSHOT=1` | fails hard (CI-update ban) |
| `Provider().InternalValidate()` | OK |
| `./scripts/coverage_ratchet.sh` | green — `internal/provider` 8.5% → 8.5% (floor 8.5%), unchanged; serializer is test-only code, so it adds no production statements. Floor not lowered, not bumped. |

## Honest residual

This gate proves the **declared schema contract** is unchanged (or human-vetted). It does **not** prove: flatteners fit the schema (walker #288), read/update preserve state at runtime (resource tests), the live API still returns this shape (#8), or plans converge (separate increment). It captures only the **presence and types** of functions, never their bodies: `DefaultFunc`/`CustomizeDiff`/`StateFunc`/`Set`/`DiffSuppressFunc`/validator/`StateUpgrader.Upgrade` behaviour changes stay covered by behavioural tests. An SDK bump that changes the golden is a feature (forces a human re-verify), not a bug.

## Governance

**Awaiting independent reviewer — do not merge without explicit human GO.**

Refs #298
