### PR TITLE
fix(#238): treat VPC 403 as not-found (live API returns 403 for absent)

### DIFF
--- a/internal/client/vpc_floating_ip.go
+++ b/internal/client/vpc_floating_ip.go
@@ -56,7 +56,7 @@ func (f *VPCFloatingIPClient) List(ctx context.Context, filter *FloatingIPFilter
 }
 
 // Read retrieves a single floating IP by ID. It returns (nil, nil) when the
-// floating IP does not exist (404).
+// floating IP does not exist (403; the API returns 403 for an absent resource).
 func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP, error) {
 	r := f.c.newRequest("GET", "/vpc/v1/floating_ips/%s", id)
 	resp, err := f.c.doRequest(ctx, r)

--- a/internal/client/vpc_floating_ip.go
+++ b/internal/client/vpc_floating_ip.go
@@ -64,7 +64,7 @@ func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP,
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 404)
+	found, err := requireNotFoundOrOK(resp, 403)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/vpc_private_network.go
+++ b/internal/client/vpc_private_network.go
@@ -49,7 +49,7 @@ func (p *VPCPrivateNetworkClient) List(ctx context.Context, filter *PrivateNetwo
 }
 
 // Read retrieves a single private network by ID. It returns (nil, nil) when the
-// private network does not exist (404).
+// private network does not exist (403; the API returns 403 for an absent resource).
 func (p *VPCPrivateNetworkClient) Read(ctx context.Context, id string) (*PrivateNetwork, error) {
 	r := p.c.newRequest("GET", "/vpc/v1/private_networks/%s", id)
 	resp, err := p.c.doRequest(ctx, r)

--- a/internal/client/vpc_private_network.go
+++ b/internal/client/vpc_private_network.go
@@ -57,7 +57,7 @@ func (p *VPCPrivateNetworkClient) Read(ctx context.Context, id string) (*Private
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 404)
+	found, err := requireNotFoundOrOK(resp, 403)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/vpc_static_ip.go
+++ b/internal/client/vpc_static_ip.go
@@ -71,7 +71,7 @@ func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, err
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 404)
+	found, err := requireNotFoundOrOK(resp, 403)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *VPCStaticIPClient) ReadByMAC(ctx context.Context, mac string) (*StaticI
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 404)
+	found, err := requireNotFoundOrOK(resp, 403)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/vpc_static_ip.go
+++ b/internal/client/vpc_static_ip.go
@@ -63,7 +63,7 @@ func (s *VPCStaticIPClient) List(ctx context.Context, privateNetworkID string, f
 }
 
 // Read retrieves a single static IP by ID. It returns (nil, nil) when the
-// static IP does not exist (404).
+// static IP does not exist (403; the API returns 403 for an absent resource).
 func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/%s", id)
 	resp, err := s.c.doRequest(ctx, r)
@@ -85,7 +85,7 @@ func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, err
 }
 
 // ReadByMAC retrieves a single static IP by MAC address. It returns (nil, nil)
-// when no static IP matches the MAC (404).
+// when no static IP matches the MAC (403; the API returns 403 for an absent resource).
 func (s *VPCStaticIPClient) ReadByMAC(ctx context.Context, mac string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/mac/%s", mac)
 	resp, err := s.c.doRequest(ctx, r)

--- a/internal/client/vpc_unit_test.go
+++ b/internal/client/vpc_unit_test.go
@@ -91,16 +91,20 @@ func TestVPCVPCListAndRead(t *testing.T) {
 		}
 	})
 
-	t.Run("Read surfaces 403 as an access error (forbidden is not not-found)", func(t *testing.T) {
-		// The VPC swagger separates 403 (Forbidden) from 404 (not found). A 403
-		// must surface as a clear access error, never be swallowed as not-found
-		// (which would mask a missing vpc_read permission as "resource absent").
+	t.Run("Read treats 403 as not-found (the live VPC API returns 403 for an absent resource)", func(t *testing.T) {
+		// LIVE EVIDENCE (verified 2026-06-14 against a real tenant): the VPC API
+		// returns 403 Forbidden for an ABSENT resource, not 404 — despite the
+		// swagger documenting 404. So a single Read must treat 403 as not-found,
+		// like every other Cloud Temple read (the provider-wide convention). The
+		// trade-off — a genuine permission denial is indistinguishable from
+		// absence because the API conflates them — is an API-design limitation
+		// (anti-enumeration), not something the provider can resolve.
 		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
 		})
-		vpc, err := c.VPC().VPC().Read(ctx, "denied")
-		if err == nil {
-			t.Fatalf("403 must surface as an access error, not be swallowed as not-found; got vpc=%+v err=nil", vpc)
+		vpc, err := c.VPC().VPC().Read(ctx, "absent")
+		if err != nil || vpc != nil {
+			t.Fatalf("403 must yield (nil,nil) (the API returns 403 for absent); got vpc=%+v err=%v", vpc, err)
 		}
 	})
 }

--- a/internal/client/vpc_vpc.go
+++ b/internal/client/vpc_vpc.go
@@ -42,7 +42,7 @@ func (v *VPCVPCClient) List(ctx context.Context) ([]*VPC, error) {
 }
 
 // Read retrieves a single VPC by ID. It returns (nil, nil) when the VPC does
-// not exist (404) so callers can surface a precise not-found error.
+// not exist (403; the API returns 403 for an absent resource) so callers can surface a precise not-found error.
 func (v *VPCVPCClient) Read(ctx context.Context, id string) (*VPC, error) {
 	r := v.c.newRequest("GET", "/vpc/v1/vpc/%s", id)
 	resp, err := v.c.doRequest(ctx, r)

--- a/internal/client/vpc_vpc.go
+++ b/internal/client/vpc_vpc.go
@@ -50,7 +50,7 @@ func (v *VPCVPCClient) Read(ctx context.Context, id string) (*VPC, error) {
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 404)
+	found, err := requireNotFoundOrOK(resp, 403)
 	if err != nil || !found {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Reverts the `403→404` change made in #301 for the five VPC single-reads: they pass `requireNotFoundOrOK(resp, 403)` again, so a `403` is treated as not-found.

## Why — live evidence (the recette tenant earned its keep)

#301 changed the VPC reads to `404` based on the **swagger**, which documents `403` (Forbidden) and `404` (not found) as distinct. A read-only probe against a **real tenant** proved the swagger wrong:

- `VPC.Read(<absent id>)` and `PrivateNetwork.Read(<absent id>)` → **`403 Forbidden`**. The live VPC API returns **403 for an ABSENT resource**, not 404.
- The datasources themselves read real data correctly (1 VPC + 4 private networks with their CIDRs).

So treating `403` as not-found is the **correct** behaviour and matches the provider-wide convention (51 call sites): a lookup of an absent VPC/network now returns a clean not-found instead of a confusing `access denied` error.

## Trade-off (API limitation, not a provider bug)

The API conflates absent and forbidden (both → `403`, an anti-enumeration pattern), so a genuine permission denial is indistinguishable from absence. The provider cannot resolve this. The **swagger incorrectly documents 404** for not-found — to be reported to the API team (tracked in #302).

## Verification

- Unit test flipped to pin `403 → (nil,nil)` with the live-evidence rationale; green.
- Re-validated **live**: `Read(absent)` now returns a clean not-found (no error).
- gofmt / vet / staticcheck clean; `go test -race ./internal/client` green.

Refs #238