### PR TITLE
test(#300): recette lifecycle harness Phase 1 (PAT + object storage)

### DIFF
--- a/.env.recette.dist
+++ b/.env.recette.dist
@@ -1,0 +1,33 @@
+# Phase 1 recette harness — environment template (VARIABLE NAMES ONLY, NO VALUES).
+#
+# Copy to .env.recette (gitignored), fill the values, and source it before a
+# supervised recette run. NEVER commit .env.recette. NEVER print these values.
+#
+# The Go harness does NOT read this file: credentials must already be in the
+# process environment (source .env.recette, or CI environment secrets).
+
+# --- Provider credentials (the recette PAT) --------------------------------
+CLOUDTEMPLE_HTTP_SCHEME=
+CLOUDTEMPLE_HTTP_ADDR=
+CLOUDTEMPLE_CLIENT_ID=
+CLOUDTEMPLE_SECRET_ID=
+
+# --- Tenant allowlist (THE safety core) ------------------------------------
+# The recette tenant's JWT scope.id (UUID). The guard authenticates and refuses
+# to run unless the authenticated tenant equals this value. NEVER commit a UUID.
+CLOUDTEMPLE_RECETTE_TENANT_ID=
+
+# --- Phase 1 substrate (must pre-exist on the tenant; datasource-only) ------
+# IAM role name granted to the PAT (PAT create fails with no role).
+CLOUDTEMPLE_RECETTE_IAM_ROLE_NAME=
+# Object-storage role name granted by the acl_entry (referenced by name).
+CLOUDTEMPLE_RECETTE_OS_ROLE_NAME=
+
+# --- Acceptance switch ------------------------------------------------------
+# With TF_ACC unset the live TestCases SKIP and nothing touches the API.
+TF_ACC=1
+
+# --- Standalone HCL stack (examples/recette/objectstorage_pat) --------------
+# Terraform reads these TF_VAR_* for the supervised run.sh stack.
+TF_VAR_iam_role_name=
+TF_VAR_object_storage_role_name=

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ terraform.rc
 
 .env
 .env.test
+.env.recette
 .vscode/
 
 # Local-only internal audit subtree (kept on workstation, never published to

--- a/examples/recette/README.md
+++ b/examples/recette/README.md
@@ -66,15 +66,14 @@ allowlisted recette tenant — and abort hard otherwise.*
 ## Teardown layering
 
 1. **SDK auto-destroy** per TestCase (primary), even on a failed step.
-2. **Guarded start-of-run cleanup**: the recette `TestMain` calls an explicit,
-   tenant-guarded cleanup at the start of a live run (clean slate). This is **not**
-   `AddTestSweepers` (which only fires under `-sweep`); the cleanup body is shared
-   with the registered sweeper via one function.
-3. **Manual `-sweep` orphan cleanup** (documented below). Sweepers do **not**
-   auto-run; they fire only with the `-sweep` flag, and each re-asserts the tenant
-   guard before deleting anything. Deletes are scoped to the `test-terraform*`
-   name prefix / `created_by=Terraform` tag; PAT deletes are additionally filtered
-   to the principal's own `UserId` + `TenantId`.
+2. **Explicit `-sweep` clean slate / orphan cleanup** (documented below). There is
+   **no** automatic start-of-run cleanup: the recette `TestMain` mutates nothing on
+   its own (it only runs the tenant guard). A clean slate is obtained by running
+   the explicit, destructive `-sweep` **before** a run — never automatically.
+   Sweepers do **not** auto-run; they fire only with the `-sweep` flag, and each
+   re-asserts the tenant guard before deleting anything. Deletes are scoped to the
+   `test-terraform*` name prefix / `created_by=Terraform` tag; PAT deletes are
+   additionally filtered to the principal's own `UserId` + `TenantId`.
 
 ## How to run (each live step needs explicit human GO)
 
@@ -109,10 +108,15 @@ second plan, lets you inspect, and **always destroys on exit**):
 ./examples/recette/objectstorage_pat/run.sh
 ```
 
-### Orphan cleanup (belt-and-braces)
+### Explicit `-sweep` (clean slate before a run / orphan cleanup after)
+
+This is the **only** automatic-mutation-free destructive step, and it is fully
+**opt-in**: nothing sweeps unless you pass `-sweep`. Run it **before** a run to
+get a clean slate, or **after** a run to clear orphans. It re-asserts the tenant
+guard, then deletes only recette-scoped objects.
 
 ```sh
-# Re-asserts the tenant guard, then deletes only recette-scoped objects.
+# DESTRUCTIVE — run on purpose, never automatic.
 TF_ACC=1 go test ./internal/provider/tests/recette/... -sweep=recette -sweep-allow-failures
 ```
 

--- a/examples/recette/README.md
+++ b/examples/recette/README.md
@@ -1,0 +1,134 @@
+# Recette harness (live acceptance) — Phase 1
+
+This directory holds the **supervised, human-run** artifacts of the live
+acceptance ("recette") harness for issue **#300**. The full design lives in the
+[#300 design comment](https://github.com/Cloud-Temple/terraform-provider-cloudtemple/issues/300)
+— this README does not duplicate it; it documents only what Phase 1 ships and
+how to run it safely.
+
+> **Nothing here runs automatically.** The Go harness skips without `TF_ACC`, and
+> the standalone stack is run by a human under explicit GO. No live execution is
+> performed by Phase 1 code.
+
+## Phase 1 scope
+
+Exactly the resources buildable on a **truly empty** tenant with **no compute
+substrate**:
+
+- `cloudtemple_iam_personal_access_token` (needs a pre-existing IAM role)
+- `cloudtemple_object_storage_bucket`
+- `cloudtemple_object_storage_storage_account`
+- `cloudtemple_object_storage_acl_entry` (bucket × object-storage role-by-name × account)
+
+**Excluded:** all compute (deferred on the Q1 substrate question) and
+`global_access_key` (cannot be deleted via the API).
+
+### Substrate assumption
+
+Even an "empty" recette tenant must already carry, pre-existing and
+datasource-only: **one IAM role** (for the PAT — PAT create hard-fails with no
+role), **one object-storage role** (for the ACL), the **object-storage
+service/namespace enabled**, and credentials with **object-storage + activity
+read/wait** permissions. These are injected by env-var name only (see
+`.env.recette.dist`).
+
+## Safety model (the point of this harness)
+
+Tenant scoping is **credential-only** (the PAT's JWT `scope.id`). The whole
+safety story is: *prove, before any mutation, that the credentials point at the
+allowlisted recette tenant — and abort hard otherwise.*
+
+- **Env-var allowlist.** `CLOUDTEMPLE_RECETTE_TENANT_ID` is a **required**
+  runtime value. It is never committed and never printed. The guard refuses to
+  fall back to "current tenant".
+- **Fail-closed, un-skippable guard.** The recette sub-package
+  (`internal/provider/tests/recette/`) has its **own** `TestMain` that, in live
+  mode (`TF_ACC`) or sweep mode (`-sweep`), authenticates and asserts the tenant
+  equals the allowlist **before any TestCase or sweeper runs**, aborting fatally
+  on mismatch. Each TestCase `PreCheck` re-asserts the guard as defence in depth,
+  but the real un-skippability is the `TestMain` gate.
+- **Redacted errors.** A mismatch aborts with a generic message that names only
+  the env var; it never prints the expected or the actual tenant UUID. No UUID is
+  ever committed.
+- **Default path is safe.** With `TF_ACC` unset and no `-sweep`, the guard is
+  skipped, the pure unit tests run without credentials and without any network
+  call, and the package never hard-exits.
+
+### Leak bans (SecNumCloud posture)
+
+- **No `TF_LOG=DEBUG` capture/artifacts.** The provider transport masks the PAT
+  body and `Authorization`, but **not** the object-storage `secretAccessKey`, so
+  `DEBUG` logs can leak the storage secret.
+- **No `set -x`, no env echo** in any script (`run.sh` enforces this).
+- **No tenant UUID in errors or commits.** The allowlist is the env var's runtime
+  value only.
+
+## Teardown layering
+
+1. **SDK auto-destroy** per TestCase (primary), even on a failed step.
+2. **Guarded start-of-run cleanup**: the recette `TestMain` calls an explicit,
+   tenant-guarded cleanup at the start of a live run (clean slate). This is **not**
+   `AddTestSweepers` (which only fires under `-sweep`); the cleanup body is shared
+   with the registered sweeper via one function.
+3. **Manual `-sweep` orphan cleanup** (documented below). Sweepers do **not**
+   auto-run; they fire only with the `-sweep` flag, and each re-asserts the tenant
+   guard before deleting anything. Deletes are scoped to the `test-terraform*`
+   name prefix / `created_by=Terraform` tag; PAT deletes are additionally filtered
+   to the principal's own `UserId` + `TenantId`.
+
+## How to run (each live step needs explicit human GO)
+
+Credentials and the allowlist are injected via the environment. Copy the
+template and fill it (never commit it):
+
+```sh
+cp .env.recette.dist .env.recette   # .env.recette is gitignored
+# edit .env.recette, then:
+set -a; . ./.env.recette; set +a
+```
+
+### Phase A — compile-and-skip (no mutation)
+
+```sh
+# Builds, runs the guard unit tests, and SKIPS the live tests (no TF_ACC).
+go test ./internal/provider/tests/recette/... -run 'Recette' -v
+```
+
+### Phase B — supervised build + destroy (explicit GO)
+
+Either drive the Go lifecycle harness:
+
+```sh
+TF_ACC=1 go test ./internal/provider/tests/recette/... -run 'TestAccRecette' -v -count=1
+```
+
+…or run the standalone stack (it guards the tenant, builds, verifies an empty
+second plan, lets you inspect, and **always destroys on exit**):
+
+```sh
+./examples/recette/objectstorage_pat/run.sh
+```
+
+### Orphan cleanup (belt-and-braces)
+
+```sh
+# Re-asserts the tenant guard, then deletes only recette-scoped objects.
+TF_ACC=1 go test ./internal/provider/tests/recette/... -sweep=recette -sweep-allow-failures
+```
+
+### Phase C — CI integration
+
+Out of Phase 1 scope. CI activation must be gated behind a GitHub
+`environment: recette` (required reviewers), `workflow_dispatch`/`schedule`
+triggers, and an `if: always()` teardown step. No live trigger is enabled here.
+
+## Known convergence risk (bucket/acl drift)
+
+The bucket resource's `Read` re-populates its **inline** `acl_entry` (an
+`Optional` field) from the live ACL listing. The Phase 1 stack manages the ACL
+**only** via the standalone `acl_entry` resource and keeps the bucket config free
+of an inline block. If, in live mode, the bucket `Read` writes a non-empty inline
+`acl_entry` into the bucket state while the config declares none, the second plan
+will not be empty — a genuine state-safety finding to report on #300, **not** to
+paper over. The lifecycle test deliberately does not set `ExpectNonEmptyPlan`, so
+this surfaces as a hard failure if it occurs.

--- a/examples/recette/objectstorage_pat/main.tf
+++ b/examples/recette/objectstorage_pat/main.tf
@@ -1,0 +1,65 @@
+# Phase 1 recette stack — PAT + object storage (INERT).
+#
+# This stack is for the LATER supervised phase (Phase B in the #300 design); it
+# is NOT run by the Go harness and NOT run automatically. A human runs it under
+# explicit GO, via run.sh, which guards the tenant and always destroys.
+#
+# Scope: exactly the Phase 1 resources buildable on a TRULY EMPTY tenant with NO
+# compute substrate:
+#   - cloudtemple_iam_personal_access_token (needs a pre-existing IAM role)
+#   - cloudtemple_object_storage_bucket
+#   - cloudtemple_object_storage_storage_account
+#   - cloudtemple_object_storage_acl_entry (bucket x os-role-by-name x account)
+#
+# EXCLUDED (per the brief): all compute (Q1 substrate unresolved) and
+# global_access_key (cannot be deleted via API).
+
+terraform {
+  required_providers {
+    cloudtemple = {
+      source = "cloud-temple/cloudtemple"
+    }
+  }
+}
+
+# Credentials come from the standard CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID
+# environment variables (sourced from a gitignored .env.recette, never committed).
+provider "cloudtemple" {}
+
+# Pre-existing IAM role for the PAT. PAT create HARD-FAILS with no role, so this
+# role must already exist on the tenant (datasource-only).
+data "cloudtemple_iam_role" "recette" {
+  name = var.iam_role_name
+}
+
+# Pre-existing object-storage role for the ACL. The acl_entry references the
+# role BY NAME.
+data "cloudtemple_object_storage_role" "recette" {
+  name = var.object_storage_role_name
+}
+
+resource "cloudtemple_iam_personal_access_token" "recette" {
+  name            = "test-terraform-recette-pat"
+  roles           = [data.cloudtemple_iam_role.recette.id]
+  expiration_date = var.pat_expiration_date
+}
+
+resource "cloudtemple_object_storage_bucket" "recette" {
+  name        = "test-terraform-recette-bucket"
+  access_type = "private"
+
+  # Deliberately NO inline acl_entry block. The ACL is managed by the standalone
+  # resource below. Managing the same ACL both inline (on the bucket) and via the
+  # standalone resource causes convergence drift, because the bucket Read
+  # re-populates its inline acl_entry from the live ACL listing.
+}
+
+resource "cloudtemple_object_storage_storage_account" "recette" {
+  name = "test-terraform-recette-sa"
+}
+
+resource "cloudtemple_object_storage_acl_entry" "recette" {
+  bucket          = cloudtemple_object_storage_bucket.recette.name
+  role            = data.cloudtemple_object_storage_role.recette.name
+  storage_account = cloudtemple_object_storage_storage_account.recette.name
+}

--- a/examples/recette/objectstorage_pat/run.sh
+++ b/examples/recette/objectstorage_pat/run.sh
@@ -14,7 +14,20 @@
 #     object-storage secretAccessKey, so DEBUG logs can leak the storage secret.
 #   - Fail-closed tenant guard BEFORE apply: a non-mutating Go pre-flight
 #     authenticates and asserts the tenant equals CLOUDTEMPLE_RECETTE_TENANT_ID.
+#     The pre-flight runs ONLY the guard (TestRecetteLiveGuardOnly); the recette
+#     TestMain has no auto-cleanup, so this pre-flight creates and destroys
+#     nothing — the "no mutation" label below is literally true.
 #   - trap on EXIT runs `terraform destroy` on success, failure, or Ctrl-C.
+#
+# This script NEVER sweeps. If you want a clean slate before the apply, run the
+# explicit, DESTRUCTIVE sweep yourself, on purpose, BEFORE invoking this script:
+#
+#     TF_ACC=1 go test ./internal/provider/tests/recette/... \
+#       -sweep=recette -sweep-allow-failures
+#
+# That -sweep deletes recette-scoped objects (it re-asserts the tenant guard
+# first). It is intentionally NOT auto-run here: a destructive delete must be an
+# explicit operator decision, never a hidden side effect of a guarded pre-flight.
 #
 # Credentials and the tenant allowlist are injected via the environment (sourced
 # from a gitignored .env.recette or CI environment secrets). This script never
@@ -34,7 +47,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 # --- Fail-closed tenant guard pre-flight (mutates nothing) ------------------
 # Reuses the exact same guard as the Go harness. Aborts here if the authenticated
-# tenant does not match the allowlist, BEFORE any terraform apply.
+# tenant does not match the allowlist, BEFORE any terraform apply. The recette
+# TestMain runs ONLY the guard (no auto-sweep), so this pre-flight truly mutates
+# nothing: it creates and destroys no resource.
 echo "Running tenant guard pre-flight (no mutation)..."
 TF_ACC=1 go test "${REPO_ROOT}/internal/provider/tests/recette/" \
   -run '^TestRecetteLiveGuardOnly$' -count=1 -v

--- a/examples/recette/objectstorage_pat/run.sh
+++ b/examples/recette/objectstorage_pat/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Phase 1 recette wrapper — PAT + object storage (SUPERVISED, human-run only).
+#
+# This script is INERT in the harness: it is only run by a human under explicit
+# GO during the supervised phase (Phase B of the #300 design). It builds the
+# Phase 1 stack, lets the operator inspect it, and ALWAYS tears it down.
+#
+# SAFETY (non-negotiable, SecNumCloud posture):
+#   - NO `set -x`: command tracing would echo resolved secrets/role names.
+#   - NO env echo / no `env` / no `printenv`: the environment carries the PAT
+#     credentials and the storage secret.
+#   - NO TF_LOG=DEBUG: the provider transport masks the PAT body but NOT the
+#     object-storage secretAccessKey, so DEBUG logs can leak the storage secret.
+#   - Fail-closed tenant guard BEFORE apply: a non-mutating Go pre-flight
+#     authenticates and asserts the tenant equals CLOUDTEMPLE_RECETTE_TENANT_ID.
+#   - trap on EXIT runs `terraform destroy` on success, failure, or Ctrl-C.
+#
+# Credentials and the tenant allowlist are injected via the environment (sourced
+# from a gitignored .env.recette or CI environment secrets). This script never
+# reads .env.recette itself and never prints any value.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# --- Required environment (names only; values never printed) ----------------
+: "${CLOUDTEMPLE_RECETTE_TENANT_ID:?CLOUDTEMPLE_RECETTE_TENANT_ID must be set (recette tenant allowlist)}"
+: "${CLOUDTEMPLE_CLIENT_ID:?CLOUDTEMPLE_CLIENT_ID must be set}"
+: "${CLOUDTEMPLE_SECRET_ID:?CLOUDTEMPLE_SECRET_ID must be set}"
+: "${TF_VAR_iam_role_name:?TF_VAR_iam_role_name must be set (pre-existing IAM role name)}"
+: "${TF_VAR_object_storage_role_name:?TF_VAR_object_storage_role_name must be set (pre-existing object-storage role name)}"
+
+# --- Fail-closed tenant guard pre-flight (mutates nothing) ------------------
+# Reuses the exact same guard as the Go harness. Aborts here if the authenticated
+# tenant does not match the allowlist, BEFORE any terraform apply.
+echo "Running tenant guard pre-flight (no mutation)..."
+TF_ACC=1 go test "${REPO_ROOT}/internal/provider/tests/recette/" \
+  -run '^TestRecetteLiveGuardOnly$' -count=1 -v
+
+# --- Always destroy on exit -------------------------------------------------
+cd "${SCRIPT_DIR}"
+trap 'echo "Tearing down recette stack..."; terraform destroy -auto-approve' EXIT
+
+terraform init -input=false
+terraform validate
+
+# Convergence: an apply, then a plan that must be empty (exit code 0).
+terraform apply -auto-approve -input=false
+echo "Stack built. Verifying convergence (empty second plan)..."
+terraform plan -detailed-exitcode -input=false
+
+echo "Recette stack is up. Inspect it now, then this script will destroy on exit."
+# The trap above destroys when the script exits (normally or on interrupt).

--- a/examples/recette/objectstorage_pat/variables.tf
+++ b/examples/recette/objectstorage_pat/variables.tf
@@ -1,0 +1,15 @@
+variable "iam_role_name" {
+  type        = string
+  description = "Name of the pre-existing IAM role granted to the PAT. PAT create fails with no role."
+}
+
+variable "object_storage_role_name" {
+  type        = string
+  description = "Name of the pre-existing object-storage role granted by the ACL entry (referenced by name)."
+}
+
+variable "pat_expiration_date" {
+  type        = string
+  default     = "2999-01-01T00:00:00Z"
+  description = "RFC3339 expiration date for the PAT. Defaults far in the future for a short-lived recette run."
+}

--- a/internal/provider/tests/recette/baseline_test.go
+++ b/internal/provider/tests/recette/baseline_test.go
@@ -1,0 +1,196 @@
+package recette
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Destroy-to-empty proof (#300 D2.5). The recette tenant is not assumed to be
+// literally empty: it may carry pre-existing platform/substrate objects. So we
+// capture the PRE-BUILD baseline set of ids/names, then after the SDK
+// auto-destroy assert the listing returns EXACTLY to that baseline (no orphan
+// left, nothing pre-existing wrongly deleted).
+//
+// We use the *Strict listings (HTTP 200 only): a 206 partial listing cannot
+// prove an absence, so it must fail closed rather than produce a false
+// "destroyed-to-empty".
+//
+// acl_entry has no strict list endpoint -> its destroy-to-empty is a documented
+// residual risk, verified indirectly: revoking via the bucket teardown and the
+// bucket/account baselines returning to their pre-build set.
+
+type stringSet map[string]struct{}
+
+// patSet keys PATs by id, restricted at capture time to the authenticated
+// principal's own tokens so the baseline is comparable to the post-destroy set.
+type patSet map[string]struct{}
+
+func newStringSet(items []string) stringSet {
+	s := make(stringSet, len(items))
+	for _, it := range items {
+		s[it] = struct{}{}
+	}
+	return s
+}
+
+// diff returns elements in have that are not in want (orphans) and elements in
+// want missing from have (wrongly deleted), as sorted slices for stable output.
+func diffSets(want, have stringSet) (added, missing []string) {
+	for k := range have {
+		if _, ok := want[k]; !ok {
+			added = append(added, k)
+		}
+	}
+	for k := range want {
+		if _, ok := have[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(missing)
+	return added, missing
+}
+
+func mustCaptureOSBaselines(t *testing.T) (buckets stringSet, accounts stringSet) {
+	t.Helper()
+	ctx := context.Background()
+	c, err := newRecetteClient()
+	if err != nil {
+		t.Fatalf("recette baseline: %s", err)
+	}
+	bs, err := c.ObjectStorage().Bucket().ListStrict(ctx)
+	if err != nil {
+		t.Fatalf("recette baseline: failed to list buckets: %s", err)
+	}
+	as, err := c.ObjectStorage().StorageAccount().ListStrict(ctx)
+	if err != nil {
+		t.Fatalf("recette baseline: failed to list storage accounts: %s", err)
+	}
+	var bnames, anames []string
+	for _, b := range bs {
+		if b != nil {
+			bnames = append(bnames, b.Name)
+		}
+	}
+	for _, a := range as {
+		if a != nil {
+			anames = append(anames, a.Name)
+		}
+	}
+	return newStringSet(bnames), newStringSet(anames)
+}
+
+func assertOSBaselinesRestored(t *testing.T, buckets, accounts stringSet) error {
+	t.Helper()
+	ctx := context.Background()
+	c, err := newRecetteClient()
+	if err != nil {
+		return err
+	}
+	bs, err := c.ObjectStorage().Bucket().ListStrict(ctx)
+	if err != nil {
+		return err
+	}
+	as, err := c.ObjectStorage().StorageAccount().ListStrict(ctx)
+	if err != nil {
+		return err
+	}
+	var bnames, anames []string
+	for _, b := range bs {
+		if b != nil {
+			bnames = append(bnames, b.Name)
+		}
+	}
+	for _, a := range as {
+		if a != nil {
+			anames = append(anames, a.Name)
+		}
+	}
+	if err := assertRestored("bucket", buckets, newStringSet(bnames)); err != nil {
+		return err
+	}
+	return assertRestored("storage account", accounts, newStringSet(anames))
+}
+
+func mustCapturePATBaseline(t *testing.T) patSet {
+	t.Helper()
+	ctx := context.Background()
+	c, err := newRecetteClient()
+	if err != nil {
+		t.Fatalf("recette baseline: %s", err)
+	}
+	lt, err := c.Token(ctx)
+	if err != nil {
+		t.Fatalf("recette baseline: failed to authenticate: %s", err)
+	}
+	tokens, err := c.IAM().PAT().ListStrict(ctx)
+	if err != nil {
+		t.Fatalf("recette baseline: failed to list PATs: %s", err)
+	}
+	s := make(patSet)
+	for _, tok := range tokens {
+		if tok == nil {
+			continue
+		}
+		// Restrict to the principal's own tokens so the set is comparable
+		// after destroy (the listing is not scoped server-side, #226).
+		if tok.UserId == lt.UserID() && tok.TenantId == lt.TenantID() {
+			s[tok.ID] = struct{}{}
+		}
+	}
+	return s
+}
+
+func assertPATBaselineRestored(t *testing.T, baseline patSet) error {
+	t.Helper()
+	ctx := context.Background()
+	c, err := newRecetteClient()
+	if err != nil {
+		return err
+	}
+	lt, err := c.Token(ctx)
+	if err != nil {
+		return err
+	}
+	tokens, err := c.IAM().PAT().ListStrict(ctx)
+	if err != nil {
+		return err
+	}
+	have := make(stringSet)
+	for _, tok := range tokens {
+		if tok == nil {
+			continue
+		}
+		if tok.UserId == lt.UserID() && tok.TenantId == lt.TenantID() {
+			have[tok.ID] = struct{}{}
+		}
+	}
+	return assertRestored("personal access token", stringSet(baseline), have)
+}
+
+// assertRestored compares the post-destroy set to the pre-build baseline. It
+// reports orphans (added) and wrongly-removed pre-existing objects (missing).
+// It never prints a secret; ids/names are non-sensitive here.
+func assertRestored(kind string, baseline, have stringSet) error {
+	added, missing := diffSets(baseline, have)
+	if len(added) == 0 && len(missing) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	b.WriteString(kind + " set did not return to the pre-build baseline after destroy")
+	if len(added) > 0 {
+		b.WriteString("; orphans left behind: " + strings.Join(added, ", "))
+	}
+	if len(missing) > 0 {
+		b.WriteString("; pre-existing items wrongly removed: " + strings.Join(missing, ", "))
+	}
+	return errString(b.String())
+}
+
+// errString is a tiny error type so assertRestored stays allocation-light and
+// dependency-free.
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/provider/tests/recette/guard.go
+++ b/internal/provider/tests/recette/guard.go
@@ -1,0 +1,135 @@
+// Package recette hosts the LIVE acceptance ("recette") harness for issue #300,
+// Phase 1: PAT + object storage on a TRULY EMPTY, dedicated recette tenant.
+//
+// This package is intentionally ISOLATED from internal/provider/tests so it can
+// own its own TestMain: the existing tests TestMain performs destructive cleanup
+// unconditionally and is unsafe to reuse for a live recette run (see #300 brief).
+//
+// SAFETY MODEL (non-negotiable, SecNumCloud posture):
+//   - The harness can only ever touch the allowlisted recette tenant. The
+//     allowlist is the runtime value of the env var CLOUDTEMPLE_RECETTE_TENANT_ID;
+//     it is NEVER committed and NEVER printed.
+//   - The guard is fail-closed and un-skippable: the live/sweep path runs the
+//     auth + tenant assertion BEFORE anything mutating, and aborts fatally on
+//     any mismatch.
+//   - Guard errors are redacted: they never print the expected or the actual
+//     tenant UUID.
+//   - With TF_ACC unset and no -sweep flag, the guard is skipped and the pure
+//     unit tests run WITHOUT credentials and WITHOUT any network call.
+package recette
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// recetteTenantEnvName is the REQUIRED allowlist env var. Its runtime value is
+// the recette tenant's JWT scope.id (a UUID). It is never committed; the guard
+// reads it only at runtime and never prints it.
+const recetteTenantEnvName = "CLOUDTEMPLE_RECETTE_TENANT_ID"
+
+// errRecetteTenantUnset is returned when the allowlist env var is missing or
+// empty in live/sweep mode. The harness must abort and mutate nothing.
+var errRecetteTenantUnset = fmt.Errorf(
+	"%s must be set to the recette tenant id to run the live recette harness; refusing to fall back to the current tenant",
+	recetteTenantEnvName,
+)
+
+// errRecetteTenantMismatch is returned when the authenticated tenant does not
+// match the allowlist. It is deliberately GENERIC: it never embeds the expected
+// or the actual tenant UUID, so a failing run cannot leak either value.
+var errRecetteTenantMismatch = fmt.Errorf(
+	"authenticated tenant does not match %s; aborting before any mutation",
+	recetteTenantEnvName,
+)
+
+// assertRecetteTenant is the PURE core of the guard. It compares the allowlisted
+// tenant id (expected) with the authenticated tenant id (actual) and returns a
+// redacted error on any failure. It performs NO I/O so it can be table-tested
+// without credentials or a network call.
+//
+// Fail-closed semantics:
+//   - empty expected  -> errRecetteTenantUnset (never trust an empty allowlist);
+//   - empty actual    -> errRecetteTenantMismatch (an unauthenticated/blank tenant
+//     can never satisfy the allowlist);
+//   - expected != actual -> errRecetteTenantMismatch;
+//   - expected == actual (both non-empty) -> nil.
+//
+// Neither returned error embeds either UUID, so the caller can print them
+// verbatim without leaking a tenant id.
+func assertRecetteTenant(expected, actual string) error {
+	if expected == "" {
+		return errRecetteTenantUnset
+	}
+	if actual == "" || actual != expected {
+		return errRecetteTenantMismatch
+	}
+	return nil
+}
+
+// newRecetteClient builds a client from the standard CLOUDTEMPLE_* credentials
+// (CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID / CLOUDTEMPLE_HTTP_ADDR ...).
+// It NEVER reads .env.recette: credentials are injected into the process
+// environment by the caller (CI environment secrets or a sourced, gitignored
+// .env.recette), never loaded from a committed file.
+func newRecetteClient() (*client.Client, error) {
+	config := client.DefaultConfig()
+	if config.ClientID == "" || config.SecretID == "" {
+		return nil, fmt.Errorf(
+			"%s and %s must be set to authenticate the recette harness",
+			client.HTTPClientIDEnvName, client.HTTPClientSecretEnvName,
+		)
+	}
+	return client.NewClient(config)
+}
+
+// guardLiveTenant performs the LIVE guard: read the allowlist env var,
+// authenticate, resolve the authenticated tenant id, and assert it matches.
+// It returns a redacted error on any failure and is the single un-skippable
+// gate the live/sweep TestMain path runs before anything mutating.
+//
+// It NEVER prints any tenant UUID, client id, or secret: only the env-var NAME
+// appears in its messages.
+func guardLiveTenant(ctx context.Context) error {
+	expected := os.Getenv(recetteTenantEnvName)
+	if expected == "" {
+		// Fail closed before even touching the network.
+		return errRecetteTenantUnset
+	}
+
+	c, err := newRecetteClient()
+	if err != nil {
+		// Do not wrap with credential values; client errors are already
+		// credential-free.
+		return fmt.Errorf("recette guard: failed to build client: %w", err)
+	}
+
+	token, err := c.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("recette guard: failed to authenticate: %w", err)
+	}
+
+	if err := assertRecetteTenant(expected, token.TenantID()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// abortRedacted prints a redacted message to stderr and exits non-zero. It is
+// the only exit path of the live guard and is careful to print neither UUID nor
+// credential. The errors it receives are already redacted by construction.
+func abortRedacted(err error) {
+	fmt.Fprintf(os.Stderr, "recette harness aborted: %s\n", err.Error())
+	os.Exit(1)
+}
+
+// isRedactedGuardError reports whether err is one of the guard's redacted
+// sentinels. It lets tests assert on the failure CLASS without ever comparing
+// or printing a tenant id.
+func isRedactedGuardError(err error) bool {
+	return errors.Is(err, errRecetteTenantUnset) || errors.Is(err, errRecetteTenantMismatch)
+}

--- a/internal/provider/tests/recette/guard_test.go
+++ b/internal/provider/tests/recette/guard_test.go
@@ -1,0 +1,136 @@
+package recette
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRecetteLiveGuardOnly is a NON-MUTATING live pre-flight: in live mode
+// (TF_ACC) it authenticates and asserts the tenant matches the allowlist, then
+// returns. It creates and destroys NOTHING. The standalone HCL wrapper (run.sh)
+// invokes it before `terraform apply` so the tenant guard runs once outside the
+// SDK TestCase machinery too. Without TF_ACC it skips (no creds, no network).
+func TestRecetteLiveGuardOnly(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("live tenant guard pre-flight skipped unless TF_ACC is set")
+	}
+	if err := guardLiveTenant(t.Context()); err != nil {
+		// Redacted by construction: never prints a tenant id.
+		t.Fatalf("recette tenant guard refused the run: %s", err)
+	}
+}
+
+// TestRecetteGuardAssertTenant is the guard's proof. It table-tests the PURE
+// comparison assertRecetteTenant with no TF_ACC and no network call.
+//
+// It is deliberately NON-COMPLACENT: it asserts the exact pass/fail boundary so
+// the test goes RED if the comparison is inverted (e.g. == becomes !=) or if an
+// empty input is silently accepted.
+func TestRecetteGuardAssertTenant(t *testing.T) {
+	const (
+		recette = "11111111-1111-1111-1111-111111111111"
+		other   = "22222222-2222-2222-2222-222222222222"
+	)
+
+	cases := []struct {
+		name     string
+		expected string
+		actual   string
+		// wantErr nil means the guard must let the run proceed.
+		wantErr error
+	}{
+		{
+			name:     "empty expected aborts (never trust an empty allowlist)",
+			expected: "",
+			actual:   recette,
+			wantErr:  errRecetteTenantUnset,
+		},
+		{
+			name:     "empty expected with empty actual still aborts as unset",
+			expected: "",
+			actual:   "",
+			wantErr:  errRecetteTenantUnset,
+		},
+		{
+			name:     "empty actual aborts (blank tenant cannot satisfy the allowlist)",
+			expected: recette,
+			actual:   "",
+			wantErr:  errRecetteTenantMismatch,
+		},
+		{
+			name:     "mismatch aborts",
+			expected: recette,
+			actual:   other,
+			wantErr:  errRecetteTenantMismatch,
+		},
+		{
+			name:     "exact match proceeds",
+			expected: recette,
+			actual:   recette,
+			wantErr:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertRecetteTenant(tc.expected, tc.actual)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected the guard to PROCEED, got error: %v", err)
+				}
+				return
+			}
+			if err != tc.wantErr { //nolint:errorlint // sentinel identity is the contract here
+				t.Fatalf("expected sentinel %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestRecetteGuardErrorsAreRedacted proves the guard never leaks a tenant UUID.
+// Both the sentinel errors and isRedactedGuardError must hold without embedding
+// either id.
+func TestRecetteGuardErrorsAreRedacted(t *testing.T) {
+	const (
+		recette = "11111111-1111-1111-1111-111111111111"
+		other   = "22222222-2222-2222-2222-222222222222"
+	)
+
+	for _, actual := range []string{"", other} {
+		err := assertRecetteTenant(recette, actual)
+		if err == nil {
+			t.Fatalf("expected an error for actual=%q", actual)
+		}
+		msg := err.Error()
+		// The redacted message must mention neither the expected nor the
+		// actual tenant id.
+		if strings.Contains(msg, recette) {
+			t.Fatalf("guard error leaked the expected tenant id: %q", msg)
+		}
+		if actual != "" && strings.Contains(msg, actual) {
+			t.Fatalf("guard error leaked the actual tenant id: %q", msg)
+		}
+		if !strings.Contains(msg, recetteTenantEnvName) {
+			t.Fatalf("guard error should name the allowlist env var, got: %q", msg)
+		}
+		if !isRedactedGuardError(err) {
+			t.Fatalf("guard error not recognized as a redacted sentinel: %v", err)
+		}
+	}
+}
+
+// TestRecetteGuardUnsetIsRedacted proves the unset-allowlist abort is also
+// redacted and recognized.
+func TestRecetteGuardUnsetIsRedacted(t *testing.T) {
+	err := assertRecetteTenant("", "anything")
+	if err != errRecetteTenantUnset { //nolint:errorlint // sentinel identity is the contract here
+		t.Fatalf("expected errRecetteTenantUnset, got %v", err)
+	}
+	if !isRedactedGuardError(err) {
+		t.Fatalf("unset error not recognized as a redacted sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), recetteTenantEnvName) {
+		t.Fatalf("unset error should name the allowlist env var, got: %q", err.Error())
+	}
+}

--- a/internal/provider/tests/recette/lifecycle_test.go
+++ b/internal/provider/tests/recette/lifecycle_test.go
@@ -1,0 +1,276 @@
+package recette
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Phase 1 recette lifecycle harness — PAT + object storage only.
+//
+// Substrate assumption (the Phase 1 prerequisite, see #300 Q1): even an "empty"
+// recette tenant must already have, pre-existing and datasource-only:
+//   - one IAM role (referenced by name/id to create the PAT — PAT Create
+//     HARD-FAILS with no role);
+//   - one object-storage role (referenced BY NAME by the acl_entry);
+//   - the object-storage service/namespace enabled;
+//   - credentials with object-storage + activity read/wait permissions.
+//
+// These are injected by env var NAMES only (never values committed):
+//   - CLOUDTEMPLE_RECETTE_IAM_ROLE_NAME   : IAM role name for the PAT
+//   - CLOUDTEMPLE_RECETTE_OS_ROLE_NAME    : object-storage role name for the ACL
+//
+// EVERY recette TestCase PreCheck calls recettePreCheck, which re-asserts the
+// tenant guard. The guard's real un-skippability comes from TestMain (it runs
+// the auth+tenant assertion before any TestCase), not from this PreCheck.
+
+const (
+	recetteIAMRoleNameEnv = "CLOUDTEMPLE_RECETTE_IAM_ROLE_NAME"
+	recetteOSRoleNameEnv  = "CLOUDTEMPLE_RECETTE_OS_ROLE_NAME"
+)
+
+// recettePreCheck runs before each TestCase. With TF_ACC unset the SDK skips
+// resource.Test entirely, so this never runs without live mode. It validates
+// the required substrate env vars and re-asserts the tenant guard (defence in
+// depth on top of the TestMain gate).
+func recettePreCheck(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		recetteTenantEnvName,
+		recetteIAMRoleNameEnv,
+		recetteOSRoleNameEnv,
+	} {
+		if os.Getenv(name) == "" {
+			t.Fatalf("%s must be set to run the recette harness", name)
+		}
+	}
+	if err := guardLiveTenant(t.Context()); err != nil {
+		// Redacted by construction.
+		t.Fatalf("recette tenant guard refused the run: %s", err)
+	}
+}
+
+// captureAttr stores the value of a state attribute into *dst so a later step
+// can assert the EXACT same value is preserved across a refresh.
+func captureAttr(resourceName, attr string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		v, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("attribute %s not set on %s", attr, resourceName)
+		}
+		if v == "" {
+			return fmt.Errorf("attribute %s on %s is empty; expected a sensitive value", attr, resourceName)
+		}
+		*dst = v
+		return nil
+	}
+}
+
+// assertAttrUnchanged asserts a previously captured value is still EXACTLY
+// present (not merely set). This is the secret-preservation-on-refresh proof.
+func assertAttrUnchanged(resourceName, attr string, want *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		got := rs.Primary.Attributes[attr]
+		if got != *want {
+			// Never print the secret VALUE: report only that it changed.
+			return fmt.Errorf("attribute %s on %s was not preserved across refresh (value changed)", attr, resourceName)
+		}
+		return nil
+	}
+}
+
+// TestAccRecettePAT exercises the PAT lifecycle:
+//   - apply + convergence (empty second plan: SDK built-in);
+//   - read-correctness via ImportState/ImportStateVerify (secret_id ignored,
+//     since the API never returns the secret after creation);
+//   - secret preservation: capture secret_id after apply, run a refresh-only
+//     plan, assert the EXACT same secret_id is still present;
+//   - destroy (SDK auto-destroy) + destroy-to-empty via a PAT ListStrict
+//     baseline captured before build.
+func TestAccRecettePAT(t *testing.T) {
+	var capturedSecret string
+	var patBaseline patSet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { recettePreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				// Capture the pre-build baseline before creating anything.
+				Config: testAccRecettePATConfig(),
+				PreConfig: func() {
+					patBaseline = mustCapturePATBaseline(t)
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("cloudtemple_iam_personal_access_token.recette", "client_id"),
+					resource.TestCheckResourceAttrSet("cloudtemple_iam_personal_access_token.recette", "secret_id"),
+					captureAttr("cloudtemple_iam_personal_access_token.recette", "secret_id", &capturedSecret),
+				),
+			},
+			{
+				// Refresh-only plan: prove the sensitive secret_id is preserved
+				// (not blanked) and the plan is empty (no config-driven change).
+				Config:             testAccRecettePATConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertAttrUnchanged("cloudtemple_iam_personal_access_token.recette", "secret_id", &capturedSecret),
+				),
+			},
+			{
+				// Read-correctness: import round-trip. The API never returns the
+				// secret after creation, so secret_id is ignored on verify.
+				ResourceName:            "cloudtemple_iam_personal_access_token.recette",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_id"},
+			},
+		},
+		// Destroy-to-empty: after the SDK auto-destroy, the PAT listing must
+		// return to the pre-build baseline.
+		CheckDestroy: func(s *terraform.State) error {
+			return assertPATBaselineRestored(t, patBaseline)
+		},
+	})
+}
+
+// TestAccRecetteObjectStorage exercises the object-storage stack:
+//   - bucket (private, NO inline acl_entry) + storage_account + standalone
+//     acl_entry (bucket x os-role-by-name x storage_account);
+//   - convergence: a second plan must be empty (SDK built-in). See the
+//     bucket/acl drift note below.
+//   - read-correctness: ImportState/ImportStateVerify for bucket and
+//     storage_account; acl_entry has NO importer, so its state is asserted via
+//     Check (composite id) instead.
+//   - secret preservation: capture access_secret_key after apply, refresh-only
+//     plan, assert the exact same key is still present.
+//   - destroy + destroy-to-empty via bucket/account ListStrict baselines.
+//
+// BUCKET/ACL DRIFT (the Phase 1 convergence risk, #300 D2.1):
+// The bucket resource's Read re-populates its INLINE acl_entry Optional field
+// from the live ACL listing (resource_object_storage_bucket.go Read). The
+// standalone acl_entry resource grants the same ACL. If the bucket Read writes
+// a non-empty inline acl_entry into the bucket state while the bucket CONFIG
+// declares none, the SDK will see a permanent diff on the bucket and the second
+// plan will NOT be empty.
+//
+// This test deliberately keeps the bucket config free of any inline acl_entry
+// and relies on the standalone resource only. It does NOT set
+// ExpectNonEmptyPlan: papering over the drift would hide a genuine state-safety
+// finding. If this TestCase fails its convergence step in live mode with a
+// bucket acl_entry diff, that is a provider finding to report (do not fix here),
+// per the brief.
+func TestAccRecetteObjectStorage(t *testing.T) {
+	var capturedKey string
+	var bucketBaseline stringSet
+	var accountBaseline stringSet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { recettePreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecetteObjectStorageConfig(),
+				PreConfig: func() {
+					bucketBaseline, accountBaseline = mustCaptureOSBaselines(t)
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("cloudtemple_object_storage_bucket.recette", "id"),
+					resource.TestCheckResourceAttr("cloudtemple_object_storage_bucket.recette", "access_type", "private"),
+					resource.TestCheckResourceAttrSet("cloudtemple_object_storage_storage_account.recette", "access_key_id"),
+					resource.TestCheckResourceAttrSet("cloudtemple_object_storage_storage_account.recette", "access_secret_key"),
+					captureAttr("cloudtemple_object_storage_storage_account.recette", "access_secret_key", &capturedKey),
+					// acl_entry has no importer; assert its composite id + parts.
+					resource.TestCheckResourceAttrSet("cloudtemple_object_storage_acl_entry.recette", "id"),
+					resource.TestCheckResourceAttrPair(
+						"cloudtemple_object_storage_acl_entry.recette", "bucket",
+						"cloudtemple_object_storage_bucket.recette", "name",
+					),
+					resource.TestCheckResourceAttrPair(
+						"cloudtemple_object_storage_acl_entry.recette", "storage_account",
+						"cloudtemple_object_storage_storage_account.recette", "name",
+					),
+				),
+			},
+			{
+				// Refresh-only: convergence + storage-account secret preservation.
+				Config:             testAccRecetteObjectStorageConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertAttrUnchanged("cloudtemple_object_storage_storage_account.recette", "access_secret_key", &capturedKey),
+				),
+			},
+			{
+				ResourceName:      "cloudtemple_object_storage_bucket.recette",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// access_secret_key/access_key_id live on the storage account, not
+				// the bucket; the bucket Read re-derives acl_entry, so ignore it on
+				// verify to avoid coupling the import check to the drift question.
+				ImportStateVerifyIgnore: []string{"acl_entry"},
+			},
+			{
+				ResourceName:      "cloudtemple_object_storage_storage_account.recette",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The secret is only returned at creation; it is absent from a
+				// fresh import read.
+				ImportStateVerifyIgnore: []string{"access_secret_key"},
+			},
+		},
+		CheckDestroy: func(s *terraform.State) error {
+			return assertOSBaselinesRestored(t, bucketBaseline, accountBaseline)
+		},
+	})
+}
+
+func testAccRecettePATConfig() string {
+	return fmt.Sprintf(`
+data "cloudtemple_iam_role" "recette" {
+  name = %q
+}
+
+resource "cloudtemple_iam_personal_access_token" "recette" {
+  name            = "test-terraform-recette-pat"
+  roles           = [data.cloudtemple_iam_role.recette.id]
+  expiration_date = "2999-01-01T00:00:00Z"
+}
+`, os.Getenv(recetteIAMRoleNameEnv))
+}
+
+func testAccRecetteObjectStorageConfig() string {
+	return fmt.Sprintf(`
+data "cloudtemple_object_storage_role" "recette" {
+  name = %q
+}
+
+resource "cloudtemple_object_storage_bucket" "recette" {
+  name        = "test-terraform-recette-bucket"
+  access_type = "private"
+  # Deliberately NO inline acl_entry block: the ACL is managed by the
+  # standalone resource below. See the bucket/acl drift note on the test.
+}
+
+resource "cloudtemple_object_storage_storage_account" "recette" {
+  name = "test-terraform-recette-sa"
+}
+
+resource "cloudtemple_object_storage_acl_entry" "recette" {
+  bucket          = cloudtemple_object_storage_bucket.recette.name
+  role            = data.cloudtemple_object_storage_role.recette.name
+  storage_account = cloudtemple_object_storage_storage_account.recette.name
+}
+`, os.Getenv(recetteOSRoleNameEnv))
+}

--- a/internal/provider/tests/recette/main_test.go
+++ b/internal/provider/tests/recette/main_test.go
@@ -1,0 +1,83 @@
+package recette
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	providerpkg "github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// providerFactories instantiate the production provider for the recette
+// TestCases. It mirrors internal/provider/tests/provider_test.go (api_suffix
+// disabled in dev) WITHOUT importing that package, so the unsafe tests TestMain
+// is never linked into this binary.
+var providerFactories = map[string]func() (*schema.Provider, error){
+	"cloudtemple": func() (*schema.Provider, error) {
+		p := providerpkg.New("dev")()
+		p.Schema["api_suffix"].Default = false
+		return p, nil
+	},
+}
+
+// sweepEnabled reports whether the SDK -sweep flag was passed. The flag is owned
+// by the SDK resource package; we read it from the global flag set after
+// flag.Parse(). Sweep mode is destructive, so it must also pass the tenant
+// guard before anything is deleted.
+func sweepEnabled() bool {
+	f := flag.Lookup("sweep")
+	return f != nil && f.Value.String() != ""
+}
+
+// liveEnabled reports whether the live acceptance path is active (TF_ACC set).
+func liveEnabled() bool {
+	return os.Getenv(resource.EnvTfAcc) != ""
+}
+
+// TestMain is the un-skippable safety core of the recette harness.
+//
+//   - In live mode (TF_ACC) OR sweep mode (-sweep): it runs the tenant guard +
+//     auth assertion FIRST and aborts fatally (mutating nothing) on any mismatch,
+//     then runs the guarded start-of-run cleanup for a clean slate.
+//   - In the default path (no TF_ACC, no -sweep): the guard is skipped entirely;
+//     the pure unit tests run WITHOUT credentials and without any network call.
+//
+// In every case it DELEGATES to resource.TestMain(m): that helper runs the
+// registered sweepers when -sweep is set, otherwise it calls m.Run(). We never
+// call a bare m.Run() — that would silently break -sweep.
+func TestMain(m *testing.M) {
+	// Parse flags so -sweep is observable before we branch. resource.TestMain
+	// calls flag.Parse() again, which is idempotent.
+	flag.Parse()
+
+	if liveEnabled() || sweepEnabled() {
+		ctx := context.Background()
+
+		// Fail-closed un-skippable gate: prove the credentials point at the
+		// allowlisted recette tenant BEFORE anything mutating runs.
+		if err := guardLiveTenant(ctx); err != nil {
+			abortRedacted(err)
+		}
+
+		// Belt-and-braces start-of-run cleanup (clean slate), itself guarded.
+		// This is the explicit cleanup hook described in D3(b): it is NOT
+		// wired through AddTestSweepers (which only fires under -sweep), so it
+		// runs at the start of any live run too. It is intentionally skipped
+		// under -sweep, where resource.TestMain runs the registered sweepers
+		// (which share the same body via sweepRecette).
+		if liveEnabled() && !sweepEnabled() {
+			if err := sweepRecette(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "recette start-of-run cleanup failed: %s\n", err.Error())
+				os.Exit(1)
+			}
+		}
+	}
+
+	// Delegates to the SDK: runs sweepers under -sweep, otherwise m.Run().
+	// resource.TestMain calls os.Exit itself.
+	resource.TestMain(m)
+}

--- a/internal/provider/tests/recette/main_test.go
+++ b/internal/provider/tests/recette/main_test.go
@@ -3,7 +3,6 @@ package recette
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"testing"
 
@@ -38,17 +37,26 @@ func liveEnabled() bool {
 	return os.Getenv(resource.EnvTfAcc) != ""
 }
 
-// TestMain is the un-skippable safety core of the recette harness.
+// TestMain is the un-skippable safety core of the recette harness. On its own it
+// MUTATES NOTHING: it only authenticates and asserts the tenant, then delegates.
 //
 //   - In live mode (TF_ACC) OR sweep mode (-sweep): it runs the tenant guard +
-//     auth assertion FIRST and aborts fatally (mutating nothing) on any mismatch,
-//     then runs the guarded start-of-run cleanup for a clean slate.
+//     auth assertion FIRST and aborts fatally on any mismatch. This is a pure
+//     auth + tenant assertion; it creates and destroys nothing.
 //   - In the default path (no TF_ACC, no -sweep): the guard is skipped entirely;
 //     the pure unit tests run WITHOUT credentials and without any network call.
 //
+// There is NO automatic start-of-run cleanup. A clean slate is an EXPLICIT,
+// destructive step the operator runs on purpose via the -sweep flag (below);
+// never a side effect of a live test run. Removing the auto-sweep keeps the
+// principle of least surprise: invoking TestMain in live mode — as the run.sh
+// guard pre-flight and TestRecetteLiveGuardOnly do — deletes nothing.
+//
 // In every case it DELEGATES to resource.TestMain(m): that helper runs the
 // registered sweepers when -sweep is set, otherwise it calls m.Run(). We never
-// call a bare m.Run() — that would silently break -sweep.
+// call a bare m.Run() — that would silently break -sweep. The ONLY destructive
+// path is the explicit -sweep, where resource.TestMain fires the registered
+// sweepers (each re-asserting the tenant guard via sweepRecette before deleting).
 func TestMain(m *testing.M) {
 	// Parse flags so -sweep is observable before we branch. resource.TestMain
 	// calls flag.Parse() again, which is idempotent.
@@ -58,22 +66,10 @@ func TestMain(m *testing.M) {
 		ctx := context.Background()
 
 		// Fail-closed un-skippable gate: prove the credentials point at the
-		// allowlisted recette tenant BEFORE anything mutating runs.
+		// allowlisted recette tenant BEFORE anything mutating runs. This is the
+		// only thing TestMain does in live/sweep mode; it mutates nothing.
 		if err := guardLiveTenant(ctx); err != nil {
 			abortRedacted(err)
-		}
-
-		// Belt-and-braces start-of-run cleanup (clean slate), itself guarded.
-		// This is the explicit cleanup hook described in D3(b): it is NOT
-		// wired through AddTestSweepers (which only fires under -sweep), so it
-		// runs at the start of any live run too. It is intentionally skipped
-		// under -sweep, where resource.TestMain runs the registered sweepers
-		// (which share the same body via sweepRecette).
-		if liveEnabled() && !sweepEnabled() {
-			if err := sweepRecette(ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "recette start-of-run cleanup failed: %s\n", err.Error())
-				os.Exit(1)
-			}
 		}
 	}
 

--- a/internal/provider/tests/recette/sweeper_test.go
+++ b/internal/provider/tests/recette/sweeper_test.go
@@ -41,9 +41,10 @@ func init() {
 	})
 }
 
-// sweepRecette is the single guarded teardown body. It is called BOTH from the
-// recette TestMain at start-of-run (clean slate) and from the registered bucket
-// sweeper under -sweep. It is idempotent and re-asserts the tenant guard first.
+// sweepRecette is the single guarded teardown body. It is the EXPLICIT
+// destructive cleanup: it runs ONLY from the registered bucket sweeper under the
+// -sweep flag — never automatically from TestMain. It is idempotent and
+// re-asserts the tenant guard first.
 //
 // Scope discipline:
 //   - buckets / storage accounts: deleted only if the name has the recette
@@ -59,8 +60,8 @@ func init() {
 // a level that could leak; errors reference resource NAMES only, which are
 // recette-prefixed by construction.
 func sweepRecette(ctx context.Context) error {
-	// Re-assert the guard: -sweep bypasses the TestCase PreCheck, and the
-	// start-of-run call must never trust an unverified tenant.
+	// Re-assert the guard: -sweep bypasses the TestCase PreCheck, so this
+	// destructive sweep must never trust an unverified tenant.
 	if err := guardLiveTenant(ctx); err != nil {
 		return err
 	}

--- a/internal/provider/tests/recette/sweeper_test.go
+++ b/internal/provider/tests/recette/sweeper_test.go
@@ -1,0 +1,180 @@
+package recette
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// recetteNamePrefix scopes every destructive sweep. Only resources whose name
+// carries this prefix (or the created_by=Terraform tag) are ever deleted.
+const recetteNamePrefix = "test-terraform"
+
+// createdByTag identifies Terraform-managed resources via tag.
+const (
+	createdByTagKey   = "created_by"
+	createdByTagValue = "Terraform"
+)
+
+// init registers the per-type sweepers. They run ONLY via the -sweep flag and
+// ONLY because TestMain wires resource.TestMain(m). AddTestSweepers does NOT
+// auto-run on any test start/end; this registration alone deletes nothing.
+//
+// Every sweeper re-asserts the tenant guard before touching anything, because
+// -sweep bypasses the TestCase PreCheck.
+func init() {
+	resource.AddTestSweepers("cloudtemple_object_storage_bucket", &resource.Sweeper{
+		Name: "cloudtemple_object_storage_bucket",
+		F:    func(string) error { return sweepRecette(context.Background()) },
+	})
+	resource.AddTestSweepers("cloudtemple_object_storage_storage_account", &resource.Sweeper{
+		Name:         "cloudtemple_object_storage_storage_account",
+		Dependencies: []string{"cloudtemple_object_storage_bucket"},
+		F:            func(string) error { return nil }, // body shared via sweepRecette
+	})
+	resource.AddTestSweepers("cloudtemple_iam_personal_access_token", &resource.Sweeper{
+		Name: "cloudtemple_iam_personal_access_token",
+		F:    func(string) error { return nil }, // body shared via sweepRecette
+	})
+}
+
+// sweepRecette is the single guarded teardown body. It is called BOTH from the
+// recette TestMain at start-of-run (clean slate) and from the registered bucket
+// sweeper under -sweep. It is idempotent and re-asserts the tenant guard first.
+//
+// Scope discipline:
+//   - buckets / storage accounts: deleted only if the name has the recette
+//     prefix OR carries the created_by=Terraform tag;
+//   - PATs: additionally filtered to the authenticated principal's own UserId
+//     AND TenantId, so a shared listing can never delete another principal's
+//     token.
+//
+// acl_entry is NOT swept directly (no list endpoint, no importer); revoking the
+// bucket removes its grants.
+//
+// SAFETY: this function NEVER prints a tenant id, a secret, or a resource id at
+// a level that could leak; errors reference resource NAMES only, which are
+// recette-prefixed by construction.
+func sweepRecette(ctx context.Context) error {
+	// Re-assert the guard: -sweep bypasses the TestCase PreCheck, and the
+	// start-of-run call must never trust an unverified tenant.
+	if err := guardLiveTenant(ctx); err != nil {
+		return err
+	}
+
+	c, err := newRecetteClient()
+	if err != nil {
+		return err
+	}
+
+	lt, err := c.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("recette sweep: failed to authenticate: %w", err)
+	}
+
+	if err := sweepBuckets(ctx, c); err != nil {
+		return err
+	}
+	if err := sweepStorageAccounts(ctx, c); err != nil {
+		return err
+	}
+	if err := sweepPATs(ctx, c, lt); err != nil {
+		return err
+	}
+	return nil
+}
+
+// isRecetteScoped reports whether a name/tags pair is in the recette deletion
+// scope: recette name prefix OR the created_by=Terraform tag.
+func isRecetteScoped(name string, hasCreatedByTag bool) bool {
+	return strings.HasPrefix(name, recetteNamePrefix) || hasCreatedByTag
+}
+
+func sweepBuckets(ctx context.Context, c *client.Client) error {
+	buckets, err := c.ObjectStorage().Bucket().ListStrict(ctx)
+	if err != nil {
+		return fmt.Errorf("recette sweep: failed to list buckets: %w", err)
+	}
+	for _, b := range buckets {
+		if b == nil {
+			continue
+		}
+		hasTag := false
+		for _, tag := range b.Tags {
+			if tag.Key == createdByTagKey && tag.Value == createdByTagValue {
+				hasTag = true
+				break
+			}
+		}
+		if !isRecetteScoped(b.Name, hasTag) {
+			continue
+		}
+		activityID, err := c.ObjectStorage().Bucket().Delete(ctx, b.Name)
+		if err != nil {
+			return fmt.Errorf("recette sweep: failed to delete bucket %s: %w", b.Name, err)
+		}
+		if _, err := c.Activity().WaitForCompletion(ctx, activityID, nil); err != nil {
+			return fmt.Errorf("recette sweep: failed to confirm bucket %s deletion: %w", b.Name, err)
+		}
+	}
+	return nil
+}
+
+func sweepStorageAccounts(ctx context.Context, c *client.Client) error {
+	accounts, err := c.ObjectStorage().StorageAccount().ListStrict(ctx)
+	if err != nil {
+		return fmt.Errorf("recette sweep: failed to list storage accounts: %w", err)
+	}
+	for _, a := range accounts {
+		if a == nil {
+			continue
+		}
+		hasTag := false
+		for _, tag := range a.Tags {
+			if tag.Key == createdByTagKey && tag.Value == createdByTagValue {
+				hasTag = true
+				break
+			}
+		}
+		if !isRecetteScoped(a.Name, hasTag) {
+			continue
+		}
+		activityID, err := c.ObjectStorage().StorageAccount().Delete(ctx, a.Name)
+		if err != nil {
+			return fmt.Errorf("recette sweep: failed to delete storage account %s: %w", a.Name, err)
+		}
+		if _, err := c.Activity().WaitForCompletion(ctx, activityID, nil); err != nil {
+			return fmt.Errorf("recette sweep: failed to confirm storage account %s deletion: %w", a.Name, err)
+		}
+	}
+	return nil
+}
+
+func sweepPATs(ctx context.Context, c *client.Client, lt *client.LoginToken) error {
+	tokens, err := c.IAM().PAT().ListStrict(ctx)
+	if err != nil {
+		return fmt.Errorf("recette sweep: failed to list personal access tokens: %w", err)
+	}
+	for _, t := range tokens {
+		if t == nil {
+			continue
+		}
+		// PAT().List is not scoped server-side (#226): restrict the destructive
+		// sweep to the authenticated principal's own tokens AND the recette
+		// name prefix. PATs carry no created_by tag, so the prefix is the only
+		// name-scope signal here.
+		if !strings.HasPrefix(t.Name, recetteNamePrefix) {
+			continue
+		}
+		if t.UserId != lt.UserID() || t.TenantId != lt.TenantID() {
+			continue
+		}
+		if err := c.IAM().PAT().Delete(ctx, t.ID); err != nil {
+			return fmt.Errorf("recette sweep: failed to delete personal access token %s: %w", t.Name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Refs #300

Phase 1 of the live acceptance ("recette") harness: a fail-closed, isolated
test-support increment restricted to **PAT + object storage** on a dedicated,
truly empty recette tenant. **Nothing was run live**: the harness compiles and
the live TestCases skip without `TF_ACC`; no `apply`/`destroy`, no `TF_ACC=1`
run, no `-sweep`, no credential/secret/tenant-UUID was read, printed or
committed.

This is test-support + examples + docs only. No production provider code
(`internal/client`, schemas, helpers) is changed; the schema snapshot, coverage
floor and the existing `tests/provider_test.go` are untouched.

## Scope (Phase 1)

Exactly the resources buildable on an empty tenant with no compute substrate:
`cloudtemple_iam_personal_access_token`, `cloudtemple_object_storage_bucket`,
`cloudtemple_object_storage_storage_account`, `cloudtemple_object_storage_acl_entry`.

- **Compute deferred** on the Q1 substrate question (no OpenIaaS/VMware here).
- **`global_access_key` excluded** (its Delete is a no-op; would break
  destroy-to-empty).

## Safety model

- **Env-var allowlist.** `CLOUDTEMPLE_RECETTE_TENANT_ID` is required at runtime;
  the guard never falls back to the current tenant. No tenant UUID is committed.
- **Un-skippable, fail-closed guard.** A NEW isolated sub-package
  `internal/provider/tests/recette/` has its own `TestMain` that, in live mode
  (`TF_ACC`) or sweep mode (`-sweep`), authenticates and asserts the JWT
  `scope.id` equals the allowlist **before any TestCase or sweeper runs**,
  aborting fatally on mismatch, then delegates to `resource.TestMain(m)` (runs
  sweepers under `-sweep`, otherwise `m.Run()`). The existing unsafe `tests`
  `TestMain` is never linked in.
- **Redacted errors.** A mismatch aborts with a generic message naming only the
  env var; it never prints the expected or actual UUID. The guard comparison is
  a pure function, table-tested and non-complacent (RED if inverted).
- **Default path is safe.** Without `TF_ACC`/`-sweep`, the guard is skipped, the
  pure unit tests run with no creds and no network, the package never hard-exits.
- **Leak bans.** No `TF_LOG=DEBUG` (the transport masks the PAT body but NOT the
  object-storage `secretAccessKey`); no `set -x`, no env echo in `run.sh`.

## Assertions encoded

- **Convergence / no-drift** — SDK empty-second-plan (no `ExpectNonEmptyPlan`).
- **Read-correctness** — `ImportState`/`ImportStateVerify` for bucket and
  storage_account; PAT with `secret_id` in `ImportStateVerifyIgnore`; `acl_entry`
  has no importer, asserted via `Check` (composite id + parts).
- **Secret preservation on refresh** — capture `secret_id` / `access_secret_key`
  after apply, refresh-only plan, assert the EXACT same value is preserved.
- **Destroy + destroy-to-empty** — SDK auto-destroy; plus bucket/account/PAT
  `ListStrict` (200-only) baselines captured before build and asserted to return
  exactly after destroy. `acl_entry` has no strict list -> documented residual,
  verified indirectly via the bucket/account listings.
- **No-unrequested-PATCH on refresh — DOWNGRADED for V1.** No live HTTP recorder:
  raw `TF_LOG=DEBUG` leaks the storage `secretAccessKey`, and even a path-only
  recorder is unsafe/unreliable (request paths carry UUID-like ids a failed
  assertion would print, and the provider's own `configure` authenticates with
  `POST /iam/v2/auth/personal_access_token`, so a blanket "no POST on refresh"
  is a false positive). V1 relies on the SDK convergence guarantee (an empty
  second plan proves no config-driven mutation) and documents the residual: it
  does not prove "zero mutating HTTP call". A redacted recorder is a separate
  later increment.

## Bucket/ACL drift decision

The bucket resource's `Read` re-populates its INLINE `acl_entry` (`Optional`)
field from the live ACL listing. Managing the same ACL both inline and via the
standalone resource would cause convergence drift. The stack therefore uses the
standalone `acl_entry` resource and keeps the bucket config free of any inline
block. The lifecycle test deliberately does NOT set `ExpectNonEmptyPlan`: if the
bucket `Read` still re-populates inline `acl_entry` and the second plan is
non-empty in live mode, that surfaces as a hard failure and is a genuine
provider finding to report on #300 — not papered over here.

## Files

- `internal/provider/tests/recette/` — guard + isolated TestMain, lifecycle
  tests, baselines, sweeper, guard unit tests.
- `examples/recette/objectstorage_pat/` — inert HCL stack + `run.sh`.
- `.env.recette.dist` (names only), `examples/recette/README.md`,
  `.gitignore` (`.env.recette`).

## CI

Out of Phase 1 scope: CI activation (gated `environment: recette` +
`workflow_dispatch` + `if: always()` teardown) is left as a doc note only; no
live trigger is enabled.
