### PR TITLE
fix(#318): redact secret JSON values in TF_LOG HTTP body logs

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -221,6 +222,19 @@ type loggingHttpTransport struct {
 	transport http.RoundTripper
 }
 
+// sensitiveBodyValueRegex redacts the VALUE of secret-bearing JSON keys wherever
+// they appear in a logged HTTP body (tf_http_req_body / tf_http_res_body), so a
+// `TF_LOG=DEBUG` run never prints a credential. Whole-body masking is only
+// applied to the auth endpoint; other endpoints (e.g. object storage, which
+// returns `secretAccessKey`, or VM customization, which sends `password`) log
+// their body, so the secret values must be redacted by key. The closing quote in
+// the alternation anchors each key exactly, so "secret" never partially matches
+// "secretAccessKey". The value matcher `"(?:[^"\\]|\\.)*"` is JSON-string aware:
+// it consumes escaped characters (including an escaped quote `\"`), so a value
+// containing a quote is masked in full — a plain `[^"]*` would stop at the
+// escaped quote and leak the suffix.
+var sensitiveBodyValueRegex = regexp.MustCompile(`(?i)"(secretAccessKey|accessSecretKey|secretKey|secret|password|domainAdminPassword)"\s*:\s*"(?:[^"\\]|\\.)*"`)
+
 func (t *loggingHttpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	if strings.Contains(req.URL.Path, "personal_access_token") {
@@ -228,6 +242,10 @@ func (t *loggingHttpTransport) RoundTrip(req *http.Request) (*http.Response, err
 		ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "tf_http_res_body")
 	}
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "Authorization")
+	// Redact secret JSON values in any logged body, regardless of endpoint, so a
+	// credential (object-storage secretAccessKey, VM password, …) cannot leak into
+	// TF_LOG=DEBUG output even when the whole body is not masked.
+	ctx = tflog.MaskAllFieldValuesRegexes(ctx, sensitiveBodyValueRegex)
 	req = req.WithContext(ctx)
 	return t.transport.RoundTrip(req)
 }

--- a/internal/provider/provider_logging_test.go
+++ b/internal/provider/provider_logging_test.go
@@ -1,0 +1,119 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+type fakeRoundTripper struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (f fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f.fn(r) }
+
+// TestLoggingHttpTransportRedactsSecretBodyValues proves that a credential
+// carried in an HTTP body never reaches the TF_LOG output, even for endpoints
+// whose whole body is not masked (object storage returns secretAccessKey; VM
+// customization sends a password). Guard under test: the
+// MaskAllFieldValuesRegexes(sensitiveBodyValueRegex) call in RoundTrip, with a
+// JSON-string-aware value matcher. Each case asserts a distinctive marker that
+// must NOT appear in the captured log. Mutation-proven RED:
+//   - removing the mask call leaks every marker;
+//   - reverting the value matcher to `[^"]*` leaks the escaped-quote case's
+//     marker (the suffix after the `\"`).
+func TestLoggingHttpTransportRedactsSecretBodyValues(t *testing.T) {
+	cases := []struct {
+		name        string
+		path        string
+		reqBody     string
+		respBody    string
+		mustNotLeak string
+	}{
+		{
+			name:        "object storage secretAccessKey in the response body",
+			path:        "/api/storage/object/v1/storage_accounts",
+			respBody:    `{"accessKeyId":"AKIAEXAMPLE","secretAccessKey":"S3cret-9f3a-do-not-log"}`,
+			mustNotLeak: "S3cret-9f3a-do-not-log",
+		},
+		{
+			name:        "VM password in the request body",
+			path:        "/api/compute/v1/virtual_machines",
+			reqBody:     `{"name":"vm-1","password":"S3cret-9f3a-do-not-log"}`,
+			mustNotLeak: "S3cret-9f3a-do-not-log",
+		},
+		{
+			name:        "global access key in the response body (case-insensitive)",
+			path:        "/api/storage/object/v1/namespaces/access_key/renew",
+			respBody:    `{"AccessSecretKey":"S3cret-9f3a-do-not-log"}`,
+			mustNotLeak: "S3cret-9f3a-do-not-log",
+		},
+		{
+			// JSON value is  pre"TAIL-do-not-log  (an embedded, escaped quote).
+			// A naive `[^"]*` matcher stops at the `\"` and leaves "TAIL-do-not-log"
+			// visible; the JSON-string-aware matcher masks the whole value.
+			name:        "password value containing an escaped JSON quote",
+			path:        "/api/compute/v1/virtual_machines",
+			reqBody:     `{"name":"vm-1","password":"pre\"TAIL-do-not-log"}`,
+			mustNotLeak: "TAIL-do-not-log",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ctx := tflogtest.RootLogger(context.Background(), &buf)
+
+			downstream := fakeRoundTripper{fn: func(r *http.Request) (*http.Response, error) {
+				if r.Body != nil {
+					_, _ = io.ReadAll(r.Body)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Proto:      "HTTP/1.1",
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(tc.respBody)),
+					Request:    r,
+				}, nil
+			}}
+
+			tr := &loggingHttpTransport{transport: logging.NewLoggingHTTPTransport(downstream)}
+
+			var body io.Reader
+			if tc.reqBody != "" {
+				body = strings.NewReader(tc.reqBody)
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.test"+tc.path, body)
+			if err != nil {
+				t.Fatalf("new request: %s", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := tr.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip: %s", err)
+			}
+			// Functional passthrough: the response body must still be readable, intact.
+			got, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if tc.respBody != "" && string(got) != tc.respBody {
+				t.Fatalf("response body altered: got %q want %q", string(got), tc.respBody)
+			}
+
+			out := buf.String()
+			if strings.Contains(out, tc.mustNotLeak) {
+				t.Fatalf("SECRET LEAKED (%q) in TF_LOG output for %q:\n%s", tc.mustNotLeak, tc.path, out)
+			}
+			if !strings.Contains(out, "***") {
+				t.Fatalf("expected a redaction marker (***) in the log output for %q; masking did not run:\n%s", tc.path, out)
+			}
+		})
+	}
+}

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -2,5 +2,5 @@
 # Raised as coverage improves (scripts/coverage_ratchet.sh --update);
 # CI fails if coverage drops below these values. Never lower by hand.
 internal/client 18.5
-internal/provider 12.2
+internal/provider 12.3
 internal/provider/helpers 65.4


### PR DESCRIPTION
Refs #318

## Summary

Fixes a secret leak in `TF_LOG=DEBUG` output. `loggingHttpTransport` previously masked the whole body **only** for the auth endpoint (plus the `Authorization` header), so secrets carried in other endpoints' bodies leaked into the debug log: object storage `secretAccessKey` / `accessSecretKey` (responses), VM customization `password` / `domainAdminPassword` (requests).

Adds an endpoint-agnostic `tflog.MaskAllFieldValuesRegexes` that redacts the **value** of secret JSON keys wherever they appear in a logged request/response body. The value matcher is JSON-string aware (`"(?:[^"\\]|\\.)*"`), so a secret whose value contains an escaped quote is masked in full (a plain `[^"]*` would stop at the escaped quote and leak the suffix).

## Validation

- Non-complacent `tflogtest`-based test covering request body, response body, case-insensitivity, and an escaped-quote value. **Mutation-proven RED** twice: removing the mask leaks every marker; reverting the matcher to `[^"]*` leaks the escaped-quote suffix.
- Adversarial **Codex DIFF** review: round 1 NO-GO (escaped-quote leak) → fixed → round 2 **GO**.
- Gates green: gofmt/vet/build, staticcheck@2025.1.1 (0 findings), `-race`, schema golden unchanged, coverage ratchet raised (provider 12.2 → 12.3).

## Residual scope

Masks the enumerated string-valued secret keys. Unknown future key names or non-JSON secret formats are out of scope — this is defense-in-depth on top of the existing `Authorization` + auth-body masking.