### PR TITLE
fix(#320): guard nil OS disk in OpenIaaS VM read (hotfix → v1.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ***Warning: Using "Release Candidate" versions (-rc.X) in a **production environment** is **strongly discouraged**, as they may contain unresolved bugs and pose risks to the stability and security of your systems.***
 
-# 1.7.1 (April 15th, 2026)
+# 1.7.2 (June 15th, 2026)
 <img id="latest" src="https://badgen.net/badge/channel/latest/yellow" alt="Channel: latest" />
+
+BUG FIXES :
+
+  * Fixed a remaining nil pointer crash during `terraform plan` when refreshing a `cloudtemple_compute_iaas_opensource_virtual_machine` whose OS disk was deleted or became forbidden out-of-band (the disk reads back as nil). Completes the partial 1.7.1 fix. (#320)
+
+# 1.7.1 (April 15th, 2026)
 
 BUG FIXES :
 

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
@@ -69,20 +69,25 @@ func FlattenOpenIaaSVirtualMachine(vm *client.OpenIaaSVirtualMachine) map[string
 }
 
 func FlattenOpenIaaSOSDisksData(osDisks []*client.OpenIaaSVirtualDisk, virtualMachineId string) []interface{} {
-	if osDisks != nil {
-		disks := make([]interface{}, len(osDisks))
-
-		for i, osDisk := range osDisks {
-			disks[i] = FlattenOpenIaaSOSDiskData(osDisk, virtualMachineId)
+	disks := make([]interface{}, 0, len(osDisks))
+	for _, osDisk := range osDisks {
+		// Skip a nil disk (the API maps a deleted/forbidden disk to nil): it
+		// must never be dereferenced nor appended as a nil entry (#320).
+		if osDisk == nil {
+			continue
 		}
-
-		return disks
+		disks = append(disks, FlattenOpenIaaSOSDiskData(osDisk, virtualMachineId))
 	}
-
-	return make([]interface{}, 0)
+	return disks
 }
 
 func FlattenOpenIaaSOSDiskData(osDisk *client.OpenIaaSVirtualDisk, virtualMachineId string) interface{} {
+	if osDisk == nil {
+		// The API maps a deleted/forbidden disk to a nil read (403 -> nil).
+		// Dereferencing it while refreshing a VM whose OS disk disappeared
+		// out-of-band panics (#320). Return nil; callers skip a nil entry.
+		return nil
+	}
 	vbd := Find(osDisk.VirtualMachines, func(virtualMachine client.OpenIaaSVirtualDiskConnection) bool {
 		return virtualMachine.ID == virtualMachineId
 	})

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
@@ -1,0 +1,41 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenOpenIaaSOSDiskDataNilIsSafe pins the #320 fix: a nil OS disk (the
+// API maps a deleted/forbidden disk to a nil read) must NOT be dereferenced.
+// Without the guard this panics (SIGSEGV on osDisk.VirtualMachines), crashing
+// `terraform plan` while refreshing a VM whose OS disk disappeared out-of-band.
+func TestFlattenOpenIaaSOSDiskDataNilIsSafe(t *testing.T) {
+	if got := FlattenOpenIaaSOSDiskData(nil, "vm-1"); got != nil {
+		t.Fatalf("expected nil for a nil os disk, got %#v", got)
+	}
+}
+
+// TestFlattenOpenIaaSOSDisksDataSkipsNil pins that the plural flatten skips nil
+// disk entries (rather than appending a nil map or panicking) and keeps the
+// valid ones.
+func TestFlattenOpenIaaSOSDisksDataSkipsNil(t *testing.T) {
+	valid := &client.OpenIaaSVirtualDisk{
+		ID:                "disk-1",
+		Name:              "data",
+		StorageRepository: client.BaseObject{ID: "sr-1"},
+		VirtualMachines:   []client.OpenIaaSVirtualDiskConnection{{ID: "vm-1", Connected: true}},
+	}
+
+	got := FlattenOpenIaaSOSDisksData([]*client.OpenIaaSVirtualDisk{nil, valid, nil}, "vm-1")
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 disk (nils skipped), got %d: %#v", len(got), got)
+	}
+	m, ok := got[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a map entry, got %#v", got[0])
+	}
+	if m["id"] != "disk-1" || m["connected"] != true {
+		t.Fatalf("unexpected flattened disk: %#v", m)
+	}
+}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -628,6 +628,12 @@ func openIaasVirtualMachineRead(ctx context.Context, d *schema.ResourceData, met
 			if err != nil {
 				return diag.Errorf("failed to read os disk: %s", err)
 			}
+			if disk == nil {
+				// A disk that read back nil (the API maps 403/absent to nil) is
+				// skipped rather than dereferenced — refreshing a VM whose OS disk
+				// disappeared out-of-band must not panic (#320).
+				continue
+			}
 			osDisks = append(osDisks, helpers.FlattenOpenIaaSOSDiskData(disk, d.Id()))
 		}
 	}


### PR DESCRIPTION
Closes #320

**Direct hotfix to `main`** for a provider crash reported by an external user on the released **v1.7.1**. Requires a `HOTFIX-APPROVED: #320` comment from an authorized human and a human merge (per the RC-flow rules).

## The crash

`terraform plan` panics (nil pointer dereference, SIGSEGV) while refreshing a `cloudtemple_compute_iaas_opensource_virtual_machine`. `VirtualDisk().Read` maps a deleted/forbidden disk to a nil read (403 -> nil); when a VM references an OS disk that disappeared out-of-band, the nil disk was passed to `FlattenOpenIaaSOSDiskData`, which dereferenced it.

## The fix (minimal, defense-in-depth)

- `FlattenOpenIaaSOSDiskData`: returns `nil` for a nil disk instead of dereferencing it.
- `FlattenOpenIaaSOSDisksData`: skips nil entries.
- VM read loop: skips a disk that read back nil (the gone disk is simply omitted from the refreshed state).

## Validation

- New unit test reproduces the **exact reported panic** (same `SIGSEGV addr=0x78`) and is **mutation-proven RED** without the guard.
- `go build ./...` ok, `gofmt` clean, `go vet ./internal/provider/helpers/` clean, helpers tests pass.
- Note: a pre-existing `go vet` failure in the acceptance harness (`internal/provider/tests/provider_test.go:127`, a stale `PAT().List` signature — already fixed on `rc/v1.8.0` via #284) is unrelated to this hotfix and left untouched to keep it minimal.

## Follow-up

The same guard is ported to `rc/v1.8.0` (defense-in-depth on top of the existing `classifyOSDiskOnRead` handling). After merge: tag **v1.7.2** from the hotfix commit on `main`.