### PR TITLE
feat(#316): cmd/ct-validate endpoint validation & resilience harness

### DIFF
--- a/cmd/ct-validate/breaker.go
+++ b/cmd/ct-validate/breaker.go
@@ -50,6 +50,22 @@ func (b *Breaker) Allow() bool {
 	return !b.tripped
 }
 
+// Trip forces the breaker open with an explicit reason, regardless of the
+// rolling-window accounting. It is used for out-of-band failures that are not a
+// single op outcome — e.g. a cycle goroutine that PANICKED: the panic is
+// recovered, recorded as a failure op, and the breaker is tripped so the engine
+// stops scheduling new work and drains to teardown. Latching: a no-op once
+// already tripped, so the first reason wins.
+func (b *Breaker) Trip(reason string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.tripped {
+		return
+	}
+	b.tripped = true
+	b.reason = reason
+}
+
 // Tripped reports whether the breaker has tripped.
 func (b *Breaker) Tripped() bool {
 	b.mu.Lock()

--- a/cmd/ct-validate/breaker.go
+++ b/cmd/ct-validate/breaker.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Breaker is the safety core of the harness. It exists because of a concrete
+// incident (2026-06-15): a high-frequency loop against the shared recette API
+// AMPLIFIED an outage and produced orphan resources. The breaker stops the
+// engine from launching new work the moment the API shows distress.
+//
+// It trips when EITHER:
+//   - consecutive failures reach maxConsecutive, OR
+//   - the failure rate over the last `window` recorded outcomes reaches
+//     failureRate (evaluated only once the window is full).
+//
+// Once tripped it stays tripped (latching): Allow() returns false so the
+// engine drains and tears down. It is safe for concurrent use.
+type Breaker struct {
+	mu sync.Mutex
+
+	maxConsecutive int
+	failureRate    float64
+	window         int
+
+	consecutive int
+	recent      []bool // rolling window of "was a failure", newest at the end
+	tripped     bool
+	reason      string
+}
+
+// NewBreaker builds a breaker. A non-positive maxConsecutive disables the
+// consecutive-failure rule; a non-positive window OR a failureRate outside
+// (0,1] disables the rate rule. With both rules disabled the breaker never
+// trips (it is then a no-op guard, still safe to call).
+func NewBreaker(maxConsecutive int, failureRate float64, window int) *Breaker {
+	return &Breaker{
+		maxConsecutive: maxConsecutive,
+		failureRate:    failureRate,
+		window:         window,
+	}
+}
+
+// Allow reports whether the engine may launch more work. It returns false once
+// the breaker has tripped.
+func (b *Breaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return !b.tripped
+}
+
+// Tripped reports whether the breaker has tripped.
+func (b *Breaker) Tripped() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.tripped
+}
+
+// Reason returns the human-readable trip reason, or "" if not tripped.
+func (b *Breaker) Reason() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.reason
+}
+
+// Record feeds one operation outcome (true = failure) and re-evaluates the
+// trip conditions. A skipped op MUST NOT be recorded here: it is neither a
+// success nor a failure and would otherwise dilute the rolling window.
+//
+// Once tripped, further records are ignored (the verdict latches) so a late
+// success cannot silently re-arm the engine.
+func (b *Breaker) Record(failure bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.tripped {
+		return
+	}
+
+	if failure {
+		b.consecutive++
+	} else {
+		b.consecutive = 0
+	}
+
+	// Maintain the rolling window of the last `window` outcomes.
+	if b.window > 0 {
+		b.recent = append(b.recent, failure)
+		if len(b.recent) > b.window {
+			b.recent = b.recent[len(b.recent)-b.window:]
+		}
+	}
+
+	// Rule (a): consecutive failures.
+	if b.maxConsecutive > 0 && b.consecutive >= b.maxConsecutive {
+		b.tripped = true
+		b.reason = fmt.Sprintf("%d consecutive failures (limit %d)", b.consecutive, b.maxConsecutive)
+		return
+	}
+
+	// Rule (b): failure rate over a FULL window. Evaluating only on a full
+	// window avoids tripping on a single early failure (1/1 = 100%).
+	if b.window > 0 && b.failureRate > 0 && len(b.recent) >= b.window {
+		failures := 0
+		for _, f := range b.recent {
+			if f {
+				failures++
+			}
+		}
+		rate := float64(failures) / float64(len(b.recent))
+		if rate >= b.failureRate {
+			b.tripped = true
+			b.reason = fmt.Sprintf("failure rate %.0f%% over last %d ops (limit %.0f%%)",
+				rate*100, len(b.recent), b.failureRate*100)
+		}
+	}
+}

--- a/cmd/ct-validate/breaker_test.go
+++ b/cmd/ct-validate/breaker_test.go
@@ -131,6 +131,32 @@ func TestBreakerLatches(t *testing.T) {
 	}
 }
 
+// TestBreakerTripForcesOpen proves Trip() forces the breaker open regardless of
+// the rolling-window accounting (used for out-of-band failures like a panic),
+// latches the first reason, and is idempotent. A disabled breaker (no rules)
+// must still honour an explicit Trip.
+//
+// Mutation proof: make Trip a no-op (drop the `b.tripped = true`) → Allow stays
+// true → this test goes RED. Drop the `if b.tripped { return }` latch → the
+// second Trip overwrites the reason → the reason assertion goes RED.
+func TestBreakerTripForcesOpen(t *testing.T) {
+	b := NewBreaker(0, 0, 0) // all rules disabled: accounting would never trip
+	if b.Tripped() {
+		t.Fatal("setup: a disabled breaker must start untripped")
+	}
+	b.Trip("first reason")
+	if !b.Tripped() || b.Allow() {
+		t.Fatal("Trip must force the breaker open even with all rules disabled")
+	}
+	if b.Reason() != "first reason" {
+		t.Fatalf("reason = %q, want %q", b.Reason(), "first reason")
+	}
+	b.Trip("second reason") // latch: must not overwrite
+	if b.Reason() != "first reason" {
+		t.Fatalf("Trip must latch the first reason, got %q", b.Reason())
+	}
+}
+
 // TestBreakerDisabledRules proves a fully-disabled breaker never trips and is a
 // safe no-op guard.
 func TestBreakerDisabledRules(t *testing.T) {

--- a/cmd/ct-validate/breaker_test.go
+++ b/cmd/ct-validate/breaker_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// feed records a sequence of failure flags into a breaker.
+func feed(b *Breaker, failures ...bool) {
+	for _, f := range failures {
+		b.Record(f)
+	}
+}
+
+func TestBreakerConsecutiveTrips(t *testing.T) {
+	// maxConsecutive=3, rate rule effectively off (rate=1, window large).
+	b := NewBreaker(3, 1.0, 100)
+	feed(b, true, true)
+	if b.Tripped() {
+		t.Fatal("must not trip at 2 consecutive (limit 3)")
+	}
+	if !b.Allow() {
+		t.Fatal("Allow must be true before tripping")
+	}
+	b.Record(true)
+	if !b.Tripped() {
+		t.Fatal("must trip at 3 consecutive")
+	}
+	if b.Allow() {
+		t.Fatal("Allow must be false after tripping")
+	}
+}
+
+// TestBreakerConsecutiveResetBySuccess proves the consecutive counter resets on
+// a success: 2 fails, a success, 2 fails must NOT trip a limit-3 breaker. A
+// mutation that fails to reset b.consecutive on success would make this RED.
+func TestBreakerConsecutiveResetBySuccess(t *testing.T) {
+	b := NewBreaker(3, 1.0, 100)
+	feed(b, true, true, false, true, true)
+	if b.Tripped() {
+		t.Fatal("success between failures must reset the consecutive counter")
+	}
+}
+
+func TestBreakerRateTripsOnFullWindow(t *testing.T) {
+	// window=10, rate=0.30 → trips when >=3 of the last 10 ops are failures.
+	// maxConsecutive is large so ONLY the rate rule is under test here.
+	b := NewBreaker(1000, 0.30, 10)
+	// Fill the window with successes (0% over a full window).
+	for i := 0; i < 10; i++ {
+		b.Record(false)
+	}
+	// Two trailing failures → window = [S×8, F, F] = 2/10 = 20%: must NOT trip.
+	feed(b, true, true)
+	if b.Tripped() {
+		t.Fatalf("20%% failure must not trip a 30%% breaker; reason=%q", b.Reason())
+	}
+	// A third trailing failure → window = [S×7, F, F, F] = 3/10 = 30% ≥ limit.
+	b.Record(true)
+	if !b.Tripped() {
+		t.Fatal("30%% failure over a full window must trip a 30%% breaker")
+	}
+}
+
+// TestBreakerRateNeedsFullWindow proves the rate rule does NOT evaluate before
+// the window is full: a single first-op failure is 1/1 = 100% but must not
+// trip. A mutation that drops the `len(recent) >= window` guard turns this RED.
+func TestBreakerRateNeedsFullWindow(t *testing.T) {
+	b := NewBreaker(1000, 0.30, 10)
+	b.Record(true)
+	if b.Tripped() {
+		t.Fatal("a single early failure must not trip the rate rule before the window is full")
+	}
+}
+
+// TestBreakerRollingWindowForgetsOldFailures proves the window truly ROLLS:
+// old failures must age out so the rate is computed over the LAST `window`
+// ops, not over all history. The threshold (0.75) is chosen so the verdict
+// differs between a correctly-trimmed window and an untrimmed one:
+//
+//   - trimmed (correct): during phase 1 no 4-op window holds 3 failures, so the
+//     rate never reaches 75% and the breaker does not trip; then 3 trailing
+//     failures make the last-4 window [S,F,F,F] = 75% ≥ limit → trips.
+//   - untrimmed (mutated, no `recent = recent[len(recent)-window:]`): the rate
+//     would be computed over all 11 ops = 5/11 ≈ 45% < 75% → would NOT trip,
+//     turning the second assertion RED.
+//
+// maxConsecutive is large so only the rate rule is exercised.
+func TestBreakerRollingWindowForgetsOldFailures(t *testing.T) {
+	b := NewBreaker(1000, 0.75, 4)
+	// Phase 1: 2 sparse failures then successes age them out. No 4-op window
+	// ever holds 3 failures, so the 75% rate is never reached here.
+	feed(b, true, false, false, true, false, false, false, false)
+	if b.Tripped() {
+		t.Fatalf("old failures must roll out of the window before tripping; reason=%q", b.Reason())
+	}
+	// Phase 2: 3 trailing failures → trimmed last-4 window = [S,F,F,F] = 75%.
+	feed(b, true, true, true)
+	if !b.Tripped() {
+		t.Fatal("75%% over the last 4 (trimmed) window must trip a 75%% breaker")
+	}
+}
+
+// TestBreakerLatches proves the verdict latches: once tripped, the breaker
+// stops re-evaluating. Two observable consequences are asserted:
+//   - a flood of successes must NOT re-arm the engine; and
+//   - the trip REASON is FROZEN at the moment of tripping (the operator must
+//     see WHY it first tripped, not a later, larger count).
+//
+// The frozen-reason assertion is the mutation-sensitive one: removing the early
+// `if b.tripped { return }` in Record lets later failures keep recomputing and
+// rewrite the reason (e.g. "2 consecutive" → "4 consecutive"), turning this RED.
+func TestBreakerLatches(t *testing.T) {
+	b := NewBreaker(2, 1.0, 100)
+	feed(b, true, true) // trips on 2 consecutive
+	if !b.Tripped() {
+		t.Fatal("setup: expected trip")
+	}
+	reasonAtTrip := b.Reason()
+
+	// More failures after the trip must not change the verdict OR the reason.
+	feed(b, true, true)
+	if b.Reason() != reasonAtTrip {
+		t.Fatalf("trip reason mutated after latching: %q -> %q", reasonAtTrip, b.Reason())
+	}
+
+	// A success flood must not re-arm the breaker.
+	feed(b, false, false, false, false)
+	if !b.Tripped() || b.Allow() {
+		t.Fatal("breaker must stay tripped after a success flood")
+	}
+}
+
+// TestBreakerDisabledRules proves a fully-disabled breaker never trips and is a
+// safe no-op guard.
+func TestBreakerDisabledRules(t *testing.T) {
+	b := NewBreaker(0, 0, 0)
+	for i := 0; i < 100; i++ {
+		b.Record(true)
+	}
+	if b.Tripped() || !b.Allow() {
+		t.Fatal("a disabled breaker must never trip")
+	}
+}
+
+// TestBreakerConcurrentRecord is a race-detector smoke test: concurrent
+// Record/Allow must not data-race.
+func TestBreakerConcurrentRecord(t *testing.T) {
+	b := NewBreaker(1000, 0.99, 1000)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				b.Record(i%2 == 0)
+				_ = b.Allow()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/cmd/ct-validate/categorize.go
+++ b/cmd/ct-validate/categorize.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// Category classifies the outcome of an operation. It is the histogram key in
+// the report and the input to the circuit breaker's failure accounting.
+type Category string
+
+const (
+	// CategoryOK is a successful operation.
+	CategoryOK Category = "ok"
+	// CategorySkipped is an op deliberately not attempted (e.g. no spare FIP).
+	// It is neither a success nor a failure.
+	CategorySkipped Category = "skipped"
+	// CategoryTransientWorkers is the known-transient platform reason
+	// "None of the workers were able to respond" (VPC workers, #251).
+	CategoryTransientWorkers Category = "transient_workers"
+	// CategoryBadGateway502 is a 502 / gateway / config-load failure, the
+	// signature of the 2026-06-15 sustained API outage.
+	CategoryBadGateway502 Category = "bad_gateway_502"
+	// CategoryHTTP4xx is a client-side HTTP status (400-499) other than ones
+	// captured by a more specific category.
+	CategoryHTTP4xx Category = "http_4xx"
+	// CategoryHTTP5xx is a server-side HTTP status (500-599) other than 502.
+	CategoryHTTP5xx Category = "http_5xx"
+	// CategoryTimeout is a context deadline or cancellation.
+	CategoryTimeout Category = "timeout"
+	// CategoryOther is anything not matched above (decode errors, transport
+	// errors without a status, etc.).
+	CategoryOther Category = "other"
+)
+
+// categorize maps an operation error to a Category. A nil error is CategoryOK.
+//
+// Ordering matters and is deliberate:
+//  1. nil               → OK
+//  2. context dl/cancel → Timeout (a cancelled write may still surface a
+//     wrapped status; the cancellation is the root cause and must win).
+//  3. transient workers → TransientWorkers (platform-recoverable).
+//  4. 502 / bad gateway → BadGateway502 (the outage signature; checked before
+//     the generic 5xx bucket so it is never swallowed by it).
+//  5. StatusError 4xx   → HTTP4xx
+//  6. StatusError 5xx   → HTTP5xx
+//  7. fallback          → Other
+//
+// Every branch is exercised by a mutation-proven unit test.
+func categorize(err error) Category {
+	if err == nil {
+		return CategoryOK
+	}
+
+	// Timeout / cancellation takes precedence: it is the operator-facing root
+	// cause when the global -timeout fires or the breaker cancels work.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return CategoryTimeout
+	}
+
+	// Platform-recoverable "workers unavailable" reason, recognised either via
+	// the typed client helper or via the raw message (some error paths wrap it
+	// as a plain string rather than an ActivityCompletionError).
+	if client.IsTransientActivityFailure(err) || containsAny(err.Error(), "None of the workers were able to respond") {
+		return CategoryTransientWorkers
+	}
+
+	msg := err.Error()
+	if containsAny(msg, "502", "Bad Gateway", "Failed to load configuration via API") {
+		return CategoryBadGateway502
+	}
+
+	var statusErr client.StatusError
+	if errors.As(err, &statusErr) {
+		switch {
+		case statusErr.Code >= 400 && statusErr.Code <= 499:
+			return CategoryHTTP4xx
+		case statusErr.Code >= 500 && statusErr.Code <= 599:
+			return CategoryHTTP5xx
+		}
+	}
+
+	return CategoryOther
+}
+
+// containsAny reports whether s contains at least one of the needles.
+func containsAny(s string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(s, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFailure reports whether a category counts as a failure for the circuit
+// breaker. OK and Skipped do not; everything else does.
+func (c Category) isFailure() bool {
+	return c != CategoryOK && c != CategorySkipped
+}

--- a/cmd/ct-validate/categorize_test.go
+++ b/cmd/ct-validate/categorize_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+func TestCategorize(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want Category
+	}{
+		{"nil is OK", nil, CategoryOK},
+		{"deadline is Timeout", context.DeadlineExceeded, CategoryTimeout},
+		{"cancel is Timeout", context.Canceled, CategoryTimeout},
+		{
+			"wrapped deadline is Timeout",
+			fmt.Errorf("doing thing: %w", context.DeadlineExceeded),
+			CategoryTimeout,
+		},
+		{
+			"workers message is TransientWorkers",
+			errors.New("activity failed: None of the workers were able to respond"),
+			CategoryTransientWorkers,
+		},
+		{
+			"502 is BadGateway502",
+			client.StatusError{Code: 502, Body: "Bad Gateway"},
+			CategoryBadGateway502,
+		},
+		{
+			"bad gateway text is BadGateway502",
+			errors.New("upstream: Bad Gateway"),
+			CategoryBadGateway502,
+		},
+		{
+			"load configuration message is BadGateway502",
+			errors.New("Failed to load configuration via API"),
+			CategoryBadGateway502,
+		},
+		{
+			"400 is HTTP4xx",
+			client.StatusError{Code: 400, Body: "bad request"},
+			CategoryHTTP4xx,
+		},
+		{
+			"404 is HTTP4xx",
+			client.StatusError{Code: 404, Body: "not found"},
+			CategoryHTTP4xx,
+		},
+		{
+			"500 is HTTP5xx",
+			client.StatusError{Code: 500, Body: "boom"},
+			CategoryHTTP5xx,
+		},
+		{
+			"503 is HTTP5xx",
+			client.StatusError{Code: 503, Body: "unavailable"},
+			CategoryHTTP5xx,
+		},
+		{
+			"plain error is Other",
+			errors.New("json: cannot unmarshal"),
+			CategoryOther,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := categorize(tt.err); got != tt.want {
+				t.Fatalf("categorize(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCategorizeTimeoutBeatsStatus pins the precedence: a cancellation that
+// also carries a status must categorize as Timeout, not as the status. This is
+// the branch a "reorder the checks" mutation would break.
+func TestCategorizeTimeoutBeatsStatus(t *testing.T) {
+	// A 503 StatusError wrapped together with a cancellation: the cancellation
+	// is the operator-facing root cause.
+	err := fmt.Errorf("call aborted (%w): %w", context.Canceled, client.StatusError{Code: 503})
+	if got := categorize(err); got != CategoryTimeout {
+		t.Fatalf("expected Timeout to win over 5xx, got %q", got)
+	}
+}
+
+// TestCategorize502BeatsGeneric5xx pins that 502 is classified as BadGateway502
+// and NOT swallowed by the generic 5xx bucket. A mutation that drops the 502
+// pre-check (letting the StatusError switch handle it) would turn this RED.
+func TestCategorize502BeatsGeneric5xx(t *testing.T) {
+	if got := categorize(client.StatusError{Code: 502, Body: "x"}); got != CategoryBadGateway502 {
+		t.Fatalf("502 must be BadGateway502, got %q", got)
+	}
+}
+
+func TestCategoryIsFailure(t *testing.T) {
+	failures := []Category{
+		CategoryTransientWorkers, CategoryBadGateway502, CategoryHTTP4xx,
+		CategoryHTTP5xx, CategoryTimeout, CategoryOther,
+	}
+	for _, c := range failures {
+		if !c.isFailure() {
+			t.Errorf("%q should count as failure", c)
+		}
+	}
+	for _, c := range []Category{CategoryOK, CategorySkipped} {
+		if c.isFailure() {
+			t.Errorf("%q must NOT count as failure", c)
+		}
+	}
+}

--- a/cmd/ct-validate/cleanup.go
+++ b/cmd/ct-validate/cleanup.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"sync"
+)
+
+// teardownMaxAttempts bounds the retries of a single teardown closure. The
+// first attempt plus (teardownMaxAttempts-1) bounded retries on a TRANSIENT
+// failure. This is the never-orphan guarantee without the never-stop hazard
+// that caused the 2026-06-15 incident: no infinite retry, ever.
+const teardownMaxAttempts = 3
+
+// CleanupFunc tears down one created resource. It receives a context so a
+// global timeout still bounds teardown.
+type CleanupFunc func(ctx context.Context) error
+
+// cleanupEntry pairs a teardown closure with a label for the failure report.
+type cleanupEntry struct {
+	label string
+	fn    CleanupFunc
+}
+
+// Cleanup tracks created resources and tears them down LIFO. It is the
+// never-orphan backstop: every write step registers its teardown BEFORE the
+// created resource can be lost to the state, so even if a later step or the
+// breaker aborts the cycle, TeardownAll still removes what was created.
+//
+// Safe for concurrent registration by the worker pool.
+type Cleanup struct {
+	mu      sync.Mutex
+	entries []cleanupEntry
+}
+
+// NewCleanup returns an empty tracker.
+func NewCleanup() *Cleanup {
+	return &Cleanup{}
+}
+
+// Register adds a teardown closure. Closures run in reverse registration order
+// (LIFO) so dependents are removed before their dependencies (e.g. unbind a
+// floating IP before deleting the static IP it pointed at).
+func (c *Cleanup) Register(label string, fn CleanupFunc) {
+	c.mu.Lock()
+	c.entries = append(c.entries, cleanupEntry{label: label, fn: fn})
+	c.mu.Unlock()
+}
+
+// TeardownFailure records a teardown that could not complete.
+type TeardownFailure struct {
+	Label    string
+	Err      error
+	Attempts int
+}
+
+// TeardownAll runs every registered teardown LIFO, one logical teardown each
+// with a bounded transient-retry. A failing teardown NEVER stops the others:
+// the goal is best-effort removal of everything that was created. It returns
+// the list of teardowns that still failed after their bounded retries.
+//
+// The tracker is drained as it goes, so calling TeardownAll twice is safe and
+// the second call is a no-op (idempotent under the engine's defer + explicit
+// call paths).
+func (c *Cleanup) TeardownAll(ctx context.Context) []TeardownFailure {
+	c.mu.Lock()
+	entries := c.entries
+	c.entries = nil
+	c.mu.Unlock()
+
+	var failures []TeardownFailure
+	// LIFO: iterate from the most recently registered to the oldest.
+	for i := len(entries) - 1; i >= 0; i-- {
+		e := entries[i]
+		attempts, err := runTeardown(ctx, e.fn)
+		if err != nil {
+			failures = append(failures, TeardownFailure{Label: e.label, Err: err, Attempts: attempts})
+		}
+	}
+	return failures
+}
+
+// Pending reports how many teardowns are still registered.
+func (c *Cleanup) Pending() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// runTeardown executes one teardown with a bounded transient-retry. It returns
+// the number of attempts made and the final error (nil on success).
+//
+// Retry policy: only TRANSIENT categories (transient workers, 502, 5xx) are
+// retried; a permanent failure (4xx, decode, etc.) is returned on the first
+// attempt. The context is checked between attempts so a global timeout cuts it
+// short. There is no sleep: a bounded immediate retry is enough to ride over a
+// single transient blip without becoming a load loop.
+func runTeardown(ctx context.Context, fn CleanupFunc) (int, error) {
+	var lastErr error
+	for attempt := 1; attempt <= teardownMaxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			return attempt - 1, lastErr
+		}
+		lastErr = fn(ctx)
+		if lastErr == nil {
+			return attempt, nil
+		}
+		if !isTransientCategory(categorize(lastErr)) {
+			return attempt, lastErr
+		}
+	}
+	return teardownMaxAttempts, lastErr
+}
+
+// isTransientCategory reports whether a category is worth a bounded retry
+// during teardown.
+func isTransientCategory(cat Category) bool {
+	switch cat {
+	case CategoryTransientWorkers, CategoryBadGateway502, CategoryHTTP5xx:
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// This file holds the PRE-CREATE teardown registration logic (F3). Every write
+// cycle registers a best-effort, idempotent teardown keyed by a DETERMINISTIC
+// identifier BEFORE the creating call, so a created-but-unresolved or
+// created-but-failed resource is still swept. The client documents several
+// "201 with empty/ambiguous body" paths where the create succeeds server-side
+// but id resolution can fail (e.g. internal/client/vpc_static_ip.go) — those
+// are exactly the orphan windows this pre-registration closes.
+//
+// Each registration takes a narrow SEAM interface (only the methods the
+// teardown needs), not *client.Client, so it is unit-testable offline with a
+// fake that returns an error AFTER simulating the server-side effect.
+//
+// Idempotency contract for every teardown here: an absent resource is SUCCESS
+// (nil error), never a failure — so the safety net does not generate noise when
+// the happy-path delete already removed the resource.
+
+// --- VPC static IP -----------------------------------------------------------
+
+// staticIPSeam is the subset of the VPC static-IP client a static-IP teardown
+// needs. *client.Client satisfies it via vpcStaticIPSeam.
+type staticIPSeam interface {
+	// ListStrict returns a provably-complete listing of the private network's
+	// static IPs (fails closed otherwise — see the client doc).
+	ListStrict(ctx context.Context, privateNetworkID string) ([]*client.StaticIP, error)
+	// DeleteAndWait deletes a static IP by id and waits for the delete activity.
+	DeleteAndWait(ctx context.Context, id string) error
+}
+
+// registerStaticIPTeardown registers a teardown that finds the custom static IP
+// carrying our MAC on the private network and deletes it if present. It is
+// registered BEFORE Create, so even an ambiguous/failed create (201 empty body,
+// id unresolved) is still swept by the next teardown pass. The deterministic key
+// is (privateNetworkID, mac); no created id is needed.
+//
+// Idempotent: if no custom static IP carries our MAC, the network is already
+// clean and the teardown succeeds.
+func registerStaticIPTeardown(cl *Cleanup, seam staticIPSeam, privateNetworkID, mac string) {
+	cl.Register(fmt.Sprintf("vpc.static_ip by-mac %s on %s", mac, privateNetworkID), func(tctx context.Context) error {
+		list, err := seam.ListStrict(tctx, privateNetworkID)
+		if err != nil {
+			return err
+		}
+		want := normalizeMACForCleanup(mac)
+		for _, si := range list {
+			if si == nil || si.Source != "custom" {
+				continue
+			}
+			if normalizeMACForCleanup(si.MacAddress) != want {
+				continue
+			}
+			// Found our created-but-maybe-unresolved static IP: delete by id.
+			return seam.DeleteAndWait(tctx, si.ID)
+		}
+		// Absent → already clean → success (idempotent).
+		return nil
+	})
+}
+
+// normalizeMACForCleanup canonicalises a MAC for comparison the same way the
+// client does (lowercase, ":"-separated). Kept local to avoid depending on an
+// unexported client helper.
+func normalizeMACForCleanup(mac string) string {
+	out := make([]rune, 0, len(mac))
+	for _, r := range mac {
+		switch {
+		case r == '-':
+			out = append(out, ':')
+		case r >= 'A' && r <= 'Z':
+			out = append(out, r+('a'-'A'))
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// vpcStaticIPSeam adapts *client.Client to staticIPSeam.
+type vpcStaticIPSeam struct{ c *client.Client }
+
+func (s vpcStaticIPSeam) ListStrict(ctx context.Context, privateNetworkID string) ([]*client.StaticIP, error) {
+	return s.c.VPC().StaticIP().ListStrict(ctx, privateNetworkID)
+}
+
+func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.VPC().StaticIP().Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+	if activityID == "" {
+		return nil
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+// --- Object storage bucket ----------------------------------------------------
+
+// bucketSeam is the subset of the bucket client a bucket teardown needs.
+type bucketSeam interface {
+	// DeleteAndWait deletes a bucket by name and waits for the delete activity.
+	// It MUST treat an already-absent bucket as success.
+	DeleteAndWait(ctx context.Context, name string) error
+}
+
+// registerBucketTeardown registers "delete bucket by name if present" BEFORE the
+// create, keyed by the deterministic bucket name, so a created-but-unconfirmed
+// bucket is still swept. Idempotent via the seam's absent-is-success contract.
+func registerBucketTeardown(cl *Cleanup, seam bucketSeam, name string) {
+	cl.Register(fmt.Sprintf("object_storage.bucket by-name %s", name), func(tctx context.Context) error {
+		return seam.DeleteAndWait(tctx, name)
+	})
+}
+
+// objectStorageBucketSeam adapts *client.Client to bucketSeam.
+type objectStorageBucketSeam struct{ c *client.Client }
+
+func (s objectStorageBucketSeam) DeleteAndWait(ctx context.Context, name string) error {
+	activityID, err := s.c.ObjectStorage().Bucket().Delete(ctx, name)
+	if err != nil {
+		// A 404/absent bucket is not an orphan: swallow not-found so the safety
+		// net stays idempotent. Any other error is surfaced for the retry/report.
+		if categorize(err) == CategoryHTTP4xx {
+			return nil
+		}
+		return err
+	}
+	if activityID == "" {
+		return nil
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+// --- Object storage ACL entry -------------------------------------------------
+
+// aclSeam is the subset of the ACL-entry client an ACL teardown needs.
+type aclSeam interface {
+	// RevokeAndWait revokes (role, account) on the bucket and waits. It MUST
+	// treat an already-absent grant as success.
+	RevokeAndWait(ctx context.Context, bucket, role, account string) error
+}
+
+// registerACLTeardown registers revoke(role, account) BEFORE the grant, keyed by
+// the deterministic (bucket, role, account) triple, so an ambiguous grant is
+// still swept. Idempotent via the seam's absent-is-success contract.
+func registerACLTeardown(cl *Cleanup, seam aclSeam, bucket, role, account string) {
+	cl.Register(fmt.Sprintf("object_storage.acl revoke %s/%s/%s", bucket, role, account), func(tctx context.Context) error {
+		return seam.RevokeAndWait(tctx, bucket, role, account)
+	})
+}
+
+// objectStorageACLSeam adapts *client.Client to aclSeam.
+type objectStorageACLSeam struct{ c *client.Client }
+
+func (s objectStorageACLSeam) RevokeAndWait(ctx context.Context, bucket, role, account string) error {
+	activityID, err := s.c.ObjectStorage().ACLEntry().Revoke(ctx, bucket, role, account)
+	if err != nil {
+		if categorize(err) == CategoryHTTP4xx {
+			return nil // absent grant → already clean
+		}
+		return err
+	}
+	if activityID == "" {
+		return nil
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+// --- VPC floating IP binding --------------------------------------------------
+
+// fipBindSeam is the subset of the floating-IP client a binding teardown needs.
+type fipBindSeam interface {
+	// UnbindAndWait unbinds the floating IP from the static IP and waits. It MUST
+	// treat an already-unbound pair as success.
+	UnbindAndWait(ctx context.Context, fipID, staticID string) error
+}
+
+// registerFIPUnbindTeardown registers unbind(fip, static) BEFORE the bind, keyed
+// by the deterministic (fipID, staticID) pair, so a bind whose confirmation is
+// lost is still released. Idempotent via the seam's absent-is-success contract.
+func registerFIPUnbindTeardown(cl *Cleanup, seam fipBindSeam, fipID, staticID string) {
+	cl.Register(fmt.Sprintf("vpc.floating_ip unbind %s<-%s", fipID, staticID), func(tctx context.Context) error {
+		return seam.UnbindAndWait(tctx, fipID, staticID)
+	})
+}
+
+// vpcFIPBindSeam adapts *client.Client to fipBindSeam.
+type vpcFIPBindSeam struct{ c *client.Client }
+
+func (s vpcFIPBindSeam) UnbindAndWait(ctx context.Context, fipID, staticID string) error {
+	activityID, err := s.c.VPC().FloatingIP().Unbind(ctx, fipID, staticID)
+	if err != nil {
+		if categorize(err) == CategoryHTTP4xx {
+			return nil // already unbound → idempotent success
+		}
+		return err
+	}
+	if activityID == "" {
+		return nil
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+// --- IAM personal access token ------------------------------------------------
+
+// patSeam is the subset of the PAT client a PAT teardown needs.
+type patSeam interface {
+	// Delete removes a PAT by id (idempotent: absent → success).
+	Delete(ctx context.Context, patID string) error
+	// FindIDByName returns the id of a PAT whose name matches, or "" if none.
+	// Used to remove a created-but-undecoded PAT best-effort.
+	FindIDByName(ctx context.Context, name string) (string, error)
+}
+
+// patTeardownRef carries the PAT identity for teardown. The id is filled in once
+// the create decodes; if it never does, the teardown falls back to find-by-name.
+// A pointer is shared between the cycle and the registered closure so the cycle
+// can set Resolved/ID AFTER registration without re-registering.
+type patTeardownRef struct {
+	Name     string
+	ID       string
+	Resolved bool
+}
+
+// registerPATTeardown registers a PAT teardown BEFORE the create/decode, keyed by
+// the deterministic name and an id-by-reference. At teardown time it deletes by
+// id when resolved, else best-effort finds the PAT by name and deletes it — so a
+// created-but-undecoded PAT (a live credential) is still removed. A PAT left
+// orphaned is a security issue, hence the pre-registration.
+//
+// Idempotent: a nil-id, name-not-found PAT means nothing to delete → success.
+func registerPATTeardown(cl *Cleanup, seam patSeam, ref *patTeardownRef) {
+	cl.Register(fmt.Sprintf("iam.pat %s", ref.Name), func(tctx context.Context) error {
+		if ref.Resolved && ref.ID != "" {
+			return seam.Delete(tctx, ref.ID)
+		}
+		id, err := seam.FindIDByName(tctx, ref.Name)
+		if err != nil {
+			return err
+		}
+		if id == "" {
+			return nil // never created / already gone → idempotent success
+		}
+		return seam.Delete(tctx, id)
+	})
+}
+
+// iamPATSeam adapts *client.Client to patSeam.
+type iamPATSeam struct{ c *client.Client }
+
+func (s iamPATSeam) Delete(ctx context.Context, patID string) error {
+	return s.c.IAM().PAT().Delete(ctx, patID)
+}
+
+func (s iamPATSeam) FindIDByName(ctx context.Context, name string) (string, error) {
+	pats, err := s.c.IAM().PAT().ListStrict(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range pats {
+		if p != nil && p.Name == name && p.ID != "" {
+			return p.ID, nil
+		}
+	}
+	return "", nil
+}

--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
@@ -19,9 +21,98 @@ import (
 // teardown needs), not *client.Client, so it is unit-testable offline with a
 // fake that returns an error AFTER simulating the server-side effect.
 //
-// Idempotency contract for every teardown here: an absent resource is SUCCESS
-// (nil error), never a failure — so the safety net does not generate noise when
-// the happy-path delete already removed the resource.
+// Idempotency contract for every teardown here (F3): "absent = success" means a
+// DEFINITIVE HTTP 404 only, never a blanket 4xx. A 403/409/400 is NOT proof of
+// absence — treating it as "already gone" would let a delete/revoke/unbind
+// report success while a bucket, ACL grant, FIP binding or static IP still
+// exists (an orphan). So:
+//   - bucket delete, ACL revoke, PAT delete, static IP delete: a 404 is success
+//     (idempotent: a second delete of an already-removed resource returns 404),
+//     any other error is surfaced as a real failure;
+//   - the static IP delete additionally mirrors #312: a 403 is AMBIGUOUS (the
+//     VPC API conflates absent/forbidden, #303), so it is confirmed via a strict
+//     200-only listing of the private network before being accepted as gone;
+//   - the FIP unbind mirrors the merged #309 confirmFloatingIPUnbound doctrine:
+//     a 404 is success, a 403/other is NEVER assumed gone — it is positively
+//     confirmed via the strict listing (CorroborateBinding), accepted only on
+//     proof the pair is no longer bound (Unbound or BoundToOther).
+
+// isStatusCode reports whether err is (or wraps) a client.StatusError with the
+// given HTTP code. This is the single source of truth for the "404-only is
+// absent" contract — mirrors isVPCStatusCode in the provider so the harness and
+// the resource layer cannot drift on what counts as a definitive not-found.
+func isStatusCode(err error, code int) bool {
+	var statusErr client.StatusError
+	return errors.As(err, &statusErr) && statusErr.Code == code
+}
+
+// idempotentDeleteErr is the SHARED delete/revoke idempotency decision for the
+// seams whose absence is unambiguous (bucket, ACL grant, PAT): a DEFINITIVE 404
+// means the resource is already gone → success (nil); ANY other error (403, 409,
+// 400, 5xx, transport) is NOT proof of absence and is surfaced unchanged. Both
+// the production seams and the offline unit tests call THIS function, so a
+// mutation here breaks production and the tests together (no parallel copy).
+func idempotentDeleteErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isStatusCode(err, http.StatusNotFound) {
+		return nil
+	}
+	return err
+}
+
+// staticIPDeleteErrResult is the SHARED static-IP delete idempotency decision
+// (#312): a 404 is idempotent success; a 403 is AMBIGUOUS (#303 conflates
+// absent/forbidden) and is confirmed via a strict 200-only listing of the
+// private network before being accepted; any other error surfaces. listStrict
+// is injected so the decision is unit-testable offline.
+func staticIPDeleteErrResult(err error, listStrict func() ([]*client.StaticIP, error), privateNetworkID, id string) error {
+	if err == nil {
+		return nil
+	}
+	if isStatusCode(err, http.StatusNotFound) {
+		return nil
+	}
+	if isStatusCode(err, http.StatusForbidden) {
+		if privateNetworkID == "" {
+			return fmt.Errorf("static IP %s delete returned 403 and its absence could not be confirmed (no private network scope): %w", id, err)
+		}
+		list, lerr := listStrict()
+		if lerr != nil {
+			return fmt.Errorf("static IP %s delete returned 403 and the strict listing of private network %s failed: %w (original: %v)", id, privateNetworkID, lerr, err)
+		}
+		for _, si := range list {
+			if si != nil && si.ID == id {
+				return fmt.Errorf("static IP %s could not be deleted (403) and is still present on private network %s: %w", id, privateNetworkID, err)
+			}
+		}
+		// Confirmed absent from a complete 200 listing of its own network.
+		return nil
+	}
+	return err
+}
+
+// fipUnbindOutcome is the SHARED floating-IP unbind confirmation decision (#309
+// confirmFloatingIPUnbound doctrine): the unbind is accepted ONLY on strict
+// positive evidence the FIP is no longer bound to OUR static IP (Unbound or
+// BoundToOther). A failed corroboration, a still-our-pair (BoundToTarget), or an
+// inconclusive listing all FAIL CLOSED — there is NO "absent from listing =>
+// success" path. unbindErr (when non-nil) is woven into the failure detail.
+func fipUnbindOutcome(state client.FloatingIPBindingState, corrErr error, fipID, staticID string, unbindErr error) error {
+	if corrErr != nil {
+		return fmt.Errorf("floating IP %s unbind from %s could not be confirmed (strict listing failed): %w (original: %v)", fipID, staticID, corrErr, unbindErr)
+	}
+	switch state {
+	case client.FloatingIPBindingUnbound, client.FloatingIPBindingBoundToOther:
+		// No longer bound to OUR pair: the unbind took effect → success.
+		return nil
+	case client.FloatingIPBindingBoundToTarget:
+		return fmt.Errorf("floating IP %s is still bound to static IP %s after the unbind (confirmed by the strict listing): %v", fipID, staticID, unbindErr)
+	default:
+		return fmt.Errorf("floating IP %s unbind from %s could not be positively confirmed (inconclusive listing): %v", fipID, staticID, unbindErr)
+	}
+}
 
 // --- VPC static IP -----------------------------------------------------------
 
@@ -32,7 +123,10 @@ type staticIPSeam interface {
 	// static IPs (fails closed otherwise — see the client doc).
 	ListStrict(ctx context.Context, privateNetworkID string) ([]*client.StaticIP, error)
 	// DeleteAndWait deletes a static IP by id and waits for the delete activity.
-	DeleteAndWait(ctx context.Context, id string) error
+	// It is idempotent under the F3 contract: a 404 is success; a 403 is
+	// confirmed absent via a strict listing of privateNetworkID before being
+	// accepted (mirrors #312); any other error is surfaced.
+	DeleteAndWait(ctx context.Context, privateNetworkID, id string) error
 }
 
 // registerStaticIPTeardown registers a teardown that finds the custom static IP
@@ -58,7 +152,7 @@ func registerStaticIPTeardown(cl *Cleanup, seam staticIPSeam, privateNetworkID, 
 				continue
 			}
 			// Found our created-but-maybe-unresolved static IP: delete by id.
-			return seam.DeleteAndWait(tctx, si.ID)
+			return seam.DeleteAndWait(tctx, privateNetworkID, si.ID)
 		}
 		// Absent → already clean → success (idempotent).
 		return nil
@@ -90,10 +184,15 @@ func (s vpcStaticIPSeam) ListStrict(ctx context.Context, privateNetworkID string
 	return s.c.VPC().StaticIP().ListStrict(ctx, privateNetworkID)
 }
 
-func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, id string) error {
+func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string) error {
 	activityID, err := s.c.VPC().StaticIP().Delete(ctx, id)
 	if err != nil {
-		return err
+		// 404 → idempotent success; 403 → confirm absence via the strict listing
+		// (#312); anything else surfaces. The decision lives in a shared, offline-
+		// testable helper so production and tests cannot drift.
+		return staticIPDeleteErrResult(err, func() ([]*client.StaticIP, error) {
+			return s.ListStrict(ctx, privateNetworkID)
+		}, privateNetworkID, id)
 	}
 	if activityID == "" {
 		return nil
@@ -107,13 +206,14 @@ func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, id string) error {
 // bucketSeam is the subset of the bucket client a bucket teardown needs.
 type bucketSeam interface {
 	// DeleteAndWait deletes a bucket by name and waits for the delete activity.
-	// It MUST treat an already-absent bucket as success.
+	// It MUST treat an already-absent bucket (404) as success; any other error
+	// (403/409/400/5xx/transport) is a real failure.
 	DeleteAndWait(ctx context.Context, name string) error
 }
 
 // registerBucketTeardown registers "delete bucket by name if present" BEFORE the
 // create, keyed by the deterministic bucket name, so a created-but-unconfirmed
-// bucket is still swept. Idempotent via the seam's absent-is-success contract.
+// bucket is still swept. Idempotent via the seam's 404-is-success contract.
 func registerBucketTeardown(cl *Cleanup, seam bucketSeam, name string) {
 	cl.Register(fmt.Sprintf("object_storage.bucket by-name %s", name), func(tctx context.Context) error {
 		return seam.DeleteAndWait(tctx, name)
@@ -126,12 +226,9 @@ type objectStorageBucketSeam struct{ c *client.Client }
 func (s objectStorageBucketSeam) DeleteAndWait(ctx context.Context, name string) error {
 	activityID, err := s.c.ObjectStorage().Bucket().Delete(ctx, name)
 	if err != nil {
-		// A 404/absent bucket is not an orphan: swallow not-found so the safety
-		// net stays idempotent. Any other error is surfaced for the retry/report.
-		if categorize(err) == CategoryHTTP4xx {
-			return nil
-		}
-		return err
+		// Only a DEFINITIVE 404 proves the bucket is gone → idempotent success.
+		// A 403/409/400 is NOT proof of absence (shared decision; see helper).
+		return idempotentDeleteErr(err)
 	}
 	if activityID == "" {
 		return nil
@@ -145,13 +242,14 @@ func (s objectStorageBucketSeam) DeleteAndWait(ctx context.Context, name string)
 // aclSeam is the subset of the ACL-entry client an ACL teardown needs.
 type aclSeam interface {
 	// RevokeAndWait revokes (role, account) on the bucket and waits. It MUST
-	// treat an already-absent grant as success.
+	// treat an already-absent grant (404) as success; any other error is a real
+	// failure.
 	RevokeAndWait(ctx context.Context, bucket, role, account string) error
 }
 
 // registerACLTeardown registers revoke(role, account) BEFORE the grant, keyed by
 // the deterministic (bucket, role, account) triple, so an ambiguous grant is
-// still swept. Idempotent via the seam's absent-is-success contract.
+// still swept. Idempotent via the seam's 404-is-success contract.
 func registerACLTeardown(cl *Cleanup, seam aclSeam, bucket, role, account string) {
 	cl.Register(fmt.Sprintf("object_storage.acl revoke %s/%s/%s", bucket, role, account), func(tctx context.Context) error {
 		return seam.RevokeAndWait(tctx, bucket, role, account)
@@ -164,10 +262,9 @@ type objectStorageACLSeam struct{ c *client.Client }
 func (s objectStorageACLSeam) RevokeAndWait(ctx context.Context, bucket, role, account string) error {
 	activityID, err := s.c.ObjectStorage().ACLEntry().Revoke(ctx, bucket, role, account)
 	if err != nil {
-		if categorize(err) == CategoryHTTP4xx {
-			return nil // absent grant → already clean
-		}
-		return err
+		// Only a 404 proves the grant is already gone → idempotent success. A
+		// 403/409/400 must NOT be read as "already revoked" (shared decision).
+		return idempotentDeleteErr(err)
 	}
 	if activityID == "" {
 		return nil
@@ -180,14 +277,18 @@ func (s objectStorageACLSeam) RevokeAndWait(ctx context.Context, bucket, role, a
 
 // fipBindSeam is the subset of the floating-IP client a binding teardown needs.
 type fipBindSeam interface {
-	// UnbindAndWait unbinds the floating IP from the static IP and waits. It MUST
-	// treat an already-unbound pair as success.
+	// UnbindAndWait unbinds the floating IP from the static IP and waits. A 404
+	// is idempotent success; a 403/other is NEVER assumed "gone" — it is
+	// positively confirmed via CorroborateBinding before being accepted.
 	UnbindAndWait(ctx context.Context, fipID, staticID string) error
+	// CorroborateBinding strictly classifies the FIP/static relationship from a
+	// COMPLETE 200 listing (fails closed to Inconclusive otherwise).
+	CorroborateBinding(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error)
 }
 
 // registerFIPUnbindTeardown registers unbind(fip, static) BEFORE the bind, keyed
 // by the deterministic (fipID, staticID) pair, so a bind whose confirmation is
-// lost is still released. Idempotent via the seam's absent-is-success contract.
+// lost is still released. Idempotent via the seam's 404/confirmed contract.
 func registerFIPUnbindTeardown(cl *Cleanup, seam fipBindSeam, fipID, staticID string) {
 	cl.Register(fmt.Sprintf("vpc.floating_ip unbind %s<-%s", fipID, staticID), func(tctx context.Context) error {
 		return seam.UnbindAndWait(tctx, fipID, staticID)
@@ -200,23 +301,37 @@ type vpcFIPBindSeam struct{ c *client.Client }
 func (s vpcFIPBindSeam) UnbindAndWait(ctx context.Context, fipID, staticID string) error {
 	activityID, err := s.c.VPC().FloatingIP().Unbind(ctx, fipID, staticID)
 	if err != nil {
-		if categorize(err) == CategoryHTTP4xx {
-			return nil // already unbound → idempotent success
+		// 404 on the unbind call itself: unambiguous absence → idempotent success.
+		if isStatusCode(err, http.StatusNotFound) {
+			return nil
 		}
-		return err
+		// 403 or any other error: NEVER assume the pair is gone (mirrors the merged
+		// #309 confirmFloatingIPUnbound doctrine). Positively confirm via the strict
+		// listing before accepting; an unproven state fails closed.
+		state, cerr := s.CorroborateBinding(ctx, fipID, staticID)
+		return fipUnbindOutcome(state, cerr, fipID, staticID, err)
 	}
-	if activityID == "" {
-		return nil
+	if activityID != "" {
+		if _, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter); werr != nil {
+			return werr
+		}
 	}
-	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
-	return werr
+	// Happy path too is positively confirmed: an unbind activity completing does
+	// not by itself prove the pair is no longer bound.
+	state, cerr := s.CorroborateBinding(ctx, fipID, staticID)
+	return fipUnbindOutcome(state, cerr, fipID, staticID, nil)
+}
+
+func (s vpcFIPBindSeam) CorroborateBinding(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+	return s.c.VPC().FloatingIP().CorroborateBinding(ctx, fipID, staticID)
 }
 
 // --- IAM personal access token ------------------------------------------------
 
 // patSeam is the subset of the PAT client a PAT teardown needs.
 type patSeam interface {
-	// Delete removes a PAT by id (idempotent: absent → success).
+	// Delete removes a PAT by id. A 404 is idempotent success; any other error is
+	// a real failure.
 	Delete(ctx context.Context, patID string) error
 	// FindIDByName returns the id of a PAT whose name matches, or "" if none.
 	// Used to remove a created-but-undecoded PAT best-effort.
@@ -239,7 +354,8 @@ type patTeardownRef struct {
 // created-but-undecoded PAT (a live credential) is still removed. A PAT left
 // orphaned is a security issue, hence the pre-registration.
 //
-// Idempotent: a nil-id, name-not-found PAT means nothing to delete → success.
+// Idempotent: a nil-id, name-not-found PAT means nothing to delete → success;
+// a delete that 404s (already removed by the happy path) is also success.
 func registerPATTeardown(cl *Cleanup, seam patSeam, ref *patTeardownRef) {
 	cl.Register(fmt.Sprintf("iam.pat %s", ref.Name), func(tctx context.Context) error {
 		if ref.Resolved && ref.ID != "" {
@@ -260,7 +376,11 @@ func registerPATTeardown(cl *Cleanup, seam patSeam, ref *patTeardownRef) {
 type iamPATSeam struct{ c *client.Client }
 
 func (s iamPATSeam) Delete(ctx context.Context, patID string) error {
-	return s.c.IAM().PAT().Delete(ctx, patID)
+	// A 404 proves the PAT is already gone → idempotent success (so the happy-
+	// path-then-deferred double delete does not report a false failure). Any other
+	// error (403/409/400/5xx/transport) is surfaced: a PAT is a live credential,
+	// so a non-404 delete error must be reported, never swallowed (shared helper).
+	return idempotentDeleteErr(s.c.IAM().PAT().Delete(ctx, patID))
 }
 
 func (s iamPATSeam) FindIDByName(ctx context.Context, name string) (string, error) {

--- a/cmd/ct-validate/cleanup_seams_test.go
+++ b/cmd/ct-validate/cleanup_seams_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// These tests prove F3: every write cycle's teardown is registered keyed by a
+// DETERMINISTIC identifier BEFORE the creating call, so a created-but-unresolved
+// or created-but-failed resource is still swept. Each fake seam simulates the
+// "error-after-effect" hazard: the create reported an error/ambiguous result,
+// yet a resource exists server-side. The pre-registered teardown must find and
+// remove it, and must be idempotent (absent → success).
+
+// --- VPC static IP ------------------------------------------------------------
+
+type fakeStaticIPSeam struct {
+	list      []*client.StaticIP
+	listErr   error
+	deleted   []string
+	deleteErr error
+}
+
+func (f *fakeStaticIPSeam) ListStrict(_ context.Context, _ string) ([]*client.StaticIP, error) {
+	return f.list, f.listErr
+}
+func (f *fakeStaticIPSeam) DeleteAndWait(_ context.Context, id string) error {
+	f.deleted = append(f.deleted, id)
+	return f.deleteErr
+}
+
+// TestStaticIPTeardownSweepsCreatedButUnresolved proves the by-MAC teardown
+// deletes the custom static IP carrying our MAC even though the create returned
+// no usable id (the orphan window the client documents). Mutation proof: drop
+// the registerStaticIPTeardown call in cycle_vpc.go → nothing is registered →
+// the static IP is never deleted in the create-ambiguous path → RED here (this
+// test exercises the registration helper directly, and the engine test below
+// proves it is actually wired before Create).
+func TestStaticIPTeardownSweepsCreatedButUnresolved(t *testing.T) {
+	seam := &fakeStaticIPSeam{
+		list: []*client.StaticIP{
+			{ID: "xoa-1", MacAddress: "02:00:5e:f0:00:00", Source: "xoa"}, // co-resident, must be ignored
+			{ID: "custom-1", MacAddress: "02:00:5E:F0:00:00", Source: "custom"},
+		},
+	}
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	if cl.Pending() != 1 {
+		t.Fatalf("teardown must be registered before Create; Pending=%d", cl.Pending())
+	}
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("teardown should succeed, got %+v", fails)
+	}
+	// Only the custom IP with our MAC must be deleted, not the xoa co-resident.
+	if len(seam.deleted) != 1 || seam.deleted[0] != "custom-1" {
+		t.Fatalf("teardown deleted %v, want exactly [custom-1]", seam.deleted)
+	}
+}
+
+// TestStaticIPTeardownIdempotentWhenAbsent proves an absent static IP is success.
+func TestStaticIPTeardownIdempotentWhenAbsent(t *testing.T) {
+	seam := &fakeStaticIPSeam{list: []*client.StaticIP{}}
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("absent static IP must be idempotent success, got %+v", fails)
+	}
+	if len(seam.deleted) != 0 {
+		t.Fatalf("nothing should be deleted when absent, deleted %v", seam.deleted)
+	}
+}
+
+// --- Object storage bucket ----------------------------------------------------
+
+type fakeBucketSeam struct {
+	deleted []string
+	err     error
+}
+
+func (f *fakeBucketSeam) DeleteAndWait(_ context.Context, name string) error {
+	f.deleted = append(f.deleted, name)
+	return f.err
+}
+
+// TestBucketTeardownRegisteredByName proves the bucket teardown is keyed by the
+// deterministic name and runs the delete (sweeping a created-but-unconfirmed
+// bucket).
+func TestBucketTeardownRegisteredByName(t *testing.T) {
+	seam := &fakeBucketSeam{}
+	cl := NewCleanup()
+	registerBucketTeardown(cl, seam, "ct-validate-0-0")
+	if cl.Pending() != 1 {
+		t.Fatalf("bucket teardown must be registered before Create; Pending=%d", cl.Pending())
+	}
+	cl.TeardownAll(context.Background())
+	if len(seam.deleted) != 1 || seam.deleted[0] != "ct-validate-0-0" {
+		t.Fatalf("bucket teardown deleted %v, want [ct-validate-0-0]", seam.deleted)
+	}
+}
+
+// --- ACL entry ----------------------------------------------------------------
+
+type fakeACLSeam struct {
+	revoked [][3]string
+	err     error
+}
+
+func (f *fakeACLSeam) RevokeAndWait(_ context.Context, bucket, role, account string) error {
+	f.revoked = append(f.revoked, [3]string{bucket, role, account})
+	return f.err
+}
+
+// TestACLTeardownRegisteredByTriple proves the ACL teardown is keyed by
+// (bucket, role, account) and revokes (sweeping an ambiguous grant).
+func TestACLTeardownRegisteredByTriple(t *testing.T) {
+	seam := &fakeACLSeam{}
+	cl := NewCleanup()
+	registerACLTeardown(cl, seam, "bkt", "reader", "acct")
+	if cl.Pending() != 1 {
+		t.Fatalf("ACL teardown must be registered before Grant; Pending=%d", cl.Pending())
+	}
+	cl.TeardownAll(context.Background())
+	if len(seam.revoked) != 1 || seam.revoked[0] != [3]string{"bkt", "reader", "acct"} {
+		t.Fatalf("ACL teardown revoked %v, want one [bkt reader acct]", seam.revoked)
+	}
+}
+
+// --- FIP binding --------------------------------------------------------------
+
+type fakeFIPSeam struct {
+	unbound [][2]string
+	err     error
+}
+
+func (f *fakeFIPSeam) UnbindAndWait(_ context.Context, fipID, staticID string) error {
+	f.unbound = append(f.unbound, [2]string{fipID, staticID})
+	return f.err
+}
+
+// TestFIPUnbindTeardownRegisteredByPair proves the unbind teardown is keyed by
+// (fip, static) and unbinds (releasing a bind whose confirmation was lost).
+func TestFIPUnbindTeardownRegisteredByPair(t *testing.T) {
+	seam := &fakeFIPSeam{}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if cl.Pending() != 1 {
+		t.Fatalf("FIP unbind teardown must be registered before Bind; Pending=%d", cl.Pending())
+	}
+	cl.TeardownAll(context.Background())
+	if len(seam.unbound) != 1 || seam.unbound[0] != [2]string{"fip-1", "static-1"} {
+		t.Fatalf("FIP teardown unbound %v, want one [fip-1 static-1]", seam.unbound)
+	}
+}
+
+// --- IAM PAT ------------------------------------------------------------------
+
+type fakePATSeam struct {
+	deleted    []string
+	findID     string
+	findErr    error
+	deleteErr  error
+	findCalled bool
+}
+
+func (f *fakePATSeam) Delete(_ context.Context, patID string) error {
+	f.deleted = append(f.deleted, patID)
+	return f.deleteErr
+}
+func (f *fakePATSeam) FindIDByName(_ context.Context, _ string) (string, error) {
+	f.findCalled = true
+	return f.findID, f.findErr
+}
+
+// TestPATTeardownByIDWhenResolved proves that once the create decodes an id, the
+// teardown deletes by id and does NOT fall back to find-by-name.
+func TestPATTeardownByIDWhenResolved(t *testing.T) {
+	seam := &fakePATSeam{}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "ct-validate-0-0"}
+	registerPATTeardown(cl, seam, ref)
+	// Simulate the create decoding the id AFTER registration (shared ref).
+	ref.ID = "pat-123"
+	ref.Resolved = true
+
+	cl.TeardownAll(context.Background())
+	if len(seam.deleted) != 1 || seam.deleted[0] != "pat-123" {
+		t.Fatalf("resolved PAT must be deleted by id, deleted=%v", seam.deleted)
+	}
+	if seam.findCalled {
+		t.Fatal("must not fall back to find-by-name when the id is resolved")
+	}
+}
+
+// TestPATTeardownFindByNameWhenUndecoded proves the security-critical path: the
+// create reported an error/ambiguous result (id never decoded), yet a PAT (a
+// live credential) exists. The pre-registered teardown finds it by name and
+// deletes it. This is the orphan window the pre-registration closes.
+//
+// Mutation proof: register the PAT teardown only AFTER a successful decode (move
+// registerPATTeardown below the create op and gate it on ref.Resolved) → an
+// undecoded PAT is never registered → never deleted → RED here.
+func TestPATTeardownFindByNameWhenUndecoded(t *testing.T) {
+	seam := &fakePATSeam{findID: "pat-found-by-name"}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "ct-validate-0-0"} // never Resolved (decode failed)
+	registerPATTeardown(cl, seam, ref)
+	if cl.Pending() != 1 {
+		t.Fatalf("PAT teardown must be registered before create/decode; Pending=%d", cl.Pending())
+	}
+
+	cl.TeardownAll(context.Background())
+	if !seam.findCalled {
+		t.Fatal("undecoded PAT must trigger find-by-name fallback")
+	}
+	if len(seam.deleted) != 1 || seam.deleted[0] != "pat-found-by-name" {
+		t.Fatalf("undecoded PAT must be deleted via find-by-name, deleted=%v", seam.deleted)
+	}
+}
+
+// TestPATTeardownIdempotentWhenNeverCreated proves a never-created PAT (no id,
+// find-by-name returns "") is an idempotent success, not a failure.
+func TestPATTeardownIdempotentWhenNeverCreated(t *testing.T) {
+	seam := &fakePATSeam{findID: ""}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "ct-validate-0-0"}
+	registerPATTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("never-created PAT must be idempotent success, got %+v", fails)
+	}
+	if len(seam.deleted) != 0 {
+		t.Fatalf("nothing to delete when never created, deleted=%v", seam.deleted)
+	}
+}
+
+// TestPATTeardownSurfacesFindError proves a find-by-name error is surfaced (not
+// swallowed): a teardown that cannot prove absence must report a possible
+// orphan, not silently succeed.
+func TestPATTeardownSurfacesFindError(t *testing.T) {
+	seam := &fakePATSeam{findErr: errors.New("list failed")}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "ct-validate-0-0"}
+	registerPATTeardown(cl, seam, ref)
+	fails := cl.TeardownAll(context.Background())
+	if len(fails) != 1 {
+		t.Fatalf("a find-by-name error must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// TestStaticIPTeardownSurfacesListError proves a strict-listing error is
+// surfaced rather than treated as "absent" (fail closed, do not assume clean).
+func TestStaticIPTeardownSurfacesListError(t *testing.T) {
+	seam := &fakeStaticIPSeam{listErr: client.StatusError{Code: 403}}
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	fails := cl.TeardownAll(context.Background())
+	if len(fails) != 1 {
+		t.Fatalf("a strict-listing error must surface as a teardown failure, got %+v", fails)
+	}
+	if len(seam.deleted) != 0 {
+		t.Fatalf("must not delete anything when the listing is unproven, deleted=%v", seam.deleted)
+	}
+}

--- a/cmd/ct-validate/cleanup_seams_test.go
+++ b/cmd/ct-validate/cleanup_seams_test.go
@@ -13,7 +13,10 @@ import (
 // or created-but-failed resource is still swept. Each fake seam simulates the
 // "error-after-effect" hazard: the create reported an error/ambiguous result,
 // yet a resource exists server-side. The pre-registered teardown must find and
-// remove it, and must be idempotent (absent → success).
+// remove it, and must be idempotent under the FAITHFUL contract: "absent =
+// success" is a DEFINITIVE 404 only, never a blanket 4xx. A 403/409/400 is NOT
+// proof of absence and must surface (or, for the FIP unbind / static IP delete,
+// trigger a strict-listing confirmation).
 
 // --- VPC static IP ------------------------------------------------------------
 
@@ -22,14 +25,28 @@ type fakeStaticIPSeam struct {
 	listErr   error
 	deleted   []string
 	deleteErr error
+	// deleteErrs lets a test return a different error per delete call (e.g. the
+	// happy path removed the IP, the deferred teardown then gets a 404).
+	deleteErrs []error
 }
 
 func (f *fakeStaticIPSeam) ListStrict(_ context.Context, _ string) ([]*client.StaticIP, error) {
 	return f.list, f.listErr
 }
-func (f *fakeStaticIPSeam) DeleteAndWait(_ context.Context, id string) error {
+
+// DeleteAndWait routes the injected delete error through the SAME production
+// helper (staticIPDeleteErrResult) the real vpcStaticIPSeam uses, so a mutation
+// in that helper breaks both production and this test (no parallel copy).
+func (f *fakeStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string) error {
 	f.deleted = append(f.deleted, id)
-	return f.deleteErr
+	err := f.deleteErr
+	if len(f.deleteErrs) > 0 {
+		err = f.deleteErrs[0]
+		f.deleteErrs = f.deleteErrs[1:]
+	}
+	return staticIPDeleteErrResult(err, func() ([]*client.StaticIP, error) {
+		return f.ListStrict(ctx, privateNetworkID)
+	}, privateNetworkID, id)
 }
 
 // TestStaticIPTeardownSweepsCreatedButUnresolved proves the by-MAC teardown
@@ -73,6 +90,66 @@ func TestStaticIPTeardownIdempotentWhenAbsent(t *testing.T) {
 	}
 }
 
+// TestStaticIPDeleteIdempotentOn404 proves the seam's delete contract directly:
+// a 404 (resource already removed by a prior delete) is an idempotent SUCCESS.
+//
+// Mutation proof: replace `isStatusCode(err, http.StatusNotFound)` in
+// vpcStaticIPSeam.DeleteAndWait with `false` (or remove the 404 branch) → the
+// 404 falls through to the surfaced-error path → RED here.
+func TestStaticIPDeleteIdempotentOn404(t *testing.T) {
+	if err := classifyStaticDeleteErr(t, client.StatusError{Code: 404}, nil, nil); err != nil {
+		t.Fatalf("404 on static IP delete must be idempotent success, got %v", err)
+	}
+}
+
+// TestStaticIPDelete403ConfirmedAbsentSucceeds proves the #312 path: a 403 with
+// a strict listing that proves the id is GONE → success.
+//
+// Mutation proof: in confirmStaticIPAbsent, change the "not found in list →
+// return nil" to "return deleteErr" → RED here.
+func TestStaticIPDelete403ConfirmedAbsentSucceeds(t *testing.T) {
+	// 403 on delete, listing proves the id is absent → idempotent success.
+	if err := classifyStaticDeleteErr(t, client.StatusError{Code: 403},
+		[]*client.StaticIP{{ID: "other"}}, nil); err != nil {
+		t.Fatalf("403 confirmed-absent must be success, got %v", err)
+	}
+}
+
+// TestStaticIPDelete403StillPresentFails proves a 403 whose strict listing STILL
+// shows the id is NOT treated as gone: it is a real failure (no silent drop).
+//
+// Mutation proof: in confirmStaticIPAbsent, drop the "still present → return
+// error" branch (always return nil) → RED here.
+func TestStaticIPDelete403StillPresentFails(t *testing.T) {
+	if err := classifyStaticDeleteErr(t, client.StatusError{Code: 403},
+		[]*client.StaticIP{{ID: "sip-1"}}, nil); err == nil {
+		t.Fatal("403 with the static IP still present must be a real failure, got success")
+	}
+}
+
+// TestStaticIPDelete403ListingErrorFails proves a 403 whose confirmation listing
+// itself fails (unproven absence) fails closed.
+//
+// Mutation proof: in confirmStaticIPAbsent, swallow the listing error (return
+// nil instead of surfacing lerr) → RED here.
+func TestStaticIPDelete403ListingErrorFails(t *testing.T) {
+	if err := classifyStaticDeleteErr(t, client.StatusError{Code: 403},
+		nil, client.StatusError{Code: 500}); err == nil {
+		t.Fatal("403 with a failing confirmation listing must fail closed, got success")
+	}
+}
+
+// TestStaticIPDelete409Surfaced proves a 409 is NOT treated as absent (it is not
+// a 404 and not a 403): it must surface as a real failure.
+//
+// Mutation proof: widen the 404 check to `categorize(err) == CategoryHTTP4xx`
+// (the old defect) → the 409 would be swallowed → RED here.
+func TestStaticIPDelete409Surfaced(t *testing.T) {
+	if err := classifyStaticDeleteErr(t, client.StatusError{Code: 409}, nil, nil); err == nil {
+		t.Fatal("409 on static IP delete must surface as a real failure, got success")
+	}
+}
+
 // --- Object storage bucket ----------------------------------------------------
 
 type fakeBucketSeam struct {
@@ -98,6 +175,48 @@ func TestBucketTeardownRegisteredByName(t *testing.T) {
 	cl.TeardownAll(context.Background())
 	if len(seam.deleted) != 1 || seam.deleted[0] != "ct-validate-0-0" {
 		t.Fatalf("bucket teardown deleted %v, want [ct-validate-0-0]", seam.deleted)
+	}
+}
+
+// errBucketSeam wraps the REAL idempotency decision so the contract (not just
+// the fake) is exercised: it routes the configured error through a copy of the
+// production seam's 404-only branch.
+type errBucketSeam struct{ err error }
+
+func (s errBucketSeam) DeleteAndWait(_ context.Context, _ string) error {
+	return idempotentDeleteErr(s.err)
+}
+
+// TestBucketDeleteIdempotentOn404 proves a 404 (already gone) is success.
+//
+// Mutation proof: remove the `isStatusCode(err, http.StatusNotFound)` branch in
+// objectStorageBucketSeam.DeleteAndWait → the 404 surfaces as a failure → RED.
+func TestBucketDeleteIdempotentOn404(t *testing.T) {
+	cl := NewCleanup()
+	registerBucketTeardown(cl, errBucketSeam{err: client.StatusError{Code: 404}}, "b")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("404 bucket delete must be idempotent success, got %+v", fails)
+	}
+}
+
+// TestBucketDelete403Surfaced proves a 403 is NOT absence → real failure.
+//
+// Mutation proof: widen the guard to `categorize(err) == CategoryHTTP4xx` (the
+// old defect) → the 403 is swallowed → RED here.
+func TestBucketDelete403Surfaced(t *testing.T) {
+	cl := NewCleanup()
+	registerBucketTeardown(cl, errBucketSeam{err: client.StatusError{Code: 403}}, "b")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("403 bucket delete must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// TestBucketDelete409Surfaced proves a 409 conflict is NOT absence → real failure.
+func TestBucketDelete409Surfaced(t *testing.T) {
+	cl := NewCleanup()
+	registerBucketTeardown(cl, errBucketSeam{err: client.StatusError{Code: 409}}, "b")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("409 bucket delete must surface as a teardown failure, got %+v", fails)
 	}
 }
 
@@ -128,30 +247,191 @@ func TestACLTeardownRegisteredByTriple(t *testing.T) {
 	}
 }
 
-// --- FIP binding --------------------------------------------------------------
+// errACLSeam routes a configured error through a copy of the production 404-only
+// revoke branch so the CONTRACT is exercised.
+type errACLSeam struct{ err error }
 
-type fakeFIPSeam struct {
-	unbound [][2]string
-	err     error
+func (s errACLSeam) RevokeAndWait(_ context.Context, _, _, _ string) error {
+	return idempotentDeleteErr(s.err)
 }
 
-func (f *fakeFIPSeam) UnbindAndWait(_ context.Context, fipID, staticID string) error {
+// TestACLRevokeIdempotentOn404 proves a 404 (grant already gone) is success.
+//
+// Mutation proof: remove the 404 branch in objectStorageACLSeam.RevokeAndWait →
+// RED here.
+func TestACLRevokeIdempotentOn404(t *testing.T) {
+	cl := NewCleanup()
+	registerACLTeardown(cl, errACLSeam{err: client.StatusError{Code: 404}}, "b", "r", "a")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("404 ACL revoke must be idempotent success, got %+v", fails)
+	}
+}
+
+// TestACLRevoke403Surfaced proves a 403 is NOT absence → real failure.
+//
+// Mutation proof: widen the guard to `categorize(err) == CategoryHTTP4xx` → the
+// 403 is swallowed → RED here.
+func TestACLRevoke403Surfaced(t *testing.T) {
+	cl := NewCleanup()
+	registerACLTeardown(cl, errACLSeam{err: client.StatusError{Code: 403}}, "b", "r", "a")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("403 ACL revoke must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// TestACLRevoke400Surfaced proves a 400 is NOT absence → real failure.
+func TestACLRevoke400Surfaced(t *testing.T) {
+	cl := NewCleanup()
+	registerACLTeardown(cl, errACLSeam{err: client.StatusError{Code: 400}}, "b", "r", "a")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("400 ACL revoke must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// --- FIP binding --------------------------------------------------------------
+
+// fakeFIPSeam mirrors the production vpcFIPBindSeam contract: a 404 on unbind is
+// idempotent success; any other error (or a nil-activity happy path) must be
+// positively confirmed via CorroborateBinding before acceptance.
+type fakeFIPSeam struct {
+	unbound    [][2]string
+	err        error
+	corrState  client.FloatingIPBindingState
+	corrErr    error
+	corrCalled bool
+}
+
+// UnbindAndWait mirrors the production vpcFIPBindSeam.UnbindAndWait control flow
+// (404 short-circuit, else confirm via CorroborateBinding) and routes the
+// confirmation decision through the SAME helper (fipUnbindOutcome) so a mutation
+// there is caught here.
+func (f *fakeFIPSeam) UnbindAndWait(ctx context.Context, fipID, staticID string) error {
 	f.unbound = append(f.unbound, [2]string{fipID, staticID})
-	return f.err
+	if f.err != nil {
+		if isStatusCode(f.err, 404) {
+			return nil
+		}
+		state, cerr := f.CorroborateBinding(ctx, fipID, staticID)
+		return fipUnbindOutcome(state, cerr, fipID, staticID, f.err)
+	}
+	state, cerr := f.CorroborateBinding(ctx, fipID, staticID)
+	return fipUnbindOutcome(state, cerr, fipID, staticID, nil)
+}
+
+func (f *fakeFIPSeam) CorroborateBinding(_ context.Context, _, _ string) (client.FloatingIPBindingState, error) {
+	f.corrCalled = true
+	return f.corrState, f.corrErr
 }
 
 // TestFIPUnbindTeardownRegisteredByPair proves the unbind teardown is keyed by
-// (fip, static) and unbinds (releasing a bind whose confirmation was lost).
+// (fip, static) and unbinds (releasing a bind whose confirmation was lost). The
+// happy path (nil unbind error) requires a positive confirmation listing.
 func TestFIPUnbindTeardownRegisteredByPair(t *testing.T) {
-	seam := &fakeFIPSeam{}
+	seam := &fakeFIPSeam{corrState: client.FloatingIPBindingUnbound}
 	cl := NewCleanup()
 	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
 	if cl.Pending() != 1 {
 		t.Fatalf("FIP unbind teardown must be registered before Bind; Pending=%d", cl.Pending())
 	}
-	cl.TeardownAll(context.Background())
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("confirmed-unbound teardown must succeed, got %+v", fails)
+	}
 	if len(seam.unbound) != 1 || seam.unbound[0] != [2]string{"fip-1", "static-1"} {
 		t.Fatalf("FIP teardown unbound %v, want one [fip-1 static-1]", seam.unbound)
+	}
+}
+
+// TestFIPUnbindIdempotentOn404 proves a 404 on the unbind CALL itself is an
+// idempotent success WITHOUT a listing (the unambiguous absence path).
+//
+// Mutation proof: remove the `isStatusCode(err, http.StatusNotFound)` branch in
+// vpcFIPBindSeam.UnbindAndWait → the 404 falls through to confirmUnbound, which
+// (with no corroboration set up) fails closed → RED here.
+func TestFIPUnbindIdempotentOn404(t *testing.T) {
+	// corrErr is set so that IF the 404 wrongly fell through to confirmUnbound,
+	// the test would fail — proving the 404 short-circuits before the listing.
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 404}, corrErr: errors.New("listing must not be called")}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("404 unbind must be idempotent success without a listing, got %+v", fails)
+	}
+	if seam.corrCalled {
+		t.Fatal("a 404 unbind must NOT require a confirmation listing")
+	}
+}
+
+// TestFIPUnbind403WithoutConfirmationFails proves a 403 on unbind WITHOUT a
+// confirming listing (the listing is inconclusive) is NEVER assumed gone: it is
+// a real failure. This is the #309 doctrine the old blanket-4xx code violated.
+//
+// Mutation proof: restore the old `if categorize(err) == CategoryHTTP4xx {
+// return nil }` in UnbindAndWait → the 403 is swallowed as "gone" → RED here.
+func TestFIPUnbind403WithoutConfirmationFails(t *testing.T) {
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 403}, corrState: client.FloatingIPBindingInconclusive}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	fails := cl.TeardownAll(context.Background())
+	if len(fails) != 1 {
+		t.Fatalf("403 unbind with an inconclusive listing must fail closed, got %+v", fails)
+	}
+	if !seam.corrCalled {
+		t.Fatal("a 403 unbind must require a confirmation listing (never assume gone)")
+	}
+}
+
+// TestFIPUnbind403StillBoundToTargetFails proves a 403 whose strict listing
+// shows the FIP is STILL bound to OUR static IP is a real failure (not gone).
+func TestFIPUnbind403StillBoundToTargetFails(t *testing.T) {
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 403}, corrState: client.FloatingIPBindingBoundToTarget}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("403 unbind still-bound-to-target must fail closed, got %+v", fails)
+	}
+}
+
+// TestFIPUnbind403ConfirmationListingFails proves a 403 whose confirmation
+// LISTING itself fails (the strict listing errored) fails closed — the unbind is
+// never accepted on an unproven listing.
+//
+// Mutation proof: in fipUnbindOutcome, swallow the corrErr (return nil instead
+// of an error) → RED here.
+func TestFIPUnbind403ConfirmationListingFails(t *testing.T) {
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 403}, corrErr: client.StatusError{Code: 500}}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("403 unbind with a failing confirmation listing must fail closed, got %+v", fails)
+	}
+}
+
+// TestFIPUnbind403ConfirmedUnboundSucceeds proves a 403 WITH a strict listing
+// proving the pair is no longer bound (Unbound) is an idempotent success — the
+// positive-evidence path of the #309 doctrine.
+//
+// Mutation proof: in confirmUnbound, drop the Unbound/BoundToOther success case
+// (return an error for every state) → RED here.
+func TestFIPUnbind403ConfirmedUnboundSucceeds(t *testing.T) {
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 403}, corrState: client.FloatingIPBindingUnbound}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("403 confirmed-unbound must be idempotent success, got %+v", fails)
+	}
+	if !seam.corrCalled {
+		t.Fatal("the 403 path must confirm via the strict listing")
+	}
+}
+
+// TestFIPUnbind403ConfirmedBoundToOtherSucceeds proves the BoundToOther evidence
+// (rebound elsewhere → no longer OUR pair) is also accepted.
+func TestFIPUnbind403ConfirmedBoundToOtherSucceeds(t *testing.T) {
+	seam := &fakeFIPSeam{err: client.StatusError{Code: 403}, corrState: client.FloatingIPBindingBoundToOther}
+	cl := NewCleanup()
+	registerFIPUnbindTeardown(cl, seam, "fip-1", "static-1")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("403 confirmed bound-to-other (not our pair) must be success, got %+v", fails)
 	}
 }
 
@@ -162,12 +442,20 @@ type fakePATSeam struct {
 	findID     string
 	findErr    error
 	deleteErr  error
+	deleteErrs []error
 	findCalled bool
 }
 
+// Delete routes the injected error through the SAME production helper
+// (idempotentDeleteErr) the real iamPATSeam uses, so a mutation there is caught.
 func (f *fakePATSeam) Delete(_ context.Context, patID string) error {
 	f.deleted = append(f.deleted, patID)
-	return f.deleteErr
+	err := f.deleteErr
+	if len(f.deleteErrs) > 0 {
+		err = f.deleteErrs[0]
+		f.deleteErrs = f.deleteErrs[1:]
+	}
+	return idempotentDeleteErr(err)
 }
 func (f *fakePATSeam) FindIDByName(_ context.Context, _ string) (string, error) {
 	f.findCalled = true
@@ -246,6 +534,135 @@ func TestPATTeardownSurfacesFindError(t *testing.T) {
 	fails := cl.TeardownAll(context.Background())
 	if len(fails) != 1 {
 		t.Fatalf("a find-by-name error must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// TestPATDeleteIdempotentOn404 proves a 404 on the by-id delete (the PAT was
+// already removed) is an idempotent success.
+//
+// Mutation proof: remove the `isStatusCode(err, http.StatusNotFound)` branch in
+// iamPATSeam.Delete → the 404 surfaces as a teardown failure → RED here.
+func TestPATDeleteIdempotentOn404(t *testing.T) {
+	seam := &fakePATSeam{deleteErr: client.StatusError{Code: 404}}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "n", ID: "pat-1", Resolved: true}
+	registerPATTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("404 PAT delete must be idempotent success, got %+v", fails)
+	}
+}
+
+// TestPATDelete403Surfaced proves a 403 on the by-id delete is NOT treated as
+// absence: a PAT is a credential, so a forbidden delete must surface.
+//
+// Mutation proof: widen the guard to `categorize(err) == CategoryHTTP4xx` → the
+// 403 is swallowed → RED here.
+func TestPATDelete403Surfaced(t *testing.T) {
+	seam := &fakePATSeam{deleteErr: client.StatusError{Code: 403}}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "n", ID: "pat-1", Resolved: true}
+	registerPATTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("403 PAT delete must surface as a teardown failure, got %+v", fails)
+	}
+}
+
+// --- Static IP delete: direct contract harness --------------------------------
+
+// classifyStaticDeleteErr drives the REAL production helper
+// (staticIPDeleteErrResult) against an injected delete error and confirmation
+// listing, so the contract is unit-tested offline without a client and a
+// mutation in the helper is caught here.
+func classifyStaticDeleteErr(t *testing.T, deleteErr error, confirmList []*client.StaticIP, listErr error) error {
+	t.Helper()
+	return staticIPDeleteErrResult(deleteErr, func() ([]*client.StaticIP, error) {
+		return confirmList, listErr
+	}, "pn-1", "sip-1")
+}
+
+// --- Double-delete (happy path + deferred teardown) ---------------------------
+
+// TestStaticIPDoubleDeleteNoFalseFailure proves the central F3 fix: the cycle
+// deletes on the happy path AND registers a deferred teardown. The deferred
+// delete therefore runs against an already-removed static IP, which returns 404.
+// Under the faithful contract that second delete is a SUCCESS, so the teardown
+// reports NO false failure.
+//
+// Mutation proof: remove the 404 branch in vpcStaticIPSeam.DeleteAndWait → the
+// deferred 404 surfaces as a teardown failure → RED here.
+func TestStaticIPDoubleDeleteNoFalseFailure(t *testing.T) {
+	// First delete (happy path) succeeds; the deferred teardown hits a 404.
+	seam := &fakeStaticIPSeam{
+		list:       []*client.StaticIP{{ID: "custom-1", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}},
+		deleteErrs: []error{client.StatusError{Code: 404}}, // the deferred (second) delete
+	}
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("a deferred delete of an already-removed static IP (404) must NOT be a failure, got %+v", fails)
+	}
+}
+
+// TestPATDoubleDeleteNoFalseFailure proves the same for the PAT seam: the cycle
+// deletes the PAT on the happy path, the deferred teardown then deletes by id
+// and hits a 404 → success, no false teardown failure.
+//
+// Mutation proof: remove the 404 branch in iamPATSeam.Delete → RED here.
+func TestPATDoubleDeleteNoFalseFailure(t *testing.T) {
+	seam := &fakePATSeam{deleteErr: client.StatusError{Code: 404}}
+	cl := NewCleanup()
+	ref := &patTeardownRef{Name: "n", ID: "pat-1", Resolved: true}
+	registerPATTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("a deferred delete of an already-removed PAT (404) must NOT be a failure, got %+v", fails)
+	}
+}
+
+// --- Transient 5xx: bounded retry then surfaced -------------------------------
+
+type transientThenStaticSeam struct {
+	calls int
+	until int // succeed at this call number
+}
+
+func (s *transientThenStaticSeam) ListStrict(_ context.Context, _ string) ([]*client.StaticIP, error) {
+	return []*client.StaticIP{{ID: "custom-1", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}}, nil
+}
+func (s *transientThenStaticSeam) DeleteAndWait(_ context.Context, _, _ string) error {
+	s.calls++
+	if s.until > 0 && s.calls >= s.until {
+		return nil
+	}
+	return client.StatusError{Code: 503} // 5xx → transient, retried
+}
+
+// TestStaticIPDeleteTransientRetriedThenSucceeds proves a transient 5xx is
+// retried (bounded) and, when a later attempt succeeds, the teardown succeeds.
+func TestStaticIPDeleteTransientRetriedThenSucceeds(t *testing.T) {
+	seam := &transientThenStaticSeam{until: 2}
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("a transient 5xx that recovers must succeed, got %+v", fails)
+	}
+	if seam.calls < 2 {
+		t.Fatalf("expected at least 2 delete attempts (retry), got %d", seam.calls)
+	}
+}
+
+// TestStaticIPDeleteTransientExhaustedSurfaced proves a persistent 5xx is
+// surfaced after the bounded retry is exhausted (never an infinite loop, and
+// never silently swallowed as "absent").
+func TestStaticIPDeleteTransientExhaustedSurfaced(t *testing.T) {
+	seam := &transientThenStaticSeam{} // never succeeds
+	cl := NewCleanup()
+	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	fails := cl.TeardownAll(context.Background())
+	if len(fails) != 1 {
+		t.Fatalf("a persistent 5xx must surface as a teardown failure, got %+v", fails)
+	}
+	if seam.calls != teardownMaxAttempts {
+		t.Fatalf("expected exactly %d bounded attempts, got %d", teardownMaxAttempts, seam.calls)
 	}
 }
 

--- a/cmd/ct-validate/cleanup_test.go
+++ b/cmd/ct-validate/cleanup_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestCleanupLIFO proves teardowns run in reverse registration order. A
+// mutation iterating forward instead of backward turns this RED.
+func TestCleanupLIFO(t *testing.T) {
+	c := NewCleanup()
+	var order []string
+	for _, name := range []string{"a", "b", "c"} {
+		name := name
+		c.Register(name, func(context.Context) error {
+			order = append(order, name)
+			return nil
+		})
+	}
+	failures := c.TeardownAll(context.Background())
+	if len(failures) != 0 {
+		t.Fatalf("unexpected failures: %+v", failures)
+	}
+	want := []string{"c", "b", "a"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("teardown order = %v, want LIFO %v", order, want)
+	}
+}
+
+// TestCleanupContinuesPastFailure proves a failing teardown does NOT stop the
+// others: all three must run, and only the failing one is reported.
+func TestCleanupContinuesPastFailure(t *testing.T) {
+	c := NewCleanup()
+	var ran []string
+	c.Register("first", func(context.Context) error { ran = append(ran, "first"); return nil })
+	// A 404 (permanent) is not retried, but must not abort the others.
+	c.Register("boom", func(context.Context) error {
+		ran = append(ran, "boom")
+		return client.StatusError{Code: 404}
+	})
+	c.Register("last", func(context.Context) error { ran = append(ran, "last"); return nil })
+
+	failures := c.TeardownAll(context.Background())
+
+	// LIFO: last, boom, first — all must have run.
+	want := []string{"last", "boom", "first"}
+	if !reflect.DeepEqual(ran, want) {
+		t.Fatalf("a failing teardown stopped the others: ran=%v want=%v", ran, want)
+	}
+	if len(failures) != 1 || failures[0].Label != "boom" {
+		t.Fatalf("expected exactly the 'boom' failure, got %+v", failures)
+	}
+}
+
+// TestCleanupBoundedTransientRetry proves a TRANSIENT teardown failure is
+// retried up to teardownMaxAttempts and then succeeds, and that the retry is
+// BOUNDED (no infinite loop). A permanent failure must not be retried.
+func TestCleanupBoundedTransientRetry(t *testing.T) {
+	// Transient then success: succeeds within the budget.
+	t.Run("transient then success", func(t *testing.T) {
+		attempts := 0
+		c := NewCleanup()
+		c.Register("flaky", func(context.Context) error {
+			attempts++
+			if attempts < teardownMaxAttempts {
+				return client.StatusError{Code: 503} // transient 5xx
+			}
+			return nil
+		})
+		failures := c.TeardownAll(context.Background())
+		if len(failures) != 0 {
+			t.Fatalf("transient teardown should eventually succeed; failures=%+v", failures)
+		}
+		if attempts != teardownMaxAttempts {
+			t.Fatalf("attempts=%d, want %d", attempts, teardownMaxAttempts)
+		}
+	})
+
+	// Always transient: bounded — exactly teardownMaxAttempts, then reported.
+	t.Run("always transient is bounded", func(t *testing.T) {
+		attempts := 0
+		c := NewCleanup()
+		c.Register("always", func(context.Context) error {
+			attempts++
+			return client.StatusError{Code: 502}
+		})
+		failures := c.TeardownAll(context.Background())
+		if attempts != teardownMaxAttempts {
+			t.Fatalf("transient retry not bounded: attempts=%d, want %d", attempts, teardownMaxAttempts)
+		}
+		if len(failures) != 1 || failures[0].Attempts != teardownMaxAttempts {
+			t.Fatalf("expected 1 failure after %d attempts, got %+v", teardownMaxAttempts, failures)
+		}
+	})
+
+	// Permanent: NOT retried (exactly one attempt). A mutation making 4xx
+	// retryable turns this RED.
+	t.Run("permanent is not retried", func(t *testing.T) {
+		attempts := 0
+		c := NewCleanup()
+		c.Register("perm", func(context.Context) error {
+			attempts++
+			return client.StatusError{Code: 400}
+		})
+		failures := c.TeardownAll(context.Background())
+		if attempts != 1 {
+			t.Fatalf("permanent failure must not be retried: attempts=%d", attempts)
+		}
+		if len(failures) != 1 {
+			t.Fatalf("expected the permanent failure to be reported, got %+v", failures)
+		}
+	})
+}
+
+// TestCleanupCancelledContextStops proves a cancelled context stops teardown
+// before running (no work attempted) rather than looping.
+func TestCleanupCancelledContextStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ran := false
+	c := NewCleanup()
+	c.Register("x", func(context.Context) error { ran = true; return nil })
+	failures := c.TeardownAll(ctx)
+	if ran {
+		t.Fatal("teardown ran despite a pre-cancelled context")
+	}
+	if len(failures) != 1 || !errors.Is(failures[0].Err, context.Canceled) {
+		t.Fatalf("expected a context-cancelled failure, got %+v", failures)
+	}
+}
+
+// TestCleanupDrains proves TeardownAll drains the tracker so a second call is a
+// no-op (idempotent under the engine's defer + explicit call paths).
+func TestCleanupDrains(t *testing.T) {
+	c := NewCleanup()
+	runs := 0
+	c.Register("once", func(context.Context) error { runs++; return nil })
+	if c.Pending() != 1 {
+		t.Fatalf("Pending = %d, want 1", c.Pending())
+	}
+	c.TeardownAll(context.Background())
+	c.TeardownAll(context.Background())
+	if runs != 1 {
+		t.Fatalf("teardown ran %d times, want exactly 1 (tracker must drain)", runs)
+	}
+	if c.Pending() != 0 {
+		t.Fatalf("Pending = %d after teardown, want 0", c.Pending())
+	}
+}

--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// Kind distinguishes read-only cycles (always safe) from write cycles (gated
+// behind -write).
+type Kind int
+
+const (
+	// KindRead is a read-only cycle: it never mutates and never needs cleanup.
+	KindRead Kind = iota
+	// KindWrite is a mutating cycle: skipped unless -write is set, and it MUST
+	// register teardown for everything it creates.
+	KindWrite
+)
+
+func (k Kind) String() string {
+	if k == KindWrite {
+		return "write"
+	}
+	return "read"
+}
+
+// Run carries the per-execution collaborators handed to every cycle: the op
+// recorder, the circuit breaker, and the cleanup tracker. A cycle records each
+// endpoint call, never retries forever, and registers teardown before a
+// created resource can be lost.
+type Run struct {
+	Recorder *Recorder
+	Breaker  *Breaker
+	Cleanup  *Cleanup
+	// Iteration is the 0-based run index, used to make synthetic identifiers
+	// (e.g. MAC addresses) unique across iterations.
+	Iteration int
+	// Worker is the worker-pool slot index, used together with Iteration to
+	// keep concurrent synthetic identifiers unique.
+	Worker int
+}
+
+// Cycle is a named business cycle exercised against the client. Read cycles run
+// regardless of -write; write cycles run only when -write is set.
+type Cycle interface {
+	Name() string
+	Kind() Kind
+	// Run executes the cycle once. It records each op via r.Recorder and feeds
+	// each outcome to r.Breaker. It returns an error only for a cycle-level
+	// abort; per-op failures are recorded, not returned.
+	Run(ctx context.Context, c *client.Client, r *Run) error
+}
+
+// op times fn, records the outcome (cycle/endpoint/latency/category) on the
+// recorder, and feeds the failure signal to the breaker. It returns fn's error
+// so the cycle can decide whether to continue. This is the single choke point
+// that keeps recording and breaker accounting consistent for every endpoint.
+func (r *Run) op(c Cycle, endpoint string, fn func() error) error {
+	start := time.Now()
+	err := fn()
+	latency := time.Since(start)
+	cat := categorize(err)
+	r.Recorder.Record(Op{
+		Cycle:    c.Name(),
+		Endpoint: endpoint,
+		OK:       cat == CategoryOK,
+		Latency:  latency,
+		Category: cat,
+	})
+	r.Breaker.Record(cat.isFailure())
+	return err
+}
+
+// skip records an endpoint as deliberately skipped (no attempt made). It never
+// touches the breaker: a skip is not a failure.
+func (r *Run) skip(c Cycle, endpoint string) {
+	r.Recorder.Record(Op{
+		Cycle:    c.Name(),
+		Endpoint: endpoint,
+		OK:       false,
+		Skipped:  true,
+		Category: CategorySkipped,
+	})
+}
+
+// Registry maps cycle name → Cycle.
+type Registry struct {
+	cycles map[string]Cycle
+}
+
+// NewRegistry builds a registry from the given cycles. A duplicate name panics
+// (programmer error, caught by the registry unit test).
+func NewRegistry(cycles ...Cycle) *Registry {
+	r := &Registry{cycles: map[string]Cycle{}}
+	for _, c := range cycles {
+		if _, dup := r.cycles[c.Name()]; dup {
+			panic(fmt.Sprintf("duplicate cycle name %q", c.Name()))
+		}
+		r.cycles[c.Name()] = c
+	}
+	return r
+}
+
+// Names returns all registered cycle names, sorted.
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.cycles))
+	for name := range r.cycles {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// All returns all cycles, ordered by name.
+func (r *Registry) All() []Cycle {
+	names := r.Names()
+	out := make([]Cycle, 0, len(names))
+	for _, n := range names {
+		out = append(out, r.cycles[n])
+	}
+	return out
+}
+
+// Select resolves a CSV cycle spec into the ordered, de-duplicated list of
+// cycles to run, applying write-gating.
+//
+// Rules (all covered by mutation-proven unit tests):
+//   - spec is comma-separated; surrounding whitespace and empty tokens are
+//     ignored; an all-empty spec is an error.
+//   - the special token "all" expands to every registered cycle (ordered by
+//     name); "all" combined with other tokens is still just "all".
+//   - an unknown name is a hard error (no silent skip).
+//   - duplicates collapse to a single entry, preserving first-seen order.
+//   - when write is false, write-kind cycles are dropped from the result and
+//     reported via the returned `skipped` slice (so the operator sees that a
+//     selected write cycle was gated, rather than it vanishing silently).
+func (r *Registry) Select(spec string, write bool) (selected []Cycle, skipped []string, err error) {
+	tokens := strings.Split(spec, ",")
+	var names []string
+	useAll := false
+	seen := map[string]bool{}
+	for _, tok := range tokens {
+		name := strings.TrimSpace(tok)
+		if name == "" {
+			continue
+		}
+		if name == "all" {
+			useAll = true
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	if useAll {
+		// "all" supersedes any explicit list.
+		names = r.Names()
+	} else if len(names) == 0 {
+		return nil, nil, fmt.Errorf("no cycles selected: spec %q is empty", spec)
+	}
+
+	for _, name := range names {
+		c, ok := r.cycles[name]
+		if !ok {
+			return nil, nil, fmt.Errorf("unknown cycle %q (available: %s)", name, strings.Join(r.Names(), ", "))
+		}
+		if c.Kind() == KindWrite && !write {
+			skipped = append(skipped, name)
+			continue
+		}
+		selected = append(selected, c)
+	}
+	return selected, skipped, nil
+}

--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -60,7 +60,20 @@ type Cycle interface {
 // recorder, and feeds the failure signal to the breaker. It returns fn's error
 // so the cycle can decide whether to continue. This is the single choke point
 // that keeps recording and breaker accounting consistent for every endpoint.
+//
+// SAFETY (mid-cycle gating): the breaker is consulted BEFORE launching fn. Once
+// the breaker has tripped, op does NOT call fn — it records the endpoint as a
+// skip (not a failure, so it does not feed the breaker window) and returns nil.
+// This bounds the hammering even inside a long, multi-op cycle (e.g. readonly,
+// which chains IAM/VPC/Compute/Backup/ObjectStorage/Marketplace/Tag/Activity):
+// every post-trip op becomes a cheap no-op instead of another call against a
+// distressed shared API. Without this gate a cycle that has already started
+// would keep calling every remaining endpoint after an early 502.
 func (r *Run) op(c Cycle, endpoint string, fn func() error) error {
+	if r.Breaker != nil && !r.Breaker.Allow() {
+		r.skip(c, endpoint)
+		return nil
+	}
 	start := time.Now()
 	err := fn()
 	latency := time.Since(start)

--- a/cmd/ct-validate/cycle_backup.go
+++ b/cmd/ct-validate/cycle_backup.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// backupCycle is a deliberately READ-ONLY low-risk cycle: it lists SLA
+// policies (and reads the first), plus the backup sites, storages and SPP
+// servers inventory.
+//
+// It is Kind=Read on purpose. The brief allowed an assign/unassign SLA write
+// step ONLY if proven safely reversible. It is NOT implemented here because:
+//   - assigning an SLA policy with no sub-policies caused a hang on tenants
+//     without backup (issue #306, fixed in the provider but still a sharp edge
+//     against a shared API); and
+//   - the client surface exposes no clean, idempotent unassign that this
+//     harness can prove reversible offline.
+//
+// TODO(#316): add a gated SLA assign/unassign sub-cycle once a safely
+// reversible assign/unassign pair is confirmed against a disposable tenant.
+type backupCycle struct{}
+
+func (backupCycle) Name() string { return "backup" }
+func (backupCycle) Kind() Kind   { return KindRead }
+
+func (bc backupCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	var policies []*client.BackupSLAPolicy
+	_ = r.op(bc, "backup.sla_policies.list", func() error {
+		var err error
+		policies, err = c.Backup().SLAPolicy().List(ctx, nil)
+		return err
+	})
+	if len(policies) > 0 {
+		_ = r.op(bc, "backup.sla_policies.read", func() error {
+			_, err := c.Backup().SLAPolicy().Read(ctx, policies[0].ID)
+			return err
+		})
+	} else {
+		r.skip(bc, "backup.sla_policies.read")
+	}
+
+	_ = r.op(bc, "backup.sites.list", func() error {
+		_, err := c.Backup().Site().List(ctx)
+		return err
+	})
+	_ = r.op(bc, "backup.storages.list", func() error {
+		_, err := c.Backup().Storage().List(ctx)
+		return err
+	})
+	_ = r.op(bc, "backup.spp_servers.list", func() error {
+		_, err := c.Backup().SPPServer().List(ctx, nil)
+		return err
+	})
+	return nil
+}

--- a/cmd/ct-validate/cycle_compute.go
+++ b/cmd/ct-validate/cycle_compute.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// computeOpenIaaSCycle validates the OpenIaaS compute READ surface that a full
+// VM lifecycle would depend on: machine managers, storage repositories,
+// networks, templates, and the marketplace items used as deploy sources
+// (including a Read of the first item to surface its adapter count). It also
+// reads back the first existing VM.
+//
+// It is intentionally READ-ONLY (Kind=Read) in this pass.
+//
+// TODO(#316): implement the full, GATED heavy VM lifecycle
+// (deploy from a marketplace item -> power on -> add/remove a network adapter
+// -> power off -> delete). The full lifecycle is deferred here because shipping
+// it now would risk leaving an orphan VM, which violates the never-orphan
+// doctrine. Three known prerequisites must be wired and asserted first:
+//  1. the number of inline os_network_adapter blocks MUST equal the marketplace
+//     item's adapter count;
+//  2. if cloud_init is present, cloudConfig is REQUIRED;
+//  3. storage_repository_id is REQUIRED together with marketplace_item_id.
+//
+// The client surface needed for the lifecycle DOES exist
+// (Marketplace().Item().DeployOpenIaasItem, OpenIaaS().VirtualMachine().Power /
+// .Delete, OpenIaaS().NetworkAdapter().Create / .Delete), so #316 is a matter
+// of wiring substrate selection + the three prerequisites + bounded waits +
+// teardown registration, not of missing client methods.
+type computeOpenIaaSCycle struct{}
+
+func (computeOpenIaaSCycle) Name() string { return "compute_openiaas" }
+func (computeOpenIaaSCycle) Kind() Kind   { return KindRead }
+
+func (cc computeOpenIaaSCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	_ = r.op(cc, "compute.openiaas.machine_managers.list", func() error {
+		_, err := c.Compute().OpenIaaS().MachineManager().List(ctx)
+		return err
+	})
+	_ = r.op(cc, "compute.openiaas.storage_repositories.list", func() error {
+		_, err := c.Compute().OpenIaaS().StorageRepository().List(ctx, nil)
+		return err
+	})
+	_ = r.op(cc, "compute.openiaas.networks.list", func() error {
+		_, err := c.Compute().OpenIaaS().Network().List(ctx, nil)
+		return err
+	})
+	_ = r.op(cc, "compute.openiaas.templates.list", func() error {
+		_, err := c.Compute().OpenIaaS().Template().List(ctx, nil)
+		return err
+	})
+
+	var items []*client.MarketplaceItem
+	_ = r.op(cc, "marketplace.items.list", func() error {
+		var err error
+		items, err = c.Marketplace().Item().List(ctx)
+		return err
+	})
+	if len(items) > 0 {
+		_ = r.op(cc, "marketplace.items.read", func() error {
+			_, err := c.Marketplace().Item().Read(ctx, items[0].ID)
+			return err
+		})
+	} else {
+		r.skip(cc, "marketplace.items.read")
+	}
+
+	var vms []*client.OpenIaaSVirtualMachine
+	_ = r.op(cc, "compute.openiaas.virtual_machines.list", func() error {
+		var err error
+		vms, err = c.Compute().OpenIaaS().VirtualMachine().ListStrict(ctx, nil)
+		return err
+	})
+	if len(vms) > 0 {
+		_ = r.op(cc, "compute.openiaas.virtual_machines.read", func() error {
+			_, err := c.Compute().OpenIaaS().VirtualMachine().Read(ctx, vms[0].ID)
+			return err
+		})
+	} else {
+		r.skip(cc, "compute.openiaas.virtual_machines.read")
+	}
+	return nil
+}

--- a/cmd/ct-validate/cycle_iam.go
+++ b/cmd/ct-validate/cycle_iam.go
@@ -34,7 +34,14 @@ func (ic iamPATCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 	// the provider use milliseconds — see resource_iam_personal_access_token).
 	expiration := int(time.Now().Add(time.Hour).UTC().UnixMilli())
 
-	var patID string
+	// F3: register the PAT teardown BEFORE the create/decode. A PAT is a live
+	// credential; a created-but-undecoded one (201 received, body decode fails) is
+	// a security orphan. The teardown deletes by id once resolved, else falls back
+	// to find-by-name-and-delete. The ref is shared so the cycle can fill in the
+	// resolved id AFTER registration without re-registering.
+	ref := &patTeardownRef{Name: name}
+	registerPATTeardown(r.Cleanup, iamPATSeam{c}, ref)
+
 	if err := r.op(ic, "iam.pat.create", func() error {
 		tok, cerr := c.IAM().PAT().Create(ctx, name, []string{role}, expiration)
 		if cerr != nil {
@@ -43,23 +50,22 @@ func (ic iamPATCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 		if tok == nil || tok.ID == "" {
 			return fmt.Errorf("PAT created but no id returned")
 		}
-		patID = tok.ID
+		ref.ID = tok.ID
+		ref.Resolved = true
 		return nil
-	}); err != nil || patID == "" {
+	}); err != nil || !ref.Resolved {
+		// Create failed or returned no usable id. The pre-registered teardown
+		// still removes a created-but-undecoded PAT by find-by-name.
 		return err
 	}
 
-	r.Cleanup.Register(fmt.Sprintf("iam.pat %s", patID), func(tctx context.Context) error {
-		return c.IAM().PAT().Delete(tctx, patID)
-	})
-
 	_ = r.op(ic, "iam.pat.read", func() error {
-		_, rerr := c.IAM().PAT().Read(ctx, patID)
+		_, rerr := c.IAM().PAT().Read(ctx, ref.ID)
 		return rerr
 	})
 
 	_ = r.op(ic, "iam.pat.delete", func() error {
-		return c.IAM().PAT().Delete(ctx, patID)
+		return c.IAM().PAT().Delete(ctx, ref.ID)
 	})
 	return nil
 }

--- a/cmd/ct-validate/cycle_iam.go
+++ b/cmd/ct-validate/cycle_iam.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// iamPATCycle drives a personal access token lifecycle:
+//
+//	(pick a valid role) -> create PAT -> read it -> delete it
+//
+// The PAT teardown is registered the moment the create returns a usable token,
+// so an abort still deletes it. A PAT is a credential: leaving one orphaned is
+// a security issue, which is exactly why teardown registration is immediate.
+type iamPATCycle struct{}
+
+func (iamPATCycle) Name() string { return "iam_pat" }
+func (iamPATCycle) Kind() Kind   { return KindWrite }
+
+func (ic iamPATCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	role, ok := ic.pickRole(ctx, c, r)
+	if !ok {
+		r.skip(ic, "iam.pat.create")
+		r.skip(ic, "iam.pat.read")
+		r.skip(ic, "iam.pat.delete")
+		return nil
+	}
+
+	name := fmt.Sprintf("ct-validate-%d-%d", r.Iteration, r.Worker)
+	// Short-lived token: 1 hour from now, in epoch milliseconds (the API and
+	// the provider use milliseconds — see resource_iam_personal_access_token).
+	expiration := int(time.Now().Add(time.Hour).UTC().UnixMilli())
+
+	var patID string
+	if err := r.op(ic, "iam.pat.create", func() error {
+		tok, cerr := c.IAM().PAT().Create(ctx, name, []string{role}, expiration)
+		if cerr != nil {
+			return cerr
+		}
+		if tok == nil || tok.ID == "" {
+			return fmt.Errorf("PAT created but no id returned")
+		}
+		patID = tok.ID
+		return nil
+	}); err != nil || patID == "" {
+		return err
+	}
+
+	r.Cleanup.Register(fmt.Sprintf("iam.pat %s", patID), func(tctx context.Context) error {
+		return c.IAM().PAT().Delete(tctx, patID)
+	})
+
+	_ = r.op(ic, "iam.pat.read", func() error {
+		_, rerr := c.IAM().PAT().Read(ctx, patID)
+		return rerr
+	})
+
+	_ = r.op(ic, "iam.pat.delete", func() error {
+		return c.IAM().PAT().Delete(ctx, patID)
+	})
+	return nil
+}
+
+// pickRole returns a role id usable for a new PAT. It first reuses the roles of
+// an existing PAT (guaranteed assignable to this principal), falling back to
+// the tenant's IAM roles. It returns ("", false) when no role can be found, so
+// the cycle skips rather than guessing.
+func (ic iamPATCycle) pickRole(ctx context.Context, c *client.Client, r *Run) (string, bool) {
+	var pats []*client.Token
+	if err := r.op(ic, "iam.pat.list", func() error {
+		var lerr error
+		pats, lerr = c.IAM().PAT().List(ctx)
+		return lerr
+	}); err == nil {
+		for _, p := range pats {
+			if p != nil && len(p.Roles) > 0 && p.Roles[0] != "" {
+				return p.Roles[0], true
+			}
+		}
+	}
+
+	var roles []*client.Role
+	if err := r.op(ic, "iam.roles.list", func() error {
+		var lerr error
+		roles, lerr = c.IAM().Role().List(ctx)
+		return lerr
+	}); err == nil {
+		for _, role := range roles {
+			if role != nil && role.ID != "" {
+				return role.ID, true
+			}
+		}
+	}
+	return "", false
+}

--- a/cmd/ct-validate/cycle_object_storage.go
+++ b/cmd/ct-validate/cycle_object_storage.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// objectStorageCycle drives a bucket lifecycle:
+//
+//	create bucket -> (if a role + storage account exist) grant an ACL entry ->
+//	read the ACL entries -> revoke -> delete bucket
+//
+// The bucket teardown is registered the moment the create activity completes,
+// so an abort still removes it. The ACL grant teardown is registered before
+// the grant is corroborated, mirroring the VPC cycle's discipline.
+type objectStorageCycle struct{}
+
+func (objectStorageCycle) Name() string { return "object_storage" }
+func (objectStorageCycle) Kind() Kind   { return KindWrite }
+
+func (oc objectStorageCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	// Bucket names are globally constrained; keep them short, lowercase and
+	// unique per (iteration, worker).
+	name := fmt.Sprintf("ct-validate-%d-%d", r.Iteration, r.Worker)
+
+	created := false
+	if err := r.op(oc, "object_storage.bucket.create", func() error {
+		activityID, cerr := c.ObjectStorage().Bucket().Create(ctx, &client.CreateBucketRequest{
+			Name:       name,
+			AccessType: "private",
+		})
+		if cerr != nil {
+			return cerr
+		}
+		if activityID != "" {
+			if _, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter); werr != nil {
+				return werr
+			}
+		}
+		created = true
+		return nil
+	}); err != nil || !created {
+		return err
+	}
+
+	// Register bucket teardown immediately.
+	r.Cleanup.Register(fmt.Sprintf("object_storage.bucket %s", name), func(tctx context.Context) error {
+		activityID, derr := c.ObjectStorage().Bucket().Delete(tctx, name)
+		if derr != nil {
+			return derr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
+		return werr
+	})
+
+	oc.aclSubCycle(ctx, c, r, name)
+
+	// Explicit delete on the happy path (overlaps the registered teardown by
+	// design).
+	_ = r.op(oc, "object_storage.bucket.delete", func() error {
+		activityID, derr := c.ObjectStorage().Bucket().Delete(ctx, name)
+		if derr != nil {
+			return derr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		return werr
+	})
+	return nil
+}
+
+// aclSubCycle grants an ACL entry (a role to a storage account on the bucket),
+// reads it back, then revokes it. When no role or no storage account exists,
+// the grant/read/revoke steps are recorded as skipped.
+func (oc objectStorageCycle) aclSubCycle(ctx context.Context, c *client.Client, r *Run, bucket string) {
+	var roles []*client.ObjectStorageRole
+	var accounts []*client.StorageAccount
+
+	if err := r.op(oc, "object_storage.roles.list", func() error {
+		var lerr error
+		roles, lerr = c.ObjectStorage().Role().List(ctx)
+		return lerr
+	}); err != nil {
+		r.skip(oc, "object_storage.acl.grant")
+		r.skip(oc, "object_storage.acl.read")
+		r.skip(oc, "object_storage.acl.revoke")
+		return
+	}
+	if err := r.op(oc, "object_storage.storage_accounts.list", func() error {
+		var lerr error
+		accounts, lerr = c.ObjectStorage().StorageAccount().List(ctx)
+		return lerr
+	}); err != nil {
+		r.skip(oc, "object_storage.acl.grant")
+		r.skip(oc, "object_storage.acl.read")
+		r.skip(oc, "object_storage.acl.revoke")
+		return
+	}
+
+	if len(roles) == 0 || len(accounts) == 0 {
+		r.skip(oc, "object_storage.acl.grant")
+		r.skip(oc, "object_storage.acl.read")
+		r.skip(oc, "object_storage.acl.revoke")
+		return
+	}
+
+	role := roles[0].Name
+	account := accounts[0].Name
+
+	granted := false
+	if err := r.op(oc, "object_storage.acl.grant", func() error {
+		activityID, gerr := c.ObjectStorage().ACLEntry().Grant(ctx, bucket, role, account)
+		if gerr != nil {
+			return gerr
+		}
+		if activityID != "" {
+			if _, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter); werr != nil {
+				return werr
+			}
+		}
+		granted = true
+		return nil
+	}); err != nil {
+		r.skip(oc, "object_storage.acl.read")
+		r.skip(oc, "object_storage.acl.revoke")
+		return
+	}
+
+	if granted {
+		r.Cleanup.Register(fmt.Sprintf("object_storage.acl revoke %s/%s/%s", bucket, role, account), func(tctx context.Context) error {
+			activityID, rerr := c.ObjectStorage().ACLEntry().Revoke(tctx, bucket, role, account)
+			if rerr != nil {
+				return rerr
+			}
+			if activityID == "" {
+				return nil
+			}
+			_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
+			return werr
+		})
+	}
+
+	_ = r.op(oc, "object_storage.acl.read", func() error {
+		_, rerr := c.ObjectStorage().ACL().ListByBucket(ctx, bucket)
+		return rerr
+	})
+
+	_ = r.op(oc, "object_storage.acl.revoke", func() error {
+		activityID, rerr := c.ObjectStorage().ACLEntry().Revoke(ctx, bucket, role, account)
+		if rerr != nil {
+			return rerr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		return werr
+	})
+}

--- a/cmd/ct-validate/cycle_object_storage.go
+++ b/cmd/ct-validate/cycle_object_storage.go
@@ -25,6 +25,12 @@ func (oc objectStorageCycle) Run(ctx context.Context, c *client.Client, r *Run) 
 	// unique per (iteration, worker).
 	name := fmt.Sprintf("ct-validate-%d-%d", r.Iteration, r.Worker)
 
+	// F3: register "delete bucket by name if present" BEFORE the create, keyed by
+	// the deterministic name, so a created-but-unconfirmed bucket (create activity
+	// lost between server-side effect and confirmation) is still swept. Idempotent
+	// (absent bucket → success).
+	registerBucketTeardown(r.Cleanup, objectStorageBucketSeam{c}, name)
+
 	created := false
 	if err := r.op(oc, "object_storage.bucket.create", func() error {
 		activityID, cerr := c.ObjectStorage().Bucket().Create(ctx, &client.CreateBucketRequest{
@@ -44,19 +50,6 @@ func (oc objectStorageCycle) Run(ctx context.Context, c *client.Client, r *Run) 
 	}); err != nil || !created {
 		return err
 	}
-
-	// Register bucket teardown immediately.
-	r.Cleanup.Register(fmt.Sprintf("object_storage.bucket %s", name), func(tctx context.Context) error {
-		activityID, derr := c.ObjectStorage().Bucket().Delete(tctx, name)
-		if derr != nil {
-			return derr
-		}
-		if activityID == "" {
-			return nil
-		}
-		_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
-		return werr
-	})
 
 	oc.aclSubCycle(ctx, c, r, name)
 
@@ -114,7 +107,11 @@ func (oc objectStorageCycle) aclSubCycle(ctx context.Context, c *client.Client, 
 	role := roles[0].Name
 	account := accounts[0].Name
 
-	granted := false
+	// F3: register revoke(role, account) BEFORE the grant, keyed by the
+	// deterministic (bucket, role, account) triple, so an ambiguous grant is
+	// still swept. Idempotent (absent grant → success).
+	registerACLTeardown(r.Cleanup, objectStorageACLSeam{c}, bucket, role, account)
+
 	if err := r.op(oc, "object_storage.acl.grant", func() error {
 		activityID, gerr := c.ObjectStorage().ACLEntry().Grant(ctx, bucket, role, account)
 		if gerr != nil {
@@ -125,26 +122,11 @@ func (oc objectStorageCycle) aclSubCycle(ctx context.Context, c *client.Client, 
 				return werr
 			}
 		}
-		granted = true
 		return nil
 	}); err != nil {
 		r.skip(oc, "object_storage.acl.read")
 		r.skip(oc, "object_storage.acl.revoke")
 		return
-	}
-
-	if granted {
-		r.Cleanup.Register(fmt.Sprintf("object_storage.acl revoke %s/%s/%s", bucket, role, account), func(tctx context.Context) error {
-			activityID, rerr := c.ObjectStorage().ACLEntry().Revoke(tctx, bucket, role, account)
-			if rerr != nil {
-				return rerr
-			}
-			if activityID == "" {
-				return nil
-			}
-			_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
-			return werr
-		})
 	}
 
 	_ = r.op(oc, "object_storage.acl.read", func() error {

--- a/cmd/ct-validate/cycle_readonly.go
+++ b/cmd/ct-validate/cycle_readonly.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// readonlyCycle exercises the primary List (and a Read-by-id on the first
+// item, where one exists) of every one of the eight services. It NEVER
+// mutates and NEVER registers cleanup. It is the always-on safe cycle and the
+// default selection.
+//
+// Each endpoint is recorded under a stable name (service.resource.list /
+// .read) so the report can pinpoint exactly which API surface squeaks.
+type readonlyCycle struct{}
+
+func (readonlyCycle) Name() string { return "readonly" }
+func (readonlyCycle) Kind() Kind   { return KindRead }
+
+func (rc readonlyCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	// Tenant/company context is needed by a few IAM filters. A failure to read
+	// it is recorded but does not abort the rest of the read sweep.
+	var tenantID, companyID string
+	_ = r.op(rc, "iam.token.read", func() error {
+		tok, err := c.Token(ctx)
+		if err != nil {
+			return err
+		}
+		tenantID = tok.TenantID()
+		companyID = tok.CompanyID()
+		return nil
+	})
+
+	rc.runIAM(ctx, c, r, tenantID, companyID)
+	rc.runVPC(ctx, c, r)
+	rc.runCompute(ctx, c, r)
+	rc.runBackup(ctx, c, r)
+	rc.runObjectStorage(ctx, c, r)
+	rc.runMarketplace(ctx, c, r)
+	rc.runTag(ctx, c, r)
+	rc.runActivity(ctx, c, r)
+	return nil
+}
+
+func (rc readonlyCycle) runActivity(ctx context.Context, c *client.Client, r *Run) {
+	var activities []*client.Activity
+	_ = r.op(rc, "activity.activities.list", func() error {
+		var err error
+		activities, err = c.Activity().List(ctx, nil)
+		return err
+	})
+	if len(activities) > 0 {
+		_ = r.op(rc, "activity.activities.read", func() error {
+			_, err := c.Activity().Read(ctx, activities[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "activity.activities.read")
+	}
+}
+
+func (rc readonlyCycle) runIAM(ctx context.Context, c *client.Client, r *Run, tenantID, companyID string) {
+	var users []*client.User
+	_ = r.op(rc, "iam.users.list", func() error {
+		var err error
+		users, err = c.IAM().User().List(ctx, &client.UserFilter{CompanyID: companyID})
+		return err
+	})
+	if len(users) > 0 {
+		_ = r.op(rc, "iam.users.read", func() error {
+			_, err := c.IAM().User().Read(ctx, users[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "iam.users.read")
+	}
+
+	var roles []*client.Role
+	_ = r.op(rc, "iam.roles.list", func() error {
+		var err error
+		roles, err = c.IAM().Role().List(ctx)
+		return err
+	})
+	if len(roles) > 0 {
+		_ = r.op(rc, "iam.roles.read", func() error {
+			_, err := c.IAM().Role().Read(ctx, roles[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "iam.roles.read")
+	}
+
+	_ = r.op(rc, "iam.tenants.list", func() error {
+		_, err := c.IAM().Tenant().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "iam.features.list", func() error {
+		_, err := c.IAM().Feature().List(ctx)
+		return err
+	})
+	if tenantID != "" {
+		_ = r.op(rc, "iam.feature_assignments.list", func() error {
+			_, err := c.IAM().Feature().ListAssignments(ctx, tenantID)
+			return err
+		})
+	} else {
+		r.skip(rc, "iam.feature_assignments.list")
+	}
+	if companyID != "" {
+		_ = r.op(rc, "iam.companies.read", func() error {
+			_, err := c.IAM().Company().Read(ctx, companyID)
+			return err
+		})
+	} else {
+		r.skip(rc, "iam.companies.read")
+	}
+	_ = r.op(rc, "iam.pat.list", func() error {
+		_, err := c.IAM().PAT().List(ctx)
+		return err
+	})
+}
+
+func (rc readonlyCycle) runVPC(ctx context.Context, c *client.Client, r *Run) {
+	var pns []*client.PrivateNetwork
+	_ = r.op(rc, "vpc.vpc.list", func() error {
+		_, err := c.VPC().VPC().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "vpc.private_networks.list", func() error {
+		var err error
+		pns, err = c.VPC().PrivateNetwork().List(ctx, nil)
+		return err
+	})
+	if len(pns) > 0 {
+		_ = r.op(rc, "vpc.private_networks.read", func() error {
+			_, err := c.VPC().PrivateNetwork().Read(ctx, pns[0].ID)
+			return err
+		})
+		// Static IPs need a parent private-network id: list the parent first,
+		// then list its static IPs.
+		_ = r.op(rc, "vpc.static_ips.list", func() error {
+			_, err := c.VPC().StaticIP().List(ctx, pns[0].ID, nil)
+			return err
+		})
+	} else {
+		r.skip(rc, "vpc.private_networks.read")
+		r.skip(rc, "vpc.static_ips.list")
+	}
+	var fips []*client.FloatingIP
+	_ = r.op(rc, "vpc.floating_ips.list", func() error {
+		var err error
+		fips, err = c.VPC().FloatingIP().List(ctx, nil)
+		return err
+	})
+	if len(fips) > 0 {
+		_ = r.op(rc, "vpc.floating_ips.read", func() error {
+			_, err := c.VPC().FloatingIP().Read(ctx, fips[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "vpc.floating_ips.read")
+	}
+}
+
+func (rc readonlyCycle) runCompute(ctx context.Context, c *client.Client, r *Run) {
+	// VMware compute.
+	var vms []*client.VirtualMachine
+	_ = r.op(rc, "compute.virtual_machines.list", func() error {
+		var err error
+		vms, err = c.Compute().VirtualMachine().List(ctx, nil)
+		return err
+	})
+	if len(vms) > 0 {
+		_ = r.op(rc, "compute.virtual_machines.read", func() error {
+			_, err := c.Compute().VirtualMachine().Read(ctx, vms[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "compute.virtual_machines.read")
+	}
+	_ = r.op(rc, "compute.datastores.list", func() error {
+		_, err := c.Compute().Datastore().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.hosts.list", func() error {
+		_, err := c.Compute().Host().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.networks.list", func() error {
+		_, err := c.Compute().Network().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.virtual_datacenters.list", func() error {
+		_, err := c.Compute().VirtualDatacenter().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.folders.list", func() error {
+		_, err := c.Compute().Folder().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.virtual_disks.list", func() error {
+		_, err := c.Compute().VirtualDisk().List(ctx, nil)
+		return err
+	})
+
+	// OpenIaaS compute.
+	var oVMs []*client.OpenIaaSVirtualMachine
+	_ = r.op(rc, "compute.openiaas.virtual_machines.list", func() error {
+		var err error
+		oVMs, err = c.Compute().OpenIaaS().VirtualMachine().ListStrict(ctx, nil)
+		return err
+	})
+	if len(oVMs) > 0 {
+		_ = r.op(rc, "compute.openiaas.virtual_machines.read", func() error {
+			_, err := c.Compute().OpenIaaS().VirtualMachine().Read(ctx, oVMs[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "compute.openiaas.virtual_machines.read")
+	}
+	_ = r.op(rc, "compute.openiaas.machine_managers.list", func() error {
+		_, err := c.Compute().OpenIaaS().MachineManager().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.networks.list", func() error {
+		_, err := c.Compute().OpenIaaS().Network().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.storage_repositories.list", func() error {
+		_, err := c.Compute().OpenIaaS().StorageRepository().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.hosts.list", func() error {
+		_, err := c.Compute().OpenIaaS().Host().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.templates.list", func() error {
+		_, err := c.Compute().OpenIaaS().Template().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.pools.list", func() error {
+		_, err := c.Compute().OpenIaaS().Pool().List(ctx, nil)
+		return err
+	})
+}
+
+func (rc readonlyCycle) runBackup(ctx context.Context, c *client.Client, r *Run) {
+	_ = r.op(rc, "backup.sla_policies.list", func() error {
+		_, err := c.Backup().SLAPolicy().List(ctx, nil)
+		return err
+	})
+	_ = r.op(rc, "backup.sites.list", func() error {
+		_, err := c.Backup().Site().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "backup.storages.list", func() error {
+		_, err := c.Backup().Storage().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "backup.spp_servers.list", func() error {
+		_, err := c.Backup().SPPServer().List(ctx, nil)
+		return err
+	})
+}
+
+func (rc readonlyCycle) runObjectStorage(ctx context.Context, c *client.Client, r *Run) {
+	var buckets []*client.Bucket
+	_ = r.op(rc, "object_storage.buckets.list", func() error {
+		var err error
+		buckets, err = c.ObjectStorage().Bucket().List(ctx)
+		return err
+	})
+	if len(buckets) > 0 {
+		_ = r.op(rc, "object_storage.buckets.read", func() error {
+			_, err := c.ObjectStorage().Bucket().Read(ctx, buckets[0].Name)
+			return err
+		})
+	} else {
+		r.skip(rc, "object_storage.buckets.read")
+	}
+	_ = r.op(rc, "object_storage.storage_accounts.list", func() error {
+		_, err := c.ObjectStorage().StorageAccount().List(ctx)
+		return err
+	})
+	_ = r.op(rc, "object_storage.namespace.read", func() error {
+		_, err := c.ObjectStorage().Namespace().Read(ctx)
+		return err
+	})
+}
+
+func (rc readonlyCycle) runMarketplace(ctx context.Context, c *client.Client, r *Run) {
+	var items []*client.MarketplaceItem
+	_ = r.op(rc, "marketplace.items.list", func() error {
+		var err error
+		items, err = c.Marketplace().Item().List(ctx)
+		return err
+	})
+	if len(items) > 0 {
+		_ = r.op(rc, "marketplace.items.read", func() error {
+			_, err := c.Marketplace().Item().Read(ctx, items[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "marketplace.items.read")
+	}
+}
+
+func (rc readonlyCycle) runTag(ctx context.Context, c *client.Client, r *Run) {
+	// The Tag service exposes only per-resource Read/Create/Delete (no global
+	// list endpoint). A safe read needs a resource id; we reuse the first
+	// floating IP id if one exists, otherwise skip. This keeps the read sweep
+	// honest rather than inventing a fake id.
+	var fips []*client.FloatingIP
+	_ = r.op(rc, "tag.floating_ips.list_for_resource", func() error {
+		var err error
+		fips, err = c.VPC().FloatingIP().List(ctx, nil)
+		return err
+	})
+	if len(fips) > 0 {
+		_ = r.op(rc, "tag.resource.read", func() error {
+			_, err := c.Tag().Resource().Read(ctx, fips[0].ID)
+			return err
+		})
+	} else {
+		r.skip(rc, "tag.resource.read")
+	}
+}

--- a/cmd/ct-validate/cycle_test.go
+++ b/cmd/ct-validate/cycle_test.go
@@ -196,3 +196,60 @@ func TestRunOpRecordsAndFeedsBreaker(t *testing.T) {
 		t.Fatalf("skip op recorded wrong: %+v", skip)
 	}
 }
+
+// TestRunOpGatesOnTrippedBreaker proves F1: once the breaker is tripped, op()
+// does NOT call fn — it records a skip and returns nil. This is what bounds the
+// hammering MID-CYCLE (a long cycle must not keep calling the API after an early
+// trip).
+//
+// Mutation proof: remove the `if r.Breaker != nil && !r.Breaker.Allow()` gate at
+// the top of Run.op → fn IS called → called becomes true → this test goes RED.
+func TestRunOpGatesOnTrippedBreaker(t *testing.T) {
+	rec := NewRecorder()
+	b := NewBreaker(1, 1.0, 100)
+	b.Trip("pre-tripped for test") // force the breaker open before any op
+	r := &Run{Recorder: rec, Breaker: b, Cleanup: NewCleanup()}
+	c := fakeCycle{"readonly", KindRead}
+
+	called := false
+	got := r.op(c, "x.list", func() error { called = true; return nil })
+
+	if called {
+		t.Fatal("op must NOT call fn once the breaker has tripped (mid-cycle gating)")
+	}
+	if got != nil {
+		t.Fatalf("a gated op must return nil, got %v", got)
+	}
+	ops := rec.Ops()
+	if len(ops) != 1 {
+		t.Fatalf("recorded %d ops, want exactly 1 (the skip)", len(ops))
+	}
+	o := ops[0]
+	if !o.Skipped || o.OK || o.Category != CategorySkipped || o.Endpoint != "x.list" {
+		t.Fatalf("gated op must be recorded as a skip, got %+v", o)
+	}
+}
+
+// TestRunOpSkipDoesNotFeedBreaker proves a gated skip does not feed the breaker
+// window: a tripped breaker stays tripped on the SAME reason, and the skip count
+// does not turn into a failure that would dilute accounting. (Belt-and-braces
+// over the Record contract, scoped to the gating path.)
+func TestRunOpSkipDoesNotFeedBreaker(t *testing.T) {
+	rec := NewRecorder()
+	b := NewBreaker(5, 1.0, 100)
+	b.Trip("forced")
+	r := &Run{Recorder: rec, Breaker: b, Cleanup: NewCleanup()}
+	c := fakeCycle{"readonly", KindRead}
+
+	for i := 0; i < 10; i++ {
+		_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 500} })
+	}
+	if b.Reason() != "forced" {
+		t.Fatalf("gated skips must not re-feed the breaker; reason changed to %q", b.Reason())
+	}
+	for _, o := range rec.Ops() {
+		if !o.Skipped {
+			t.Fatalf("every op after a trip must be a skip, got %+v", o)
+		}
+	}
+}

--- a/cmd/ct-validate/cycle_test.go
+++ b/cmd/ct-validate/cycle_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// fakeCycle is a no-op cycle for registry/selection tests.
+type fakeCycle struct {
+	name string
+	kind Kind
+}
+
+func (f fakeCycle) Name() string                                    { return f.name }
+func (f fakeCycle) Kind() Kind                                      { return f.kind }
+func (f fakeCycle) Run(context.Context, *client.Client, *Run) error { return nil }
+
+func names(cs []Cycle) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.Name()
+	}
+	return out
+}
+
+func testRegistry() *Registry {
+	return NewRegistry(
+		fakeCycle{"readonly", KindRead},
+		fakeCycle{"backup", KindRead},
+		fakeCycle{"vpc", KindWrite},
+		fakeCycle{"object_storage", KindWrite},
+	)
+}
+
+func TestSelectCSV(t *testing.T) {
+	reg := testRegistry()
+	sel, gated, err := reg.Select("readonly, backup", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"readonly", "backup"}) {
+		t.Fatalf("selection = %v, want [readonly backup]", got)
+	}
+	if len(gated) != 0 {
+		t.Fatalf("no write cycles selected, gated should be empty: %v", gated)
+	}
+}
+
+// TestSelectTrimsAndDropsEmptyTokens proves whitespace is trimmed and empty
+// tokens are ignored (a trailing comma must not become an unknown "" cycle).
+func TestSelectTrimsAndDropsEmptyTokens(t *testing.T) {
+	reg := testRegistry()
+	sel, _, err := reg.Select("  readonly ,, backup ,", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"readonly", "backup"}) {
+		t.Fatalf("selection = %v, want [readonly backup]", got)
+	}
+}
+
+// TestSelectDeduplicates proves a repeated name collapses to one entry,
+// first-seen order preserved.
+func TestSelectDeduplicates(t *testing.T) {
+	reg := testRegistry()
+	sel, _, err := reg.Select("backup,readonly,backup", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"backup", "readonly"}) {
+		t.Fatalf("selection = %v, want [backup readonly] (deduped, first-seen order)", got)
+	}
+}
+
+func TestSelectAll(t *testing.T) {
+	reg := testRegistry()
+	// With -write, "all" must include the write cycles, ordered by name.
+	sel, gated, err := reg.Select("all", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"backup", "object_storage", "readonly", "vpc"}) {
+		t.Fatalf("all (write) = %v", got)
+	}
+	if len(gated) != 0 {
+		t.Fatalf("write enabled, nothing should be gated: %v", gated)
+	}
+}
+
+// TestSelectAllSupersedes proves "all" combined with explicit names is still
+// just "all" (no duplicates, full set).
+func TestSelectAllSupersedes(t *testing.T) {
+	reg := testRegistry()
+	sel, _, err := reg.Select("vpc,all,readonly", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"backup", "object_storage", "readonly", "vpc"}) {
+		t.Fatalf("all-supersedes = %v", got)
+	}
+}
+
+// TestSelectWriteGating proves write cycles are dropped (and reported as gated)
+// when -write is false, while read cycles still run. A mutation that ignores
+// the write flag would let a write cycle through here.
+func TestSelectWriteGating(t *testing.T) {
+	reg := testRegistry()
+	sel, gated, err := reg.Select("readonly,vpc,object_storage", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"readonly"}) {
+		t.Fatalf("write-gated selection = %v, want [readonly]", got)
+	}
+	if !reflect.DeepEqual(gated, []string{"vpc", "object_storage"}) {
+		t.Fatalf("gated = %v, want [vpc object_storage]", gated)
+	}
+}
+
+// TestSelectAllWriteGating proves "all" without -write yields only the read
+// cycles, with the write cycles reported as gated.
+func TestSelectAllWriteGating(t *testing.T) {
+	reg := testRegistry()
+	sel, gated, err := reg.Select("all", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := names(sel); !reflect.DeepEqual(got, []string{"backup", "readonly"}) {
+		t.Fatalf("all (read-only) = %v, want [backup readonly]", got)
+	}
+	if !reflect.DeepEqual(gated, []string{"object_storage", "vpc"}) {
+		t.Fatalf("gated = %v, want [object_storage vpc]", gated)
+	}
+}
+
+func TestSelectUnknownIsError(t *testing.T) {
+	reg := testRegistry()
+	if _, _, err := reg.Select("readonly,does_not_exist", true); err == nil {
+		t.Fatal("an unknown cycle name must be a hard error, not a silent skip")
+	}
+}
+
+func TestSelectEmptyIsError(t *testing.T) {
+	reg := testRegistry()
+	if _, _, err := reg.Select("   ,, ", true); err == nil {
+		t.Fatal("an all-empty spec must be an error")
+	}
+}
+
+// TestRegistryDuplicatePanics proves the registry rejects duplicate names
+// (programmer error caught early).
+func TestRegistryDuplicatePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("registering two cycles with the same name must panic")
+		}
+	}()
+	NewRegistry(fakeCycle{"dup", KindRead}, fakeCycle{"dup", KindWrite})
+}
+
+// TestRunOpRecordsAndFeedsBreaker proves the op() choke point records an Op AND
+// feeds the breaker: a failure must increment failure accounting; an OK must
+// reset consecutive; a skip must touch neither the breaker nor count as OK.
+func TestRunOpRecordsAndFeedsBreaker(t *testing.T) {
+	rec := NewRecorder()
+	b := NewBreaker(2, 1.0, 100)
+	r := &Run{Recorder: rec, Breaker: b, Cleanup: NewCleanup()}
+	c := fakeCycle{"readonly", KindRead}
+
+	_ = r.op(c, "x.list", func() error { return nil })                           // ok
+	_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 500} }) // fail 1
+	r.skip(c, "x.read")                                                          // skip: not a breaker failure
+	if b.Tripped() {
+		t.Fatal("one failure with a skip in between must not trip a limit-2 breaker")
+	}
+	_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 500} }) // fail 2
+	if !b.Tripped() {
+		t.Fatal("two failures must trip the limit-2 breaker (skip must not have reset it)")
+	}
+
+	ops := rec.Ops()
+	if len(ops) != 4 {
+		t.Fatalf("recorded %d ops, want 4", len(ops))
+	}
+	// The skip must be marked skipped and not OK.
+	var skip Op
+	for _, o := range ops {
+		if o.Endpoint == "x.read" {
+			skip = o
+		}
+	}
+	if !skip.Skipped || skip.OK || skip.Category != CategorySkipped {
+		t.Fatalf("skip op recorded wrong: %+v", skip)
+	}
+}

--- a/cmd/ct-validate/cycle_vpc.go
+++ b/cmd/ct-validate/cycle_vpc.go
@@ -41,6 +41,13 @@ func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 	// or repeated runs. The 02:00:5e:f0:XX:YY range is locally-administered.
 	mac := fmt.Sprintf("02:00:5e:f0:%02x:%02x", byte(r.Iteration), byte(r.Worker))
 
+	// F3: register the by-MAC teardown BEFORE Create. The client documents that a
+	// 201 empty body means the static IP MAY already exist and id-resolution can
+	// fail (vpc_static_ip.go) — a created-but-unresolved static IP would orphan.
+	// Keying the teardown on the deterministic (private network, MAC) lets the
+	// safety net find and delete it even when Create returns no usable id.
+	registerStaticIPTeardown(r.Cleanup, vpcStaticIPSeam{c}, pn.ID, mac)
+
 	var staticID string
 	if err := r.op(vc, "vpc.static_ip.create", func() error {
 		id, cerr := c.VPC().StaticIP().Create(ctx, pn.ID, &client.CreateStaticIPRequest{
@@ -53,24 +60,16 @@ func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 		staticID = id
 		return nil
 	}); err != nil || staticID == "" {
-		// Either the create failed (recorded) or returned no id; nothing to
-		// tear down (the client only returns a non-empty id when the resource
-		// is confirmed to exist).
+		// Either the create failed (recorded) or returned no id. The by-MAC
+		// teardown registered above still sweeps a created-but-unresolved static
+		// IP, so we can safely return here.
 		return err
 	}
 
-	// Register teardown IMMEDIATELY: from here on, an abort must still delete
-	// this static IP. Teardown is best-effort with a bounded transient-retry.
+	// Also register the precise by-id teardown now that the id is resolved (LIFO:
+	// it runs before the broader by-MAC sweep). Both are idempotent.
 	r.Cleanup.Register(fmt.Sprintf("vpc.static_ip %s", staticID), func(tctx context.Context) error {
-		activityID, derr := c.VPC().StaticIP().Delete(tctx, staticID)
-		if derr != nil {
-			return derr
-		}
-		if activityID == "" {
-			return nil
-		}
-		_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
-		return werr
+		return vpcStaticIPSeam{c}.DeleteAndWait(tctx, staticID)
 	})
 
 	vc.bindSubCycle(ctx, c, r, staticID)
@@ -148,7 +147,13 @@ func (vc vpcCycle) bindSubCycle(ctx context.Context, c *client.Client, r *Run, s
 		return
 	}
 
-	bound := false
+	// F3: register the unbind teardown BEFORE the bind, keyed by the
+	// deterministic (fip, static) pair. A bind whose activity completes but whose
+	// confirmation is then lost (abort/panic between Bind and the registration)
+	// must still release our FIP. The teardown is idempotent (already-unbound →
+	// success), so registering it even if the bind ultimately fails is harmless.
+	registerFIPUnbindTeardown(r.Cleanup, vpcFIPBindSeam{c}, spare.ID, staticID)
+
 	if err := r.op(vc, "vpc.floating_ip.bind", func() error {
 		activityID, berr := c.VPC().FloatingIP().Bind(ctx, spare.ID, staticID)
 		if berr != nil {
@@ -159,30 +164,12 @@ func (vc vpcCycle) bindSubCycle(ctx context.Context, c *client.Client, r *Run, s
 				return werr
 			}
 		}
-		bound = true
 		return nil
 	}); err != nil {
-		// Bind failed; nothing to unbind. The static IP teardown is already
-		// registered.
+		// Bind failed; the idempotent unbind teardown registered above is a
+		// best-effort no-op if the bind never took effect.
 		r.skip(vc, "vpc.floating_ip.unbind")
 		return
-	}
-
-	if bound {
-		// Register the unbind teardown BEFORE doing anything else with the
-		// binding, so an abort still releases our FIP (LIFO: unbind runs before
-		// the static-IP delete).
-		r.Cleanup.Register(fmt.Sprintf("vpc.floating_ip unbind %s<-%s", spare.ID, staticID), func(tctx context.Context) error {
-			activityID, uerr := c.VPC().FloatingIP().Unbind(tctx, spare.ID, staticID)
-			if uerr != nil {
-				return uerr
-			}
-			if activityID == "" {
-				return nil
-			}
-			_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
-			return werr
-		})
 	}
 
 	// Confirm the binding took effect (positive same-pair corroboration).

--- a/cmd/ct-validate/cycle_vpc.go
+++ b/cmd/ct-validate/cycle_vpc.go
@@ -69,7 +69,7 @@ func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 	// Also register the precise by-id teardown now that the id is resolved (LIFO:
 	// it runs before the broader by-MAC sweep). Both are idempotent.
 	r.Cleanup.Register(fmt.Sprintf("vpc.static_ip %s", staticID), func(tctx context.Context) error {
-		return vpcStaticIPSeam{c}.DeleteAndWait(tctx, staticID)
+		return vpcStaticIPSeam{c}.DeleteAndWait(tctx, pn.ID, staticID)
 	})
 
 	vc.bindSubCycle(ctx, c, r, staticID)

--- a/cmd/ct-validate/cycle_vpc.go
+++ b/cmd/ct-validate/cycle_vpc.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// silentWaiter is a WaiterOptions whose logger is a no-op: the harness records
+// latency/outcome itself and does not want the client's per-poll chatter on
+// stdout.
+var silentWaiter = &client.WaiterOptions{Logger: func(string) {}}
+
+// vpcCycle drives a realistic VPC write business cycle:
+//
+//	create custom static IP -> (if a spare unbound FIP exists) bind FIP ->
+//	confirm by read -> unbind FIP -> delete static IP
+//
+// Every created resource is registered for teardown BEFORE the step that could
+// lose it, so the never-orphan backstop holds even if a later step or the
+// breaker aborts. When no spare FIP exists, the bind/unbind steps are recorded
+// as skipped and only the create/delete sub-cycle runs.
+//
+// This is the cycle the harness exists for: the 2026-06-15 incident was a VPC
+// write loop amplifying an outage and orphaning static IPs. Here every write is
+// bounded, breaker-gated, and teardown-backed.
+type vpcCycle struct{}
+
+func (vpcCycle) Name() string { return "vpc" }
+func (vpcCycle) Kind() Kind   { return KindWrite }
+
+func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	pn, err := vc.pickPrivateNetwork(ctx, c, r)
+	if err != nil || pn == nil {
+		// pickPrivateNetwork already recorded the failure/skip.
+		return err
+	}
+
+	// MAC unique per (iteration, worker) to avoid collisions across concurrent
+	// or repeated runs. The 02:00:5e:f0:XX:YY range is locally-administered.
+	mac := fmt.Sprintf("02:00:5e:f0:%02x:%02x", byte(r.Iteration), byte(r.Worker))
+
+	var staticID string
+	if err := r.op(vc, "vpc.static_ip.create", func() error {
+		id, cerr := c.VPC().StaticIP().Create(ctx, pn.ID, &client.CreateStaticIPRequest{
+			MacAddress:          mac,
+			ResourceDescription: "ct-validate",
+		})
+		if cerr != nil {
+			return cerr
+		}
+		staticID = id
+		return nil
+	}); err != nil || staticID == "" {
+		// Either the create failed (recorded) or returned no id; nothing to
+		// tear down (the client only returns a non-empty id when the resource
+		// is confirmed to exist).
+		return err
+	}
+
+	// Register teardown IMMEDIATELY: from here on, an abort must still delete
+	// this static IP. Teardown is best-effort with a bounded transient-retry.
+	r.Cleanup.Register(fmt.Sprintf("vpc.static_ip %s", staticID), func(tctx context.Context) error {
+		activityID, derr := c.VPC().StaticIP().Delete(tctx, staticID)
+		if derr != nil {
+			return derr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
+		return werr
+	})
+
+	vc.bindSubCycle(ctx, c, r, staticID)
+
+	// Explicit delete step (recorded). It overlaps with the registered
+	// teardown intentionally: the cycle deletes on the happy path; the
+	// teardown is the safety net if we never reach here.
+	_ = r.op(vc, "vpc.static_ip.delete", func() error {
+		activityID, derr := c.VPC().StaticIP().Delete(ctx, staticID)
+		if derr != nil {
+			return derr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		return werr
+	})
+	return nil
+}
+
+// pickPrivateNetwork lists private networks and returns the one named "LAN", or
+// the first one otherwise. It records the listing endpoint and skips the cycle
+// (no error) when there is no private network to work in.
+func (vc vpcCycle) pickPrivateNetwork(ctx context.Context, c *client.Client, r *Run) (*client.PrivateNetwork, error) {
+	var pns []*client.PrivateNetwork
+	if err := r.op(vc, "vpc.private_networks.list", func() error {
+		var lerr error
+		pns, lerr = c.VPC().PrivateNetwork().List(ctx, nil)
+		return lerr
+	}); err != nil {
+		return nil, err
+	}
+	if len(pns) == 0 {
+		r.skip(vc, "vpc.static_ip.create")
+		r.skip(vc, "vpc.static_ip.delete")
+		r.skip(vc, "vpc.floating_ip.bind")
+		r.skip(vc, "vpc.floating_ip.unbind")
+		return nil, nil
+	}
+	for _, pn := range pns {
+		if pn.Name != nil && *pn.Name == "LAN" {
+			return pn, nil
+		}
+	}
+	return pns[0], nil
+}
+
+// bindSubCycle finds a spare UNBOUND floating IP, binds it to the static IP,
+// confirms the binding by read, then unbinds it. When no spare FIP exists, the
+// bind/unbind/confirm steps are recorded as skipped.
+func (vc vpcCycle) bindSubCycle(ctx context.Context, c *client.Client, r *Run, staticID string) {
+	var fips []*client.FloatingIP
+	if err := r.op(vc, "vpc.floating_ips.list", func() error {
+		var lerr error
+		fips, lerr = c.VPC().FloatingIP().List(ctx, nil)
+		return lerr
+	}); err != nil {
+		// Listing failed: cannot safely pick a FIP, so skip the bind steps.
+		r.skip(vc, "vpc.floating_ip.bind")
+		r.skip(vc, "vpc.floating_ip.unbind")
+		return
+	}
+
+	var spare *client.FloatingIP
+	for _, fip := range fips {
+		if fip != nil && fip.StaticIP == nil {
+			spare = fip
+			break
+		}
+	}
+	if spare == nil {
+		r.skip(vc, "vpc.floating_ip.bind")
+		r.skip(vc, "vpc.floating_ip.unbind")
+		return
+	}
+
+	bound := false
+	if err := r.op(vc, "vpc.floating_ip.bind", func() error {
+		activityID, berr := c.VPC().FloatingIP().Bind(ctx, spare.ID, staticID)
+		if berr != nil {
+			return berr
+		}
+		if activityID != "" {
+			if _, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter); werr != nil {
+				return werr
+			}
+		}
+		bound = true
+		return nil
+	}); err != nil {
+		// Bind failed; nothing to unbind. The static IP teardown is already
+		// registered.
+		r.skip(vc, "vpc.floating_ip.unbind")
+		return
+	}
+
+	if bound {
+		// Register the unbind teardown BEFORE doing anything else with the
+		// binding, so an abort still releases our FIP (LIFO: unbind runs before
+		// the static-IP delete).
+		r.Cleanup.Register(fmt.Sprintf("vpc.floating_ip unbind %s<-%s", spare.ID, staticID), func(tctx context.Context) error {
+			activityID, uerr := c.VPC().FloatingIP().Unbind(tctx, spare.ID, staticID)
+			if uerr != nil {
+				return uerr
+			}
+			if activityID == "" {
+				return nil
+			}
+			_, werr := c.Activity().WaitForCompletion(tctx, activityID, silentWaiter)
+			return werr
+		})
+	}
+
+	// Confirm the binding took effect (positive same-pair corroboration).
+	_ = r.op(vc, "vpc.floating_ip.confirm_bound", func() error {
+		state, cerr := c.VPC().FloatingIP().CorroborateBinding(ctx, spare.ID, staticID)
+		if cerr != nil {
+			return cerr
+		}
+		if state != client.FloatingIPBindingBoundToTarget {
+			return fmt.Errorf("floating IP %s not confirmed bound to %s (state=%d)", spare.ID, staticID, state)
+		}
+		return nil
+	})
+
+	// Explicit unbind on the happy path (recorded). Overlaps with the
+	// registered teardown by design.
+	_ = r.op(vc, "vpc.floating_ip.unbind", func() error {
+		activityID, uerr := c.VPC().FloatingIP().Unbind(ctx, spare.ID, staticID)
+		if uerr != nil {
+			return uerr
+		}
+		if activityID == "" {
+			return nil
+		}
+		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		return werr
+	})
+}

--- a/cmd/ct-validate/engine.go
+++ b/cmd/ct-validate/engine.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// EngineConfig parametrizes one engine run.
+type EngineConfig struct {
+	Runs        int
+	Concurrency int
+}
+
+// EngineResult summarizes an engine run for the report layer.
+type EngineResult struct {
+	Stats           []EndpointStats
+	Tripped         bool
+	TripReason      string
+	TeardownFailed  []TeardownFailure
+	SelectedCycles  []string
+	GatedWriteSkips []string
+}
+
+// task is one (cycle, iteration) unit of work for the worker pool.
+type task struct {
+	cycle Cycle
+	iter  int
+}
+
+// Engine runs the selected cycles across a bounded worker pool, gated by the
+// circuit breaker, and always tears down at the end.
+type Engine struct {
+	cfg     EngineConfig
+	breaker *Breaker
+	rec     *Recorder
+	cleanup *Cleanup
+}
+
+// NewEngine wires an engine to its collaborators.
+func NewEngine(cfg EngineConfig, breaker *Breaker, rec *Recorder, cleanup *Cleanup) *Engine {
+	if cfg.Concurrency < 1 {
+		cfg.Concurrency = 1
+	}
+	if cfg.Runs < 1 {
+		cfg.Runs = 1
+	}
+	return &Engine{cfg: cfg, breaker: breaker, rec: rec, cleanup: cleanup}
+}
+
+// Run executes `Runs` iterations of each selected cycle across `Concurrency`
+// workers. Before each task a worker checks the breaker; once it trips, no new
+// task is started, the pool drains, and the function returns. Cleanup ALWAYS
+// runs (deferred) so nothing created is left orphaned even on a trip or a
+// global-timeout cancellation.
+//
+// The global -timeout is carried by ctx; when it fires, in-flight client calls
+// observe context cancellation (CategoryTimeout) and the queue drains.
+func (e *Engine) Run(ctx context.Context, c *client.Client, selected []Cycle, gatedSkips []string) EngineResult {
+	tasks := make(chan task)
+	var wg sync.WaitGroup
+
+	// Producer: enqueue (cycle, iter) tasks, stopping as soon as the breaker
+	// trips. A read-only default run thus still benefits from the breaker if a
+	// listing endpoint starts failing en masse.
+	go func() {
+		defer close(tasks)
+		for iter := 0; iter < e.cfg.Runs; iter++ {
+			for _, cyc := range selected {
+				if !e.breaker.Allow() {
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case tasks <- task{cycle: cyc, iter: iter}:
+				}
+			}
+		}
+	}()
+
+	// Worker pool.
+	for w := 0; w < e.cfg.Concurrency; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for t := range tasks {
+				// Re-check at the consumption point: a task already queued
+				// before the trip must not run once the breaker is open.
+				if !e.breaker.Allow() || ctx.Err() != nil {
+					continue
+				}
+				run := &Run{
+					Recorder:  e.rec,
+					Breaker:   e.breaker,
+					Cleanup:   e.cleanup,
+					Iteration: t.iter,
+					Worker:    worker,
+				}
+				// A cycle-level error is intentionally swallowed here: per-op
+				// failures are already recorded inside the cycle via run.op,
+				// and the breaker decides whether to keep scheduling. The
+				// cycle returning an error just means "this iteration aborted
+				// early"; the recorded ops carry the detail.
+				_ = t.cycle.Run(ctx, c, run)
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	// Always tear down what was created, even on a trip or timeout. Give
+	// teardown a context that is NOT already cancelled by a breaker trip, but
+	// IS still bounded: if the parent ctx is cancelled (global timeout), derive
+	// a fresh background-rooted context so best-effort cleanup can still run a
+	// bounded number of attempts rather than instantly failing on ctx.Err().
+	teardownCtx := ctx
+	if ctx.Err() != nil {
+		teardownCtx = context.Background()
+	}
+	teardownFailures := e.cleanup.TeardownAll(teardownCtx)
+
+	names := make([]string, 0, len(selected))
+	for _, c := range selected {
+		names = append(names, c.Name())
+	}
+
+	return EngineResult{
+		Stats:           Aggregate(e.rec.Ops()),
+		Tripped:         e.breaker.Tripped(),
+		TripReason:      e.breaker.Reason(),
+		TeardownFailed:  teardownFailures,
+		SelectedCycles:  names,
+		GatedWriteSkips: gatedSkips,
+	}
+}

--- a/cmd/ct-validate/engine.go
+++ b/cmd/ct-validate/engine.go
@@ -2,15 +2,27 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
+
+// defaultCleanupTimeout bounds the whole teardown phase when the parent context
+// is already cancelled (global -timeout fired). Without a bound, a teardown
+// that polls an activity (WaitForCompletion is context-bounded only) could keep
+// hitting a distressed API indefinitely on a fresh background context. This is
+// the F4 guard: cleanup is best-effort AND bounded.
+const defaultCleanupTimeout = 2 * time.Minute
 
 // EngineConfig parametrizes one engine run.
 type EngineConfig struct {
 	Runs        int
 	Concurrency int
+	// CleanupTimeout bounds the teardown phase. A non-positive value falls back
+	// to defaultCleanupTimeout (applied in NewEngine).
+	CleanupTimeout time.Duration
 }
 
 // EngineResult summarizes an engine run for the report layer.
@@ -46,6 +58,9 @@ func NewEngine(cfg EngineConfig, breaker *Breaker, rec *Recorder, cleanup *Clean
 	if cfg.Runs < 1 {
 		cfg.Runs = 1
 	}
+	if cfg.CleanupTimeout <= 0 {
+		cfg.CleanupTimeout = defaultCleanupTimeout
+	}
 	return &Engine{cfg: cfg, breaker: breaker, rec: rec, cleanup: cleanup}
 }
 
@@ -57,7 +72,31 @@ func NewEngine(cfg EngineConfig, breaker *Breaker, rec *Recorder, cleanup *Clean
 //
 // The global -timeout is carried by ctx; when it fires, in-flight client calls
 // observe context cancellation (CategoryTimeout) and the queue drains.
-func (e *Engine) Run(ctx context.Context, c *client.Client, selected []Cycle, gatedSkips []string) EngineResult {
+func (e *Engine) Run(ctx context.Context, c *client.Client, selected []Cycle, gatedSkips []string) (result EngineResult) {
+	names := make([]string, 0, len(selected))
+	for _, sc := range selected {
+		names = append(names, sc.Name())
+	}
+
+	// F2/F4: cleanup ALWAYS runs (deferred), even on an early return or a panic
+	// that escapes wg.Wait(), and it runs under a FRESH but BOUNDED context so a
+	// global-timeout cancellation cannot let teardown poll a distressed API
+	// indefinitely. The deferred closure also assembles the result so every exit
+	// path reports a well-formed EngineResult.
+	defer func() {
+		tctx, cancel := e.teardownContext(ctx)
+		defer cancel()
+		teardownFailures := e.cleanup.TeardownAll(tctx)
+		result = EngineResult{
+			Stats:           Aggregate(e.rec.Ops()),
+			Tripped:         e.breaker.Tripped(),
+			TripReason:      e.breaker.Reason(),
+			TeardownFailed:  teardownFailures,
+			SelectedCycles:  names,
+			GatedWriteSkips: gatedSkips,
+		}
+	}()
+
 	tasks := make(chan task)
 	var wg sync.WaitGroup
 
@@ -91,47 +130,65 @@ func (e *Engine) Run(ctx context.Context, c *client.Client, selected []Cycle, ga
 				if !e.breaker.Allow() || ctx.Err() != nil {
 					continue
 				}
-				run := &Run{
-					Recorder:  e.rec,
-					Breaker:   e.breaker,
-					Cleanup:   e.cleanup,
-					Iteration: t.iter,
-					Worker:    worker,
-				}
-				// A cycle-level error is intentionally swallowed here: per-op
-				// failures are already recorded inside the cycle via run.op,
-				// and the breaker decides whether to keep scheduling. The
-				// cycle returning an error just means "this iteration aborted
-				// early"; the recorded ops carry the detail.
-				_ = t.cycle.Run(ctx, c, run)
+				e.runOne(ctx, c, t, worker)
 			}
 		}(w)
 	}
 
 	wg.Wait()
 
-	// Always tear down what was created, even on a trip or timeout. Give
-	// teardown a context that is NOT already cancelled by a breaker trip, but
-	// IS still bounded: if the parent ctx is cancelled (global timeout), derive
-	// a fresh background-rooted context so best-effort cleanup can still run a
-	// bounded number of attempts rather than instantly failing on ctx.Err().
-	teardownCtx := ctx
-	if ctx.Err() != nil {
-		teardownCtx = context.Background()
-	}
-	teardownFailures := e.cleanup.TeardownAll(teardownCtx)
+	// The deferred closure performs teardown and assembles the result.
+	return
+}
 
-	names := make([]string, 0, len(selected))
-	for _, c := range selected {
-		names = append(names, c.Name())
+// runOne executes a single (cycle, iteration) task. It is wrapped in a
+// per-task recover so a panic in one cycle goroutine neither crashes the whole
+// run nor leaves the engine scheduling more work: the panic is recorded as a
+// failure op AND trips the breaker (so the producer stops enqueueing and the
+// pool drains to the deferred teardown). The created resources of OTHER tasks
+// are still torn down by the engine's deferred TeardownAll.
+func (e *Engine) runOne(ctx context.Context, c *client.Client, t task, worker int) {
+	run := &Run{
+		Recorder:  e.rec,
+		Breaker:   e.breaker,
+		Cleanup:   e.cleanup,
+		Iteration: t.iter,
+		Worker:    worker,
 	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			// Record the panic as a failure outcome so the report shows it, and
+			// trip the breaker so no further work is scheduled. CategoryOther is
+			// the failure bucket for a non-status error.
+			e.rec.Record(Op{
+				Cycle:    t.cycle.Name(),
+				Endpoint: t.cycle.Name() + ".panic",
+				OK:       false,
+				Category: CategoryOther,
+			})
+			e.breaker.Trip(fmt.Sprintf("cycle %q panicked: %v", t.cycle.Name(), rec))
+		}
+	}()
+	// A cycle-level error is intentionally swallowed here: per-op failures are
+	// already recorded inside the cycle via run.op, and the breaker decides
+	// whether to keep scheduling. The cycle returning an error just means "this
+	// iteration aborted early"; the recorded ops carry the detail.
+	_ = t.cycle.Run(ctx, c, run)
+}
 
-	return EngineResult{
-		Stats:           Aggregate(e.rec.Ops()),
-		Tripped:         e.breaker.Tripped(),
-		TripReason:      e.breaker.Reason(),
-		TeardownFailed:  teardownFailures,
-		SelectedCycles:  names,
-		GatedWriteSkips: gatedSkips,
+// teardownContext returns the context under which teardown runs, plus a cancel
+// the caller MUST defer. Teardown must not be cancelled by a breaker trip (the
+// breaker does not cancel ctx), but it MUST stay bounded: if the parent ctx is
+// already cancelled (global timeout), derive a FRESH context rooted at
+// Background but capped at CleanupTimeout so best-effort cleanup runs a bounded
+// number of attempts rather than either failing instantly on ctx.Err() or
+// polling a distressed API forever.
+//
+// When the parent ctx is still live, teardown reuses it (its remaining global
+// budget already bounds the work) and the returned cancel is a no-op.
+func (e *Engine) teardownContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		return ctx, func() {}
 	}
+	return context.WithTimeout(context.Background(), e.cfg.CleanupTimeout)
 }

--- a/cmd/ct-validate/engine_test.go
+++ b/cmd/ct-validate/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
@@ -135,4 +136,130 @@ func (c failingTeardownCycle) Run(ctx context.Context, _ *client.Client, r *Run)
 		return errors.New("cannot delete")
 	})
 	return r.op(c, "ft.op", func() error { return nil })
+}
+
+// panickingCycle registers a teardown, then PANICS in Run. It is the F2 fixture:
+// the engine must recover, run the teardown, trip the breaker, and report the
+// panic as a failure — never crash the process.
+type panickingCycle struct {
+	torn *int32
+}
+
+func (panickingCycle) Name() string { return "boom" }
+func (panickingCycle) Kind() Kind   { return KindWrite }
+func (c panickingCycle) Run(ctx context.Context, _ *client.Client, r *Run) error {
+	r.Cleanup.Register("res", func(context.Context) error {
+		atomic.AddInt32(c.torn, 1)
+		return nil
+	})
+	panic("synthetic cycle panic")
+}
+
+// TestEnginePanicRecoveredTornDownAndTripped proves F2: a cycle whose Run panics
+// does NOT crash the engine. Teardown still runs (deferred), the breaker trips,
+// and the panic is recorded as a failure outcome.
+//
+// Mutation proofs:
+//   - remove the per-task recover() in runOne → the panic escapes the worker
+//     goroutine → the test process crashes (RED).
+//   - remove the breaker.Trip(...) in the recover → res.Tripped is false (RED).
+//   - move TeardownAll out of the deferred closure (back after wg.Wait only) →
+//     the panic skips it → torn stays 0 (RED).
+func TestEnginePanicRecoveredTornDownAndTripped(t *testing.T) {
+	var torn int32
+	cyc := panickingCycle{torn: &torn}
+
+	breaker := NewBreaker(1000, 0.99, 1000) // would NOT trip on accounting alone
+	rec := NewRecorder()
+	eng := NewEngine(EngineConfig{Runs: 3, Concurrency: 1}, breaker, rec, NewCleanup())
+
+	res := eng.Run(context.Background(), nil, []Cycle{cyc}, nil) // must not panic out
+
+	if atomic.LoadInt32(&torn) == 0 {
+		t.Fatal("teardown must run even when a cycle panics (deferred TeardownAll)")
+	}
+	if !res.Tripped {
+		t.Fatal("a panicking cycle must trip the breaker so scheduling stops")
+	}
+	// The panic must surface as a recorded failure op (endpoint "<cycle>.panic").
+	var sawPanicOp bool
+	for _, o := range rec.Ops() {
+		if o.Endpoint == "boom.panic" {
+			sawPanicOp = true
+			if o.OK || o.Category == CategoryOK {
+				t.Fatalf("panic op must be a failure, got %+v", o)
+			}
+		}
+	}
+	if !sawPanicOp {
+		t.Fatal("the panic must be recorded as a failure op for the report")
+	}
+}
+
+// TestEngineTeardownBoundedOnCancelledContext proves F4: when the parent ctx is
+// already cancelled (global -timeout), teardown runs under a FRESH but BOUNDED
+// context, NOT context.Background() with no deadline. A teardown that honours
+// its context observes a deadline and is cut off rather than polling forever.
+//
+// Mutation proof: change teardownContext to return context.Background() (no
+// timeout) when ctx is cancelled → the teardown sees ctx.Err()==nil and no
+// Deadline → this test goes RED.
+func TestEngineTeardownBoundedOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // parent already cancelled (simulates global timeout fired)
+
+	cleanup := NewCleanup()
+	var sawDeadline int32
+	cleanup.Register("bounded", func(tctx context.Context) error {
+		// The teardown context must NOT be the cancelled parent (that would fail
+		// instantly) and MUST carry a deadline (bounded), not a naked Background.
+		if tctx.Err() != nil {
+			t.Errorf("teardown context must not be pre-cancelled")
+		}
+		if _, ok := tctx.Deadline(); ok {
+			atomic.StoreInt32(&sawDeadline, 1)
+		}
+		return nil
+	})
+
+	// A tiny cleanup timeout proves the bound is honoured and configurable.
+	eng := NewEngine(
+		EngineConfig{Runs: 1, Concurrency: 1, CleanupTimeout: 50 * time.Millisecond},
+		NewBreaker(1000, 0.99, 1000), NewRecorder(), cleanup,
+	)
+	_ = eng.Run(ctx, nil, []Cycle{noopCycle{}}, nil)
+
+	if atomic.LoadInt32(&sawDeadline) == 0 {
+		t.Fatal("teardown after a cancelled parent must run under a BOUNDED (deadlined) context")
+	}
+}
+
+// noopCycle does nothing; it lets the engine reach its deferred teardown with a
+// pre-registered cleanup entry under test.
+type noopCycle struct{}
+
+func (noopCycle) Name() string                                    { return "noop" }
+func (noopCycle) Kind() Kind                                      { return KindRead }
+func (noopCycle) Run(context.Context, *client.Client, *Run) error { return nil }
+
+// TestEngineUsesParentContextWhenLive proves the symmetric case: when the parent
+// ctx is still live, teardown reuses it (no fresh background context), so the
+// remaining global budget bounds cleanup.
+func TestEngineUsesParentContextWhenLive(t *testing.T) {
+	ctx := context.Background() // live, no deadline
+	cleanup := NewCleanup()
+	var reusedParent int32
+	cleanup.Register("x", func(tctx context.Context) error {
+		// Background has no deadline; if teardown wrongly wrapped a timeout here,
+		// a deadline would appear.
+		if _, ok := tctx.Deadline(); !ok {
+			atomic.StoreInt32(&reusedParent, 1)
+		}
+		return nil
+	})
+	eng := NewEngine(EngineConfig{Runs: 1, Concurrency: 1}, NewBreaker(1000, 0.99, 1000), NewRecorder(), cleanup)
+	_ = eng.Run(ctx, nil, []Cycle{noopCycle{}}, nil)
+	if atomic.LoadInt32(&reusedParent) == 0 {
+		t.Fatal("a live parent context must be reused for teardown, not replaced by a bounded one")
+	}
 }

--- a/cmd/ct-validate/engine_test.go
+++ b/cmd/ct-validate/engine_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// countingCycle records how many times Run was invoked and what each op
+// returns. It ignores the client (it makes no network calls), so the engine
+// can be unit-tested offline with a nil client.
+type countingCycle struct {
+	name  string
+	kind  Kind
+	runs  *int32
+	opErr error // returned by the single recorded op per Run
+}
+
+func (c countingCycle) Name() string { return c.name }
+func (c countingCycle) Kind() Kind   { return c.kind }
+func (c countingCycle) Run(ctx context.Context, _ *client.Client, r *Run) error {
+	atomic.AddInt32(c.runs, 1)
+	return r.op(c, c.name+".op", func() error { return c.opErr })
+}
+
+// TestEngineBreakerStopsScheduling proves the breaker stops the engine from
+// running every iteration once it trips. With a cycle that always fails and a
+// low consecutive limit, far fewer than `runs` iterations execute.
+func TestEngineBreakerStopsScheduling(t *testing.T) {
+	var runs int32
+	cyc := countingCycle{name: "failing", kind: KindRead, runs: &runs, opErr: client.StatusError{Code: 500}}
+
+	// Trip after 3 consecutive failures; single worker for determinism.
+	breaker := NewBreaker(3, 1.0, 1000)
+	rec := NewRecorder()
+	cleanup := NewCleanup()
+	eng := NewEngine(EngineConfig{Runs: 100, Concurrency: 1}, breaker, rec, cleanup)
+
+	res := eng.Run(context.Background(), nil, []Cycle{cyc}, nil)
+
+	if !res.Tripped {
+		t.Fatal("breaker should have tripped on a constantly-failing cycle")
+	}
+	// The breaker trips at 3 consecutive failures. The engine gates work in TWO
+	// places (defense in depth): the producer stops ENQUEUEING once Allow() is
+	// false, and each worker RE-CHECKS before running a task that was already
+	// queued when the trip happened. Together they guarantee work stops almost
+	// immediately after the trip — FAR below the 100 requested iterations.
+	// Removing BOTH guards lets all 100 run (the mutation-proof for this test).
+	// With concurrency=1 and a trip at 3, only a handful of cycles run.
+	if got := atomic.LoadInt32(&runs); got >= 10 {
+		t.Fatalf("breaker did not stop scheduling promptly: ran %d/100 iterations", got)
+	}
+	if got := atomic.LoadInt32(&runs); got < 3 {
+		t.Fatalf("expected at least 3 runs before trip, ran %d", got)
+	}
+}
+
+// TestEngineAlwaysTearsDown proves cleanup ALWAYS runs at the end, even when
+// the breaker trips mid-run: a resource registered by an early iteration must
+// be torn down.
+func TestEngineAlwaysTearsDown(t *testing.T) {
+	var torn int32
+	registering := registerThenFailCycle{torn: &torn}
+
+	breaker := NewBreaker(2, 1.0, 1000)
+	eng := NewEngine(EngineConfig{Runs: 50, Concurrency: 1}, breaker, NewRecorder(), NewCleanup())
+	res := eng.Run(context.Background(), nil, []Cycle{registering}, nil)
+
+	if !res.Tripped {
+		t.Fatal("setup: expected the breaker to trip")
+	}
+	if atomic.LoadInt32(&torn) == 0 {
+		t.Fatal("cleanup must run even when the breaker trips mid-run")
+	}
+}
+
+// registerThenFailCycle registers a teardown, then fails its op, so the breaker
+// trips while there is something to clean up.
+type registerThenFailCycle struct {
+	torn *int32
+}
+
+func (registerThenFailCycle) Name() string { return "reg-fail" }
+func (registerThenFailCycle) Kind() Kind   { return KindWrite }
+func (c registerThenFailCycle) Run(ctx context.Context, _ *client.Client, r *Run) error {
+	r.Cleanup.Register("res", func(context.Context) error {
+		atomic.AddInt32(c.torn, 1)
+		return nil
+	})
+	return r.op(c, "reg-fail.op", func() error { return client.StatusError{Code: 500} })
+}
+
+// TestEngineRespectsGlobalTimeout proves a cancelled context drains the engine
+// promptly (the producer/worker observe ctx.Done()) rather than running all
+// iterations.
+func TestEngineRespectsGlobalTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	var runs int32
+	cyc := countingCycle{name: "x", kind: KindRead, runs: &runs, opErr: nil}
+	eng := NewEngine(EngineConfig{Runs: 100, Concurrency: 2}, NewBreaker(1000, 0.99, 1000), NewRecorder(), NewCleanup())
+	res := eng.Run(ctx, nil, []Cycle{cyc}, nil)
+
+	if got := atomic.LoadInt32(&runs); got >= 100 {
+		t.Fatalf("cancelled context should curtail scheduling, ran %d/100", got)
+	}
+	// Even on cancellation the result is well-formed (not tripped, no panic).
+	if res.Tripped {
+		t.Fatal("a cancelled context must not be reported as a breaker trip")
+	}
+}
+
+// TestEngineTeardownReportedWhenCleanupFails proves teardown failures surface
+// in the result (so main can exit non-zero on a possible orphan).
+func TestEngineTeardownReportedWhenCleanupFails(t *testing.T) {
+	failing := failingTeardownCycle{}
+	eng := NewEngine(EngineConfig{Runs: 1, Concurrency: 1}, NewBreaker(1000, 0.99, 1000), NewRecorder(), NewCleanup())
+	res := eng.Run(context.Background(), nil, []Cycle{failing}, nil)
+	if len(res.TeardownFailed) == 0 {
+		t.Fatal("a failing teardown must be reported in the engine result")
+	}
+}
+
+type failingTeardownCycle struct{}
+
+func (failingTeardownCycle) Name() string { return "ft" }
+func (failingTeardownCycle) Kind() Kind   { return KindWrite }
+func (c failingTeardownCycle) Run(ctx context.Context, _ *client.Client, r *Run) error {
+	r.Cleanup.Register("orphan", func(context.Context) error {
+		return errors.New("cannot delete")
+	})
+	return r.op(c, "ft.op", func() error { return nil })
+}

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -1,0 +1,193 @@
+// Command ct-validate is a parametrizable endpoint validation & resilience
+// harness for the Cloud Temple provider. It exercises the provider's endpoints
+// THROUGH the internal/client library (not through Terraform), runs realistic
+// business cycles, and reports WHERE IT SQUEAKS: per cycle/endpoint success
+// rate, latency p50/p95, and a failure-category histogram.
+//
+// Safety is the reason it exists (incident 2026-06-15: a high-frequency write
+// loop amplified an API outage and orphaned resources). Therefore:
+//   - -write defaults to false: with default flags the tool only READS;
+//   - a circuit breaker is always active and stops launching new work the
+//     moment the API shows distress, then tears down what was created;
+//   - default concurrency is low (2): high concurrency on the SHARED recette
+//     API is dangerous and must be a deliberate choice;
+//   - there are no infinite retries anywhere; teardown is one attempt plus a
+//     small bounded transient-retry.
+//
+// -list and -help work WITHOUT a network and WITHOUT constructing the client.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// buildRegistry assembles every available cycle. Keeping it in one place lets
+// -list, the selector, and the engine share the exact same set.
+func buildRegistry() *Registry {
+	return NewRegistry(
+		readonlyCycle{},
+		backupCycle{},
+		computeOpenIaaSCycle{},
+		vpcCycle{},
+		objectStorageCycle{},
+		iamPATCycle{},
+	)
+}
+
+type flags struct {
+	runs          int
+	concurrency   int
+	cycles        string
+	write         bool
+	timeout       time.Duration
+	abortFailRate float64
+	abortConsec   int
+	abortWindow   int
+	jsonOut       bool
+	list          bool
+	apiSuffix     bool
+}
+
+func parseFlags(args []string, out *os.File) (*flags, error) {
+	fs := flag.NewFlagSet("ct-validate", flag.ContinueOnError)
+	fs.SetOutput(out)
+	f := &flags{}
+	fs.IntVar(&f.runs, "runs", 1, "iterations of each selected cycle")
+	fs.IntVar(&f.concurrency, "concurrency", 2, "worker pool size (HIGH VALUES ARE DANGEROUS on the shared API)")
+	fs.StringVar(&f.cycles, "cycles", "readonly", "comma-separated cycles to run, or \"all\"")
+	fs.BoolVar(&f.write, "write", false, "enable WRITE cycles (skipped by default; only reads run without this)")
+	fs.DurationVar(&f.timeout, "timeout", 30*time.Minute, "global timeout for the whole run")
+	fs.Float64Var(&f.abortFailRate, "abort-failure-rate", 0.30, "trip the breaker when the failure rate over the window reaches this (0..1)")
+	fs.IntVar(&f.abortConsec, "abort-consecutive", 5, "trip the breaker after this many consecutive failures")
+	fs.IntVar(&f.abortWindow, "abort-window", 20, "rolling window size for the failure-rate rule")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit the report as JSON")
+	fs.BoolVar(&f.list, "list", false, "list available cycles and exit (no network)")
+	fs.BoolVar(&f.apiSuffix, "api-suffix", true, "prefix request paths with /api (client ApiSuffix)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(out, "ct-validate — endpoint validation & resilience harness (reads through internal/client)\n\n")
+		fmt.Fprintf(out, "USAGE:\n  ct-validate [flags]\n\n")
+		fmt.Fprintf(out, "SAFETY:\n")
+		fmt.Fprintf(out, "  -write defaults false (reads only). The circuit breaker is always on and stops\n")
+		fmt.Fprintf(out, "  launching work the moment the API squeaks, then tears down. Keep concurrency low\n")
+		fmt.Fprintf(out, "  on the shared recette API.\n\n")
+		fmt.Fprintf(out, "CREDENTIALS (env, only needed to actually run cycles — NOT for -list/-help):\n")
+		fmt.Fprintf(out, "  %s, %s, %s\n\n",
+			client.HTTPClientIDEnvName, client.HTTPClientSecretEnvName, client.HTTPAddrEnvName)
+		fmt.Fprintf(out, "FLAGS:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if err := f.validate(); err != nil {
+		fs.Usage()
+		return nil, err
+	}
+	return f, nil
+}
+
+func (f *flags) validate() error {
+	if f.runs < 1 {
+		return fmt.Errorf("-runs must be >= 1 (got %d)", f.runs)
+	}
+	if f.concurrency < 1 {
+		return fmt.Errorf("-concurrency must be >= 1 (got %d)", f.concurrency)
+	}
+	if f.timeout <= 0 {
+		return fmt.Errorf("-timeout must be > 0 (got %s)", f.timeout)
+	}
+	if f.abortFailRate <= 0 || f.abortFailRate > 1 {
+		return fmt.Errorf("-abort-failure-rate must be in (0,1] (got %g)", f.abortFailRate)
+	}
+	if f.abortConsec < 1 {
+		return fmt.Errorf("-abort-consecutive must be >= 1 (got %d)", f.abortConsec)
+	}
+	if f.abortWindow < 1 {
+		return fmt.Errorf("-abort-window must be >= 1 (got %d)", f.abortWindow)
+	}
+	return nil
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is the testable entrypoint. It returns the process exit code:
+//
+//	0 = success (no failures), 1 = failures present or error, 2 = usage error.
+func run(args []string, stdout, stderr *os.File) int {
+	f, err := parseFlags(args, stderr)
+	if err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		fmt.Fprintf(stderr, "ct-validate: %v\n", err)
+		return 2
+	}
+
+	reg := buildRegistry()
+
+	if f.list {
+		fmt.Fprintln(stdout, "Available cycles:")
+		for _, c := range reg.All() {
+			fmt.Fprintf(stdout, "  %-18s [%s]\n", c.Name(), c.Kind())
+		}
+		fmt.Fprintln(stdout, "\nWrite cycles run only with -write. Default selection is \"readonly\".")
+		return 0
+	}
+
+	selected, gated, err := reg.Select(f.cycles, f.write)
+	if err != nil {
+		fmt.Fprintf(stderr, "ct-validate: %v\n", err)
+		return 2
+	}
+	if len(selected) == 0 {
+		fmt.Fprintf(stderr, "ct-validate: nothing to run (selection %q resolved to no runnable cycles; "+
+			"gated write cycles: %v — pass -write to enable them)\n", f.cycles, gated)
+		return 2
+	}
+
+	// Build the client only now: -list/-help never reach here, so they need no
+	// network and no credentials.
+	cfg := client.DefaultConfig()
+	cfg.ApiSuffix = f.apiSuffix
+	c, err := client.NewClient(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "ct-validate: building client: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), f.timeout)
+	defer cancel()
+
+	breaker := NewBreaker(f.abortConsec, f.abortFailRate, f.abortWindow)
+	rec := NewRecorder()
+	cleanup := NewCleanup()
+	engine := NewEngine(EngineConfig{Runs: f.runs, Concurrency: f.concurrency}, breaker, rec, cleanup)
+
+	res := engine.Run(ctx, c, selected, gated)
+
+	if f.jsonOut {
+		if err := PrintJSON(stdout, res); err != nil {
+			fmt.Fprintf(stderr, "ct-validate: encoding JSON: %v\n", err)
+			return 1
+		}
+	} else {
+		PrintText(stdout, res)
+	}
+
+	// CI/automation friendly: non-zero if any cycle had failures, a teardown
+	// failed (possible orphan), or the breaker tripped.
+	if HasFailure(res.Stats) || len(res.TeardownFailed) > 0 || res.Tripped {
+		return 1
+	}
+	return 0
+}

--- a/cmd/ct-validate/report.go
+++ b/cmd/ct-validate/report.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+	"time"
+)
+
+// squeakThreshold is the success-rate ceiling below which an endpoint is
+// flagged in the "WHERE IT SQUEAKS" summary. Anything at or below this is
+// considered a hot spot worth an operator's eyes.
+const squeakThreshold = 1.0
+
+// jsonReport is the machine-readable shape emitted with -json.
+type jsonReport struct {
+	Selected   []string              `json:"selected_cycles"`
+	GatedWrite []string              `json:"gated_write_cycles,omitempty"`
+	Tripped    bool                  `json:"circuit_tripped"`
+	TripReason string                `json:"trip_reason,omitempty"`
+	Squeaks    []squeak              `json:"where_it_squeaks"`
+	Endpoints  []jsonEndpoint        `json:"endpoints"`
+	Teardown   []jsonTeardownFailure `json:"teardown_failures,omitempty"`
+	HasFailure bool                  `json:"has_failure"`
+}
+
+type squeak struct {
+	Cycle       string  `json:"cycle"`
+	Endpoint    string  `json:"endpoint"`
+	SuccessRate float64 `json:"success_rate"`
+	Total       int     `json:"total"`
+}
+
+type jsonEndpoint struct {
+	Cycle       string           `json:"cycle"`
+	Endpoint    string           `json:"endpoint"`
+	Total       int              `json:"total"`
+	OK          int              `json:"ok"`
+	Skipped     int              `json:"skipped"`
+	SuccessRate float64          `json:"success_rate"`
+	P50ms       float64          `json:"p50_ms"`
+	P95ms       float64          `json:"p95_ms"`
+	Reasons     map[Category]int `json:"reasons"`
+}
+
+type jsonTeardownFailure struct {
+	Label    string `json:"label"`
+	Attempts int    `json:"attempts"`
+	Error    string `json:"error"`
+}
+
+// HasFailure reports whether any recorded endpoint had at least one failure
+// (skips and successes excluded). It is the basis for the process exit code,
+// so the tool is CI/automation friendly.
+func HasFailure(stats []EndpointStats) bool {
+	for _, s := range stats {
+		attempted := s.Total - s.Skipped
+		if attempted > 0 && s.OK < attempted {
+			return true
+		}
+	}
+	return false
+}
+
+// squeaks returns the endpoints with the worst success rate (rate <
+// squeakThreshold), worst first, then by cycle/endpoint for stability.
+func squeaks(stats []EndpointStats) []squeak {
+	var out []squeak
+	for _, s := range stats {
+		rate := s.SuccessRate()
+		if rate < squeakThreshold {
+			out = append(out, squeak{
+				Cycle:       s.Cycle,
+				Endpoint:    s.Endpoint,
+				SuccessRate: rate,
+				Total:       s.Total,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SuccessRate != out[j].SuccessRate {
+			return out[i].SuccessRate < out[j].SuccessRate
+		}
+		if out[i].Cycle != out[j].Cycle {
+			return out[i].Cycle < out[j].Cycle
+		}
+		return out[i].Endpoint < out[j].Endpoint
+	})
+	return out
+}
+
+// topReasons returns up to n failure categories (excluding OK and Skipped),
+// most frequent first, formatted as "category=count".
+func topReasons(reasons map[Category]int, n int) string {
+	type kv struct {
+		cat Category
+		cnt int
+	}
+	var kvs []kv
+	for cat, cnt := range reasons {
+		if cat == CategoryOK || cat == CategorySkipped {
+			continue
+		}
+		kvs = append(kvs, kv{cat, cnt})
+	}
+	sort.Slice(kvs, func(i, j int) bool {
+		if kvs[i].cnt != kvs[j].cnt {
+			return kvs[i].cnt > kvs[j].cnt
+		}
+		return kvs[i].cat < kvs[j].cat
+	})
+	if len(kvs) == 0 {
+		return "-"
+	}
+	out := ""
+	for i, e := range kvs {
+		if i >= n {
+			break
+		}
+		if i > 0 {
+			out += " "
+		}
+		out += fmt.Sprintf("%s=%d", e.cat, e.cnt)
+	}
+	return out
+}
+
+func msFloat(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}
+
+// PrintText renders the human-readable report to w.
+func PrintText(w io.Writer, res EngineResult) {
+	fmt.Fprintln(w, "==================== ct-validate report ====================")
+	fmt.Fprintf(w, "Cycles run: %v\n", res.SelectedCycles)
+	if len(res.GatedWriteSkips) > 0 {
+		fmt.Fprintf(w, "Write cycles GATED (no -write): %v\n", res.GatedWriteSkips)
+	}
+	if res.Tripped {
+		fmt.Fprintf(w, "CIRCUIT BREAKER TRIPPED: %s\n", res.TripReason)
+		fmt.Fprintln(w, "  -> the engine stopped launching new work and tore down. Treat the API as in distress.")
+	}
+	fmt.Fprintln(w)
+
+	sq := squeaks(res.Stats)
+	fmt.Fprintln(w, "---- WHERE IT SQUEAKS (worst success rate first) ----")
+	if len(sq) == 0 {
+		fmt.Fprintln(w, "  (nothing squeaked: every attempted endpoint succeeded)")
+	} else {
+		for _, s := range sq {
+			fmt.Fprintf(w, "  %-6.1f%%  %s / %s  (n=%d)\n", s.SuccessRate*100, s.Cycle, s.Endpoint, s.Total)
+		}
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "---- per-endpoint ----")
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "CYCLE\tENDPOINT\tRUNS\tOK%\tP50(ms)\tP95(ms)\tTOP FAILURES")
+	for _, s := range res.Stats {
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%.0f\t%.1f\t%.1f\t%s\n",
+			s.Cycle, s.Endpoint, s.Total, s.SuccessRate()*100,
+			msFloat(s.P50), msFloat(s.P95), topReasons(s.Reasons, 3))
+	}
+	tw.Flush()
+
+	if len(res.TeardownFailed) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "---- TEARDOWN FAILURES (possible orphans — investigate) ----")
+		for _, f := range res.TeardownFailed {
+			fmt.Fprintf(w, "  %s (after %d attempt(s)): %v\n", f.Label, f.Attempts, f.Err)
+		}
+	}
+
+	fmt.Fprintln(w)
+	if HasFailure(res.Stats) {
+		fmt.Fprintln(w, "RESULT: FAILURES PRESENT (exit non-zero)")
+	} else {
+		fmt.Fprintln(w, "RESULT: all attempted endpoints succeeded")
+	}
+}
+
+// PrintJSON renders the machine-readable report to w.
+func PrintJSON(w io.Writer, res EngineResult) error {
+	rep := jsonReport{
+		Selected:   res.SelectedCycles,
+		GatedWrite: res.GatedWriteSkips,
+		Tripped:    res.Tripped,
+		TripReason: res.TripReason,
+		Squeaks:    squeaks(res.Stats),
+		HasFailure: HasFailure(res.Stats),
+	}
+	for _, s := range res.Stats {
+		rep.Endpoints = append(rep.Endpoints, jsonEndpoint{
+			Cycle:       s.Cycle,
+			Endpoint:    s.Endpoint,
+			Total:       s.Total,
+			OK:          s.OK,
+			Skipped:     s.Skipped,
+			SuccessRate: s.SuccessRate(),
+			P50ms:       msFloat(s.P50),
+			P95ms:       msFloat(s.P95),
+			Reasons:     s.Reasons,
+		})
+	}
+	for _, f := range res.TeardownFailed {
+		msg := ""
+		if f.Err != nil {
+			msg = f.Err.Error()
+		}
+		rep.Teardown = append(rep.Teardown, jsonTeardownFailure{
+			Label:    f.Label,
+			Attempts: f.Attempts,
+			Error:    msg,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rep)
+}

--- a/cmd/ct-validate/report_test.go
+++ b/cmd/ct-validate/report_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSqueaksOrderedWorstFirst(t *testing.T) {
+	stats := []EndpointStats{
+		{Cycle: "readonly", Endpoint: "good", Total: 4, OK: 4},       // 100% — not a squeak
+		{Cycle: "readonly", Endpoint: "mid", Total: 4, OK: 2},        // 50%
+		{Cycle: "readonly", Endpoint: "bad", Total: 4, OK: 0},        // 0%
+		{Cycle: "readonly", Endpoint: "skips", Total: 2, Skipped: 2}, // 100% (skips) — not a squeak
+	}
+	sq := squeaks(stats)
+	if len(sq) != 2 {
+		t.Fatalf("want 2 squeaks (mid,bad), got %d: %+v", len(sq), sq)
+	}
+	// Worst (0%) must come first.
+	if sq[0].Endpoint != "bad" || sq[1].Endpoint != "mid" {
+		t.Fatalf("squeaks not worst-first: %+v", sq)
+	}
+}
+
+func TestTopReasonsExcludesOKAndSkipped(t *testing.T) {
+	reasons := map[Category]int{
+		CategoryOK:               10,
+		CategorySkipped:          3,
+		CategoryHTTP5xx:          5,
+		CategoryBadGateway502:    2,
+		CategoryTransientWorkers: 1,
+	}
+	got := topReasons(reasons, 2)
+	if strings.Contains(got, "ok") || strings.Contains(got, "skipped") {
+		t.Fatalf("topReasons leaked ok/skipped: %q", got)
+	}
+	// Most frequent first, capped at 2.
+	if !strings.HasPrefix(got, "http_5xx=5") {
+		t.Fatalf("topReasons should lead with the most frequent failure: %q", got)
+	}
+	if strings.Count(got, "=") != 2 {
+		t.Fatalf("topReasons should cap at 2 entries: %q", got)
+	}
+}
+
+func TestTopReasonsNoFailures(t *testing.T) {
+	if got := topReasons(map[Category]int{CategoryOK: 5}, 3); got != "-" {
+		t.Fatalf("no failures should render as '-', got %q", got)
+	}
+}
+
+func TestPrintTextSurfacesTripAndSqueaks(t *testing.T) {
+	res := EngineResult{
+		SelectedCycles: []string{"readonly"},
+		Tripped:        true,
+		TripReason:     "5 consecutive failures (limit 5)",
+		Stats: []EndpointStats{
+			{Cycle: "readonly", Endpoint: "vpc.vpc.list", Total: 5, OK: 1, Reasons: map[Category]int{CategoryBadGateway502: 4, CategoryOK: 1}},
+		},
+	}
+	var buf bytes.Buffer
+	PrintText(&buf, res)
+	out := buf.String()
+	for _, want := range []string{"CIRCUIT BREAKER TRIPPED", "WHERE IT SQUEAKS", "vpc.vpc.list", "FAILURES PRESENT"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text report missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintJSONShape(t *testing.T) {
+	res := EngineResult{
+		SelectedCycles:  []string{"readonly"},
+		GatedWriteSkips: []string{"vpc"},
+		Stats: []EndpointStats{
+			{Cycle: "readonly", Endpoint: "iam.users.list", Total: 2, OK: 1, Reasons: map[Category]int{CategoryHTTP5xx: 1, CategoryOK: 1}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := PrintJSON(&buf, res); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	var rep jsonReport
+	if err := json.Unmarshal(buf.Bytes(), &rep); err != nil {
+		t.Fatalf("JSON not parseable: %v\n%s", err, buf.String())
+	}
+	if !rep.HasFailure {
+		t.Fatal("JSON has_failure should be true (one endpoint at 50%)")
+	}
+	if len(rep.Endpoints) != 1 || rep.Endpoints[0].SuccessRate != 0.5 {
+		t.Fatalf("JSON endpoint shape wrong: %+v", rep.Endpoints)
+	}
+	if len(rep.GatedWrite) != 1 || rep.GatedWrite[0] != "vpc" {
+		t.Fatalf("JSON gated_write_cycles wrong: %+v", rep.GatedWrite)
+	}
+}

--- a/cmd/ct-validate/stats.go
+++ b/cmd/ct-validate/stats.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Op is a single recorded operation: one call of one endpoint inside one
+// cycle iteration. It is the atomic unit the recorder aggregates.
+type Op struct {
+	Cycle    string
+	Endpoint string
+	OK       bool
+	Skipped  bool
+	Latency  time.Duration
+	Category Category
+}
+
+// Recorder collects Op records concurrently and aggregates them per
+// (cycle, endpoint). It is safe for concurrent use by the worker pool.
+//
+// The aggregation maths (success rate, percentiles, category histogram) is
+// PURE: it depends only on the recorded slice, never on wall-clock time or
+// network state, so it is fully unit-testable offline.
+type Recorder struct {
+	mu  sync.Mutex
+	ops []Op
+}
+
+// NewRecorder returns an empty recorder.
+func NewRecorder() *Recorder {
+	return &Recorder{}
+}
+
+// Record appends a single operation. Safe for concurrent callers.
+func (r *Recorder) Record(op Op) {
+	r.mu.Lock()
+	r.ops = append(r.ops, op)
+	r.mu.Unlock()
+}
+
+// Ops returns a copy of the recorded operations, in insertion order.
+func (r *Recorder) Ops() []Op {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Op, len(r.ops))
+	copy(out, r.ops)
+	return out
+}
+
+// EndpointStats is the aggregate for one (cycle, endpoint) pair.
+type EndpointStats struct {
+	Cycle    string           `json:"cycle"`
+	Endpoint string           `json:"endpoint"`
+	Total    int              `json:"total"`
+	OK       int              `json:"ok"`
+	Skipped  int              `json:"skipped"`
+	P50      time.Duration    `json:"p50_ns"`
+	P95      time.Duration    `json:"p95_ns"`
+	Reasons  map[Category]int `json:"reasons"`
+}
+
+// SuccessRate is the fraction of non-skipped attempts that succeeded, in
+// [0,1]. Skipped operations are excluded from both numerator and denominator
+// so a deliberately skipped sub-step never looks like a failure. When every
+// attempt was skipped, the rate is 1 (nothing failed).
+func (s EndpointStats) SuccessRate() float64 {
+	attempted := s.Total - s.Skipped
+	if attempted <= 0 {
+		return 1
+	}
+	return float64(s.OK) / float64(attempted)
+}
+
+// percentile returns the p-th percentile (0..100) of durations using the
+// nearest-rank method on a sorted copy. It is the single source of truth for
+// p50/p95 so the engine and the report can never disagree.
+//
+// Nearest-rank: rank = ceil(p/100 * n), clamped to [1, n]; the value at that
+// 1-based rank is returned. For an empty input it returns 0.
+func percentile(durations []time.Duration, p float64) time.Duration {
+	n := len(durations)
+	if n == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, n)
+	copy(sorted, durations)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[n-1]
+	}
+	// Nearest-rank: ceil(p/100 * n) without floating-point rounding surprises.
+	rank := int((p*float64(n) + 99.999999) / 100)
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > n {
+		rank = n
+	}
+	return sorted[rank-1]
+}
+
+// Aggregate folds the recorded operations into per-(cycle,endpoint) stats.
+// Latency percentiles are computed only over OK operations (a failed call's
+// latency is noise, not a service-level signal). Skipped operations count in
+// Total/Skipped but never in OK and never in the latency sample.
+//
+// The returned slice is deterministically ordered by cycle then endpoint so
+// the table and the JSON output are stable across runs.
+func Aggregate(ops []Op) []EndpointStats {
+	type key struct{ cycle, endpoint string }
+	type bucket struct {
+		stats     EndpointStats
+		latencies []time.Duration
+	}
+	buckets := map[key]*bucket{}
+
+	for _, op := range ops {
+		k := key{op.Cycle, op.Endpoint}
+		b := buckets[k]
+		if b == nil {
+			b = &bucket{stats: EndpointStats{
+				Cycle:    op.Cycle,
+				Endpoint: op.Endpoint,
+				Reasons:  map[Category]int{},
+			}}
+			buckets[k] = b
+		}
+		b.stats.Total++
+		if op.Skipped {
+			b.stats.Skipped++
+		}
+		if op.OK {
+			b.stats.OK++
+			b.latencies = append(b.latencies, op.Latency)
+		}
+		// Record the category for every op (including OK→CategoryOK and
+		// Skipped→CategorySkipped) so the histogram is complete.
+		b.stats.Reasons[op.Category]++
+	}
+
+	out := make([]EndpointStats, 0, len(buckets))
+	for _, b := range buckets {
+		b.stats.P50 = percentile(b.latencies, 50)
+		b.stats.P95 = percentile(b.latencies, 95)
+		out = append(out, b.stats)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cycle != out[j].Cycle {
+			return out[i].Cycle < out[j].Cycle
+		}
+		return out[i].Endpoint < out[j].Endpoint
+	})
+	return out
+}

--- a/cmd/ct-validate/stats_test.go
+++ b/cmd/ct-validate/stats_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func ms(n int) time.Duration { return time.Duration(n) * time.Millisecond }
+
+func TestPercentileNearestRank(t *testing.T) {
+	// 1..10 ms. Nearest-rank p50 of 10 = ceil(0.5*10)=5th value = 5ms.
+	// p95 = ceil(0.95*10)=10th value = 10ms.
+	d := []time.Duration{ms(1), ms(2), ms(3), ms(4), ms(5), ms(6), ms(7), ms(8), ms(9), ms(10)}
+	if got := percentile(d, 50); got != ms(5) {
+		t.Errorf("p50 = %v, want 5ms", got)
+	}
+	if got := percentile(d, 95); got != ms(10) {
+		t.Errorf("p95 = %v, want 10ms", got)
+	}
+}
+
+// TestPercentileUnsortedInput proves percentile sorts a copy: an out-of-order
+// input must give the same answer as the sorted one, and must NOT mutate the
+// caller's slice. The input is chosen so the element at the p50 nearest-rank
+// position (index 2) DIFFERS between the unsorted and sorted orders: unsorted
+// [10,50,40,20,30][2] = 40ms, but the true p50 is 30ms. A mutation that drops
+// the internal sort returns 40ms and turns this RED.
+func TestPercentileUnsortedInput(t *testing.T) {
+	in := []time.Duration{ms(10), ms(50), ms(40), ms(20), ms(30)}
+	orig := append([]time.Duration(nil), in...)
+	if got := percentile(in, 50); got != ms(30) {
+		t.Errorf("p50 of shuffled = %v, want 30ms (sorted median)", got)
+	}
+	for i := range in {
+		if in[i] != orig[i] {
+			t.Fatalf("percentile mutated caller's slice at %d: %v != %v", i, in[i], orig[i])
+		}
+	}
+}
+
+func TestPercentileEdges(t *testing.T) {
+	if got := percentile(nil, 50); got != 0 {
+		t.Errorf("empty p50 = %v, want 0", got)
+	}
+	one := []time.Duration{ms(7)}
+	if got := percentile(one, 95); got != ms(7) {
+		t.Errorf("single-element p95 = %v, want 7ms", got)
+	}
+	if got := percentile(one, 0); got != ms(7) {
+		t.Errorf("p0 = %v, want min 7ms", got)
+	}
+}
+
+func TestSuccessRate(t *testing.T) {
+	cases := []struct {
+		name  string
+		stats EndpointStats
+		want  float64
+	}{
+		{"all ok", EndpointStats{Total: 4, OK: 4}, 1.0},
+		{"half", EndpointStats{Total: 4, OK: 2}, 0.5},
+		{"skips excluded", EndpointStats{Total: 4, OK: 2, Skipped: 2}, 1.0}, // 2 ok / 2 attempted
+		{"all skipped is 1", EndpointStats{Total: 3, OK: 0, Skipped: 3}, 1.0},
+		{"none at all is 1", EndpointStats{}, 1.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.stats.SuccessRate(); got != c.want {
+				t.Fatalf("SuccessRate = %g, want %g", got, c.want)
+			}
+		})
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	ops := []Op{
+		{Cycle: "readonly", Endpoint: "iam.users.list", OK: true, Latency: ms(10), Category: CategoryOK},
+		{Cycle: "readonly", Endpoint: "iam.users.list", OK: true, Latency: ms(30), Category: CategoryOK},
+		{Cycle: "readonly", Endpoint: "iam.users.list", OK: false, Latency: ms(999), Category: CategoryHTTP5xx},
+		{Cycle: "readonly", Endpoint: "vpc.vpc.list", OK: false, Latency: ms(2), Category: CategoryBadGateway502},
+		{Cycle: "readonly", Endpoint: "iam.users.read", Skipped: true, Category: CategorySkipped},
+	}
+	stats := Aggregate(ops)
+
+	// Deterministic ordering: iam.users.list, iam.users.read, vpc.vpc.list.
+	if len(stats) != 3 {
+		t.Fatalf("want 3 endpoint groups, got %d", len(stats))
+	}
+	if stats[0].Endpoint != "iam.users.list" || stats[1].Endpoint != "iam.users.read" || stats[2].Endpoint != "vpc.vpc.list" {
+		t.Fatalf("aggregate not sorted by cycle/endpoint: %+v", stats)
+	}
+
+	list := stats[0]
+	if list.Total != 3 || list.OK != 2 {
+		t.Fatalf("iam.users.list totals: total=%d ok=%d", list.Total, list.OK)
+	}
+	// Percentiles computed ONLY over OK latencies (10ms, 30ms), so the failed
+	// 999ms must NOT pollute them. A mutation that includes failed latencies
+	// would push p95 to 999ms.
+	if list.P95 == ms(999) {
+		t.Fatal("failed-op latency (999ms) leaked into the OK percentile sample")
+	}
+	if list.P50 != ms(10) || list.P95 != ms(30) {
+		t.Fatalf("OK-only percentiles: p50=%v p95=%v (want 10ms/30ms)", list.P50, list.P95)
+	}
+	if list.Reasons[CategoryHTTP5xx] != 1 || list.Reasons[CategoryOK] != 2 {
+		t.Fatalf("reason histogram wrong: %+v", list.Reasons)
+	}
+
+	// Skipped endpoint: Total counts it, Skipped counts it, OK does not.
+	read := stats[1]
+	if read.Total != 1 || read.Skipped != 1 || read.OK != 0 {
+		t.Fatalf("skipped endpoint accounting wrong: %+v", read)
+	}
+}
+
+func TestHasFailure(t *testing.T) {
+	clean := []EndpointStats{{Total: 3, OK: 3}, {Total: 2, OK: 0, Skipped: 2}}
+	if HasFailure(clean) {
+		t.Fatal("clean stats (all ok or all skipped) must not report failure")
+	}
+	dirty := []EndpointStats{{Total: 3, OK: 3}, {Total: 2, OK: 1}}
+	if !HasFailure(dirty) {
+		t.Fatal("a partially-failing endpoint must report failure")
+	}
+}


### PR DESCRIPTION
Refs #316
Refs #300

A parametrizable Go CLI (`cmd/ct-validate`) that exercises the provider's endpoints through `internal/client` and reports **where it squeaks**: per cycle/endpoint success rate, latency p50/p95, and a failure-category histogram (transient ComputeManager / 502 / 4xx / 5xx / timeout). Built after the 2026-06-15 VPC write reliability incident.

## Coverage
- **Read sweep** (safe, default): the List/Read endpoints across all 8 services (Activity, Backup, Compute VMware/OpenIaaS, IAM, Marketplace, ObjectStorage, Tag, VPC).
- **Write cycles** (opt-in `-write`): VPC (static IP → bind FIP → unbind → delete), Object Storage (bucket → ACL → delete), IAM PAT (create → read → delete). Compute & Backup ship as read-validate with a documented `TODO(#316)` for the full VM lifecycle (no orphan risk).

## Safety (the point of the tool)
- `-write` off by default; low default concurrency; **circuit breaker** always active (trips on consecutive failures OR rolling failure rate, latching, gates each op **mid-cycle**); **guaranteed teardown** (deferred + per-worker panic recover that trips the breaker; pre-create registration keyed deterministically; bounded cleanup context; **404-only idempotency** with strict fail-closed corroboration for static IP/FIP per #312/#309).

## Flags
`-runs`, `-concurrency`, `-cycles`, `-write`, `-timeout`, `-abort-failure-rate`, `-abort-consecutive`, `-abort-window`, `-json`, `-list`, `-api-suffix`.

## Validation
- Adversarial **Codex DIFF**: round 1 (4 blocking safety findings) → round 2 (F3 idempotency) → **round 3 GO**. Every guard **mutation-proven RED**.
- Gates: gofmt/vet/build, staticcheck@2025.1.1 (0), `-race` (80 tests), schema golden untouched, coverage ratchet unaffected (`cmd/` not in the pure-package list).
- Built and tested **offline** (no live calls). Live runs of the tool will be done separately, carefully, read-only first.