### PR TITLE
ct-validate: hardening + trustworthy read map + OpenIaaS & VMware compute write lifecycles (first-live-run readiness)

### DIFF
--- a/cmd/ct-validate/README.md
+++ b/cmd/ct-validate/README.md
@@ -1,0 +1,126 @@
+# ct-validate — Cloud Temple API check & resilience tool
+
+`ct-validate` checks that the Cloud Temple API behaves correctly and stays
+responsive. It runs realistic business scenarios — read-only checks and,
+on request, full create-and-clean-up lifecycles — directly against the API
+(through the provider's `internal/client` library), and produces a clear
+per-endpoint health report: success rate, latency (p50/p95), and a breakdown of
+any errors.
+
+It can also replay a scenario repeatedly and in parallel to observe how the API
+holds up under increasing load.
+
+## Safe by design
+
+- **Read-only by default** — it only reads unless you explicitly ask for write
+  scenarios.
+- **Automatic back-off** — a built-in circuit breaker eases off and stops
+  launching new work as soon as the API shows signs of strain, then reports
+  where.
+- **Cleans up after itself** — every resource a write scenario creates is
+  automatically removed, even if a run is interrupted.
+- **Sensible limits** — conservative defaults (low concurrency, a single run)
+  and built-in ceilings keep a run bounded.
+
+## Two ways to run it
+
+| | What | When |
+|---|---|---|
+| `scripts/ct-test.sh` | A simple wrapper: loads your credentials, targets the API, no flags to remember. | Everyday use. |
+| `go run ./cmd/ct-validate` (or a built binary) | The tool itself, with every option exposed. | Fine-grained control / CI. |
+
+### Quick start (the wrapper)
+
+```sh
+scripts/ct-test.sh list            # show the available scenarios
+scripts/ct-test.sh api readonly    # read every service and report its health
+scripts/ct-test.sh api vpc         # VPC: create → verify → remove
+scripts/ct-test.sh api storage     # object storage: create → verify → remove
+scripts/ct-test.sh api vm          # full VM lifecycle: create → verify → remove
+scripts/ct-test.sh tf  <scenario>  # run the same scenario through Terraform
+```
+
+`api` exercises the API directly. `tf` runs the scenario through Terraform
+(`apply` then `destroy`), which additionally validates the provider end to end.
+
+### Running the tool directly
+
+```sh
+go run ./cmd/ct-validate -list                    # list scenarios (no network)
+go run ./cmd/ct-validate -cycles readonly -json   # a read-only health report
+```
+
+## Scenarios
+
+| Scenario | Type | What it does |
+|---|---|---|
+| `readonly` | read | Lists every service and reads a sample item — the broad health map. |
+| `backup` | read | Backup service reads. |
+| `compute_openiaas` | read | OpenIaaS compute reads. |
+| `vpc` | write | Allocate a VPC static IP and a floating-IP binding, verify, then remove. |
+| `object_storage` | write | Create a bucket, a storage account and an ACL, verify, then remove. |
+| `iam_pat` | write | Create a personal access token, verify, then remove. |
+| `compute_lifecycle` | write | Create a VM from a template, attach a disk and a network adapter, then remove everything. |
+
+Write scenarios run only when you pass `-write`; otherwise they are listed and
+skipped.
+
+## Options
+
+| Option | Default | Meaning |
+|---|---|---|
+| `-cycles` | `readonly` | Comma-separated scenario names, or `all`. |
+| `-write` | `false` | Enable the write scenarios (they create and remove resources). |
+| `-runs` | `1` | How many times to repeat each scenario (up to 10000). |
+| `-concurrency` | `2` | Number of parallel workers (up to 64). |
+| `-timeout` | `30m` | Overall time limit for the run. |
+| `-abort-consecutive` | `5` | Back off after this many consecutive failures. |
+| `-abort-failure-rate` | `0.30` | Back off when the failure rate over the window reaches this. |
+| `-abort-window` | `20` | Size of the rolling window for the rate above. |
+| `-json` | `false` | Emit the report as JSON. |
+| `-list` | `false` | List scenarios and exit (no network, no credentials). |
+| `-api-suffix` | `true` | Prefix request paths with `/api`. |
+
+## Credentials
+
+Provide your Cloud Temple personal access token and the API host via environment
+variables:
+
+| Variable | Meaning |
+|---|---|
+| `CLOUDTEMPLE_CLIENT_ID` / `CLOUDTEMPLE_SECRET_ID` | Your personal access token. The tenant is determined by the token. |
+| `CLOUDTEMPLE_HTTP_ADDR` | API host (e.g. `shiva.cloud-temple.com`). Use the API hostname, not your web-console URL. |
+| `CLOUDTEMPLE_HTTP_SCHEME` | `https`. |
+
+Before sending anything, the tool prints the resolved target so you can confirm
+it, requires HTTPS, and checks that your credentials are set.
+
+## The report
+
+For each endpoint the report shows the success rate, latency (p50/p95) and a
+breakdown of outcomes. A short **"where it squeaks"** section lists the
+endpoints that did not return 100% success, worst first.
+
+How to read it:
+
+- A **5xx / timeout** points to a real server-side issue worth reporting.
+- A **4xx** is a client-side result — most often a **service this tenant does
+  not use** (for example VMware on an OpenIaaS-only tenant), which is expected.
+
+Exit code: `0` if every endpoint succeeded, `1` if anything failed or the tool
+backed off, `2` for a configuration error.
+
+## Observing behaviour under load
+
+To see how the API behaves as load increases, replay a scenario and raise the
+load gradually between runs:
+
+```sh
+… -cycles compute_lifecycle -write -runs 20 -concurrency 2
+… -cycles compute_lifecycle -write -runs 20 -concurrency 4
+… -cycles compute_lifecycle -write -runs 20 -concurrency 8
+```
+
+The tool eases off automatically if the API starts to strain and reports exactly
+where, so you can find the comfortable operating range without overloading the
+service. For deliberate stress testing, point it at a dedicated environment.

--- a/cmd/ct-validate/README.md
+++ b/cmd/ct-validate/README.md
@@ -7,6 +7,10 @@ on request, full create-and-clean-up lifecycles — directly against the API
 per-endpoint health report: success rate, latency (p50/p95), and a breakdown of
 any errors.
 
+As it runs, it streams each endpoint live — a running counter, the outcome
+(`ok` / `skip` / `FAIL`) and the latency — so you always see what it is doing
+(pass `-quiet` to show only the final report).
+
 It can also replay a scenario repeatedly and in parallel to observe how the API
 holds up under increasing load.
 

--- a/cmd/ct-validate/README.md
+++ b/cmd/ct-validate/README.md
@@ -36,12 +36,38 @@ holds up under increasing load.
 ### Quick start (the wrapper)
 
 ```sh
-scripts/ct-test.sh list            # show the available scenarios
-scripts/ct-test.sh api readonly    # read every service and report its health
-scripts/ct-test.sh api vpc         # VPC: create → verify → remove
-scripts/ct-test.sh api storage     # object storage: create → verify → remove
-scripts/ct-test.sh api vm          # full VM lifecycle: create → verify → remove
-scripts/ct-test.sh tf  <scenario>  # run the same scenario through Terraform
+scripts/ct-test.sh list                       # show the available scenarios
+scripts/ct-test.sh api readonly                # read every service and report its health
+scripts/ct-test.sh api vpc                     # VPC: create → verify → remove
+scripts/ct-test.sh api storage                 # object storage: create → verify → remove
+scripts/ct-test.sh api vm                      # OpenIaaS VM lifecycle: create → verify → remove
+scripts/ct-test.sh --tenant vmware api vm-vmware   # VMware VM lifecycle: create → verify → remove
+scripts/ct-test.sh tf  <scenario>             # run the same scenario through Terraform
+```
+
+### Choosing the tenant (VMware or OpenIaaS)
+
+The API host is the same for every tenant — the tenant is determined by the
+credentials, not the URL. Pick which credentials to use with `--tenant`:
+
+```sh
+scripts/ct-test.sh --tenant openiaas api vm        # default
+scripts/ct-test.sh --tenant vmware   api vm-vmware
+```
+
+Point each tenant at its credentials file with `CT_ENV_OPENIAAS` /
+`CT_ENV_VMWARE` (or `CT_TEST_ENV` to override directly). A read-only scenario
+(`readonly`) exercises whichever services the tenant actually has — VMware
+endpoints on a VMware tenant, OpenIaaS endpoints on an OpenIaaS one — and quietly
+skips the ones it does not.
+
+### Repetition and parallelism (bounded load)
+
+In `api` mode, any flags after the scenario are forwarded to the runner, so you
+can replay a scenario and raise the load gradually:
+
+```sh
+scripts/ct-test.sh --tenant vmware api vm-vmware -runs 20 -concurrency 4
 ```
 
 `api` exercises the API directly. `tf` runs the scenario through Terraform
@@ -64,7 +90,8 @@ go run ./cmd/ct-validate -cycles readonly -json   # a read-only health report
 | `vpc` | write | Allocate a VPC static IP and a floating-IP binding, verify, then remove. |
 | `object_storage` | write | Create a bucket, a storage account and an ACL, verify, then remove. |
 | `iam_pat` | write | Create a personal access token, verify, then remove. |
-| `compute_lifecycle` | write | Create a VM from a template, attach a disk and a network adapter, then remove everything. |
+| `compute_lifecycle` | write | OpenIaaS: create a VM from a template, attach a disk and a network adapter, then remove everything. |
+| `compute_vmware_lifecycle` | write | VMware: create a VM (discovered datacenter/host/datastore/guest-OS), attach a disk and a network adapter, then remove everything. |
 
 Write scenarios run only when you pass `-write`; otherwise they are listed and
 skipped.

--- a/cmd/ct-validate/categorize.go
+++ b/cmd/ct-validate/categorize.go
@@ -24,8 +24,14 @@ const (
 	// CategoryBadGateway502 is a 502 / gateway / config-load failure, the
 	// signature of the 2026-06-15 sustained API outage.
 	CategoryBadGateway502 Category = "bad_gateway_502"
+	// CategoryRateLimited is HTTP 429 Too Many Requests. It is a 4xx by status
+	// but, unlike the other client errors, it IS a distress signal ("back off"),
+	// so it is split out and DOES trip the breaker (see isDistress).
+	CategoryRateLimited Category = "rate_limited"
 	// CategoryHTTP4xx is a client-side HTTP status (400-499) other than ones
-	// captured by a more specific category.
+	// captured by a more specific category (e.g. 429). These are deterministic
+	// client errors (bad request, not authorized, forbidden, not found,
+	// conflict) — a real failure to report, but NOT API distress.
 	CategoryHTTP4xx Category = "http_4xx"
 	// CategoryHTTP5xx is a server-side HTTP status (500-599) other than 502.
 	CategoryHTTP5xx Category = "http_5xx"
@@ -45,9 +51,10 @@ const (
 //  3. transient workers → TransientWorkers (platform-recoverable).
 //  4. 502 / bad gateway → BadGateway502 (the outage signature; checked before
 //     the generic 5xx bucket so it is never swallowed by it).
-//  5. StatusError 4xx   → HTTP4xx
-//  6. StatusError 5xx   → HTTP5xx
-//  7. fallback          → Other
+//  5. StatusError 429   → RateLimited (a 4xx, but a "back off" distress signal)
+//  6. StatusError 4xx   → HTTP4xx
+//  7. StatusError 5xx   → HTTP5xx
+//  8. fallback          → Other
 //
 // Every branch is exercised by a mutation-proven unit test.
 func categorize(err error) Category {
@@ -76,6 +83,8 @@ func categorize(err error) Category {
 	var statusErr client.StatusError
 	if errors.As(err, &statusErr) {
 		switch {
+		case statusErr.Code == 429:
+			return CategoryRateLimited
 		case statusErr.Code >= 400 && statusErr.Code <= 499:
 			return CategoryHTTP4xx
 		case statusErr.Code >= 500 && statusErr.Code <= 599:
@@ -86,6 +95,29 @@ func categorize(err error) Category {
 	return CategoryOther
 }
 
+// isDistress reports whether a category indicates the shared API is in DISTRESS,
+// so the circuit breaker should trip and stop launching work. It is deliberately
+// NARROWER than "is this a failure": a deterministic client error (HTTP 4xx —
+// tenant not entitled to a service, missing filter, 404, conflict) is a real
+// failure to REPORT, but it is NOT distress and must not trip the breaker and
+// mask the rest of the map. Rate limiting (429) and server/transport distress DO
+// trip. OK and Skipped are never distress.
+//
+// CategoryOther (transport error without a status, or an unexpected
+// decode/contract error) is treated as distress on purpose: fail-safe, an
+// UNCLASSIFIED error against a shared API is a reason to back off. A deterministic
+// decode error could in theory re-trip like the old 4xx did; if that ever shows
+// up in practice, split Other into transport vs decode and only trip on transport.
+func (c Category) isDistress() bool {
+	switch c {
+	case CategoryTransientWorkers, CategoryBadGateway502, CategoryHTTP5xx,
+		CategoryTimeout, CategoryRateLimited, CategoryOther:
+		return true
+	default: // CategoryOK, CategorySkipped, CategoryHTTP4xx
+		return false
+	}
+}
+
 // containsAny reports whether s contains at least one of the needles.
 func containsAny(s string, needles ...string) bool {
 	for _, n := range needles {
@@ -94,10 +126,4 @@ func containsAny(s string, needles ...string) bool {
 		}
 	}
 	return false
-}
-
-// isFailure reports whether a category counts as a failure for the circuit
-// breaker. OK and Skipped do not; everything else does.
-func (c Category) isFailure() bool {
-	return c != CategoryOK && c != CategorySkipped
 }

--- a/cmd/ct-validate/categorize_test.go
+++ b/cmd/ct-validate/categorize_test.go
@@ -54,6 +54,11 @@ func TestCategorize(t *testing.T) {
 			CategoryHTTP4xx,
 		},
 		{
+			"429 is RateLimited (split out of the 4xx bucket)",
+			client.StatusError{Code: 429, Body: "too many requests"},
+			CategoryRateLimited,
+		},
+		{
 			"500 is HTTP5xx",
 			client.StatusError{Code: 500, Body: "boom"},
 			CategoryHTTP5xx,
@@ -100,19 +105,25 @@ func TestCategorize502BeatsGeneric5xx(t *testing.T) {
 	}
 }
 
-func TestCategoryIsFailure(t *testing.T) {
-	failures := []Category{
-		CategoryTransientWorkers, CategoryBadGateway502, CategoryHTTP4xx,
-		CategoryHTTP5xx, CategoryTimeout, CategoryOther,
+// TestCategoryIsDistress pins which categories trip the breaker. The crucial
+// assertion is that a deterministic 4xx is NOT distress (it is a real failure to
+// report, but must not latch the breaker and mask the rest of the map), while
+// 429 IS distress. Mutation proof: widen isDistress to include CategoryHTTP4xx
+// (the old isFailure behaviour) and the "HTTP4xx must NOT be distress" assertion
+// goes RED.
+func TestCategoryIsDistress(t *testing.T) {
+	distress := []Category{
+		CategoryTransientWorkers, CategoryBadGateway502, CategoryHTTP5xx,
+		CategoryTimeout, CategoryRateLimited, CategoryOther,
 	}
-	for _, c := range failures {
-		if !c.isFailure() {
-			t.Errorf("%q should count as failure", c)
+	for _, c := range distress {
+		if !c.isDistress() {
+			t.Errorf("%q should count as distress (trip the breaker)", c)
 		}
 	}
-	for _, c := range []Category{CategoryOK, CategorySkipped} {
-		if c.isFailure() {
-			t.Errorf("%q must NOT count as failure", c)
+	for _, c := range []Category{CategoryOK, CategorySkipped, CategoryHTTP4xx} {
+		if c.isDistress() {
+			t.Errorf("%q must NOT count as distress", c)
 		}
 	}
 }

--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -395,3 +395,277 @@ func (s iamPATSeam) FindIDByName(ctx context.Context, name string) (string, erro
 	}
 	return "", nil
 }
+
+// --- OpenIaaS compute lifecycle teardowns (#316 compute_lifecycle) -----------
+//
+// Teardown ordering is leaves-first (LIFO over registration order): the network
+// adapter and the user data disk are removed BEFORE the VM anchor, because a VM
+// delete does NOT cascade a user-created disk (it would orphan storage) and a
+// still-connected disk can refuse deletion. Each teardown is registered BEFORE
+// the create it undoes (F3), keyed by a deterministic identity, and finds its
+// resource via a STRICT listing when the create's activity did not resolve the
+// id. Q4/#303 note: a compute DELETE that answered 403 for an absent resource
+// would surface here as a teardown FAILURE (a false alarm, never an orphan — the
+// safe direction); only a definitive 404 is idempotent success.
+
+// vmSeam is the subset of the VM client a VM teardown needs.
+type vmSeam interface {
+	DeleteAndWait(ctx context.Context, id string) error
+	PowerOffAndWait(ctx context.Context, id string) error // best-effort, never fatal
+	FindIDByName(ctx context.Context, name, machineManagerID string) (string, error)
+}
+
+// vmTeardownRef carries the VM identity; ID is filled once the create activity
+// resolves it (shared pointer, like patTeardownRef). MachineManagerID scopes the
+// fallback find-by-name (the OpenIaaS list 5xx's without a scope).
+type vmTeardownRef struct {
+	Name             string
+	MachineManagerID string
+	ID               string
+	Resolved         bool
+}
+
+// registerVMTeardown registers the VM teardown (the anchor; runs LAST under LIFO).
+// Best-effort power-off (a running VM can refuse delete) then delete; if the id
+// never resolved, find the VM by its deterministic name within the machine
+// manager and delete that.
+func registerVMTeardown(cl *Cleanup, seam vmSeam, ref *vmTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.openiaas.virtual_machine %s", ref.Name), func(tctx context.Context) error {
+		id := ref.ID
+		if !ref.Resolved || id == "" {
+			found, err := seam.FindIDByName(tctx, ref.Name, ref.MachineManagerID)
+			if err != nil {
+				return err
+			}
+			if found == "" {
+				return nil // never created / already gone → idempotent success
+			}
+			id = found
+		}
+		_ = seam.PowerOffAndWait(tctx, id) // best-effort: a powered-on VM may refuse delete
+		return seam.DeleteAndWait(tctx, id)
+	})
+}
+
+type computeVMSeam struct{ c *client.Client }
+
+func (s computeVMSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().OpenIaaS().VirtualMachine().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err) // 404 → already gone; other surfaced
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr // a failed delete activity is a real teardown failure
+}
+
+func (s computeVMSeam) PowerOffAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().OpenIaaS().VirtualMachine().Power(ctx, id,
+		&client.UpdateOpenIaasVirtualMachinePowerRequest{PowerState: "off", Force: true})
+	if err != nil {
+		return nil // best-effort; the subsequent delete surfaces a real problem
+	}
+	_, _ = s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return nil
+}
+
+func (s computeVMSeam) FindIDByName(ctx context.Context, name, machineManagerID string) (string, error) {
+	vms, err := s.c.Compute().OpenIaaS().VirtualMachine().ListStrict(ctx,
+		&client.OpenIaaSVirtualMachineFilter{MachineManagerID: machineManagerID})
+	if err != nil {
+		return "", err
+	}
+	var found string
+	for _, vm := range vms {
+		if vm != nil && vm.Name == name && vm.ID != "" {
+			if found != "" {
+				// Ambiguous: the run-unique name should match at most one. More
+				// than one means an anomaly — fail closed (surface), never delete
+				// a possibly-wrong VM.
+				return "", fmt.Errorf("ambiguous: more than one virtual machine named %q", name)
+			}
+			found = vm.ID
+		}
+	}
+	return found, nil
+}
+
+// diskSeam is the subset of the virtual-disk client a disk teardown needs.
+type diskSeam interface {
+	ReadConnections(ctx context.Context, id string) ([]string, error) // connected VM ids
+	DisconnectAndWait(ctx context.Context, id, vmID string) error
+	DeleteAndWait(ctx context.Context, id string) error
+	FindIDByName(ctx context.Context, name, vmID string) (string, error)
+}
+
+type diskTeardownRef struct {
+	Name     string
+	VMID     string
+	ID       string
+	Resolved bool
+}
+
+// registerVirtualDiskTeardown registers the user data-disk teardown: disconnect
+// from EVERY connected VM (a VM delete never cascades a user disk) THEN delete.
+// Registered before the disk create; runs before the VM teardown (LIFO).
+func registerVirtualDiskTeardown(cl *Cleanup, seam diskSeam, ref *diskTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.openiaas.virtual_disk %s", ref.Name), func(tctx context.Context) error {
+		id := ref.ID
+		if !ref.Resolved || id == "" {
+			found, err := seam.FindIDByName(tctx, ref.Name, ref.VMID)
+			if err != nil {
+				return err
+			}
+			if found == "" {
+				return nil
+			}
+			id = found
+		}
+		vmIDs, err := seam.ReadConnections(tctx, id)
+		if err != nil {
+			return err
+		}
+		for _, vmID := range vmIDs {
+			if derr := seam.DisconnectAndWait(tctx, id, vmID); derr != nil {
+				return derr
+			}
+		}
+		return seam.DeleteAndWait(tctx, id)
+	})
+}
+
+type computeVirtualDiskSeam struct{ c *client.Client }
+
+func (s computeVirtualDiskSeam) ReadConnections(ctx context.Context, id string) ([]string, error) {
+	disk, err := s.c.Compute().OpenIaaS().VirtualDisk().Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if disk == nil { // 403/absent mapped to nil → nothing connected to disconnect
+		return nil, nil
+	}
+	var vmIDs []string
+	for _, vm := range disk.VirtualMachines {
+		if vm.Connected && vm.ID != "" {
+			vmIDs = append(vmIDs, vm.ID)
+		}
+	}
+	return vmIDs, nil
+}
+
+func (s computeVirtualDiskSeam) DisconnectAndWait(ctx context.Context, id, vmID string) error {
+	activityID, err := s.c.Compute().OpenIaaS().VirtualDisk().Disconnect(ctx, id,
+		&client.OpenIaaSVirtualDiskConnectionRequest{VirtualMachineID: vmID})
+	if err != nil {
+		return idempotentDeleteErr(err) // already disconnected/gone → ok
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+func (s computeVirtualDiskSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().OpenIaaS().VirtualDisk().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err)
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+func (s computeVirtualDiskSeam) FindIDByName(ctx context.Context, name, vmID string) (string, error) {
+	// VM-scoped first, then tenant-wide (mirrors the #325 provider doctrine): a
+	// created-but-UNATTACHED disk (the create materialized it but lost the result
+	// before attachment) is NOT in the VM-scoped listing, so a VM-scoped-only
+	// search would orphan it after the VM delete. The disk name is run-unique, so
+	// a tenant-wide match is unambiguous; >1 fails closed.
+	for _, filter := range []*client.OpenIaaSVirtualDiskFilter{{VirtualMachineID: vmID}, {}} {
+		id, err := s.findDiskByName(ctx, name, filter)
+		if err != nil {
+			return "", err
+		}
+		if id != "" {
+			return id, nil
+		}
+	}
+	return "", nil
+}
+
+func (s computeVirtualDiskSeam) findDiskByName(ctx context.Context, name string, filter *client.OpenIaaSVirtualDiskFilter) (string, error) {
+	disks, err := s.c.Compute().OpenIaaS().VirtualDisk().ListStrict(ctx, filter)
+	if err != nil {
+		return "", err
+	}
+	var found string
+	for _, d := range disks {
+		if d != nil && d.Name == name && d.ID != "" {
+			if found != "" {
+				return "", fmt.Errorf("ambiguous: more than one virtual disk named %q", name)
+			}
+			found = d.ID
+		}
+	}
+	return found, nil
+}
+
+// adapterSeam is the subset of the network-adapter client an adapter teardown needs.
+type adapterSeam interface {
+	// FindIDsByVM returns the ids of EVERY adapter on the VM. For a
+	// created-but-unresolved adapter the teardown deletes all of them: the VM is
+	// run-unique and ours and is being destroyed, so removing its adapters
+	// (including any template-provided one) is safe, and there is no MAC to match
+	// on (the platform assigns it).
+	FindIDsByVM(ctx context.Context, vmID string) ([]string, error)
+	DeleteAndWait(ctx context.Context, id string) error
+}
+
+type adapterTeardownRef struct {
+	VMID     string
+	ID       string
+	Resolved bool
+}
+
+// registerNetworkAdapterTeardown registers the adapter teardown (a network leaf;
+// runs FIRST under LIFO). When the id resolved, delete it; otherwise delete every
+// adapter on the (run-unique, ours) VM.
+func registerNetworkAdapterTeardown(cl *Cleanup, seam adapterSeam, ref *adapterTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.openiaas.network_adapter %s", ref.VMID), func(tctx context.Context) error {
+		if ref.Resolved && ref.ID != "" {
+			return seam.DeleteAndWait(tctx, ref.ID)
+		}
+		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+				return derr
+			}
+		}
+		return nil
+	})
+}
+
+type computeNetworkAdapterSeam struct{ c *client.Client }
+
+func (s computeNetworkAdapterSeam) FindIDsByVM(ctx context.Context, vmID string) ([]string, error) {
+	adapters, err := s.c.Compute().OpenIaaS().NetworkAdapter().ListStrict(ctx,
+		&client.OpenIaaSNetworkAdapterFilter{VirtualMachineID: vmID})
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, a := range adapters {
+		if a != nil && a.ID != "" {
+			ids = append(ids, a.ID)
+		}
+	}
+	return ids, nil
+}
+
+func (s computeNetworkAdapterSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().OpenIaaS().NetworkAdapter().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err)
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}

--- a/cmd/ct-validate/cleanup_seams_vmware.go
+++ b/cmd/ct-validate/cleanup_seams_vmware.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// VMware (vCenter) compute lifecycle teardowns — the sibling of the OpenIaaS
+// teardowns in cleanup_seams.go, with the SAME doctrine:
+//   - registered BEFORE the create they undo (F3), keyed by a deterministic
+//     run-unique identity, so a created-but-unresolved resource is still swept;
+//   - leaves-first under LIFO (adapter, then data disk, then the VM anchor): a VM
+//     delete must not be relied on to cascade a user disk/adapter;
+//   - find-by-name via a STRICT listing when the create activity did not resolve
+//     the id, FAIL CLOSED on >1 match (the run-unique name matches at most one);
+//   - 404-only idempotent deletes (shared idempotentDeleteErr): only a definitive
+//     not-found proves absence — a 403/409 is NOT "already gone" (mirrors the
+//     #303/#325 doctrine), so a compute DELETE that 403s for an absent resource
+//     surfaces here as a teardown FAILURE (a false alarm, never an orphan).
+//
+// Each registration takes a narrow SEAM interface (only the methods it needs),
+// not *client.Client, so it is unit-testable offline with a fake that returns an
+// error AFTER simulating the server-side effect.
+
+// --- VMware virtual machine ---------------------------------------------------
+
+// vmwareVMSeam is the subset of the VMware VM client a VM teardown needs.
+type vmwareVMSeam interface {
+	DeleteAndWait(ctx context.Context, id string) error
+	PowerOffAndWait(ctx context.Context, id string) error // best-effort, never fatal
+	FindIDByName(ctx context.Context, name, datacenterID string) (string, error)
+}
+
+// vmwareVMTeardownRef carries the VM identity; ID is filled once the create
+// activity resolves it (shared pointer). DatacenterID scopes the fallback
+// find-by-name to a bounded, strict listing.
+type vmwareVMTeardownRef struct {
+	Name         string
+	DatacenterID string
+	ID           string
+	Resolved     bool
+}
+
+// registerVMwareVMTeardown registers the VM teardown (the anchor; runs LAST under
+// LIFO). Best-effort power-off (a running VM can refuse delete) then delete; if
+// the id never resolved, find the VM by its deterministic name within the
+// datacenter and delete that.
+func registerVMwareVMTeardown(cl *Cleanup, seam vmwareVMSeam, ref *vmwareVMTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.vmware.virtual_machine %s", ref.Name), func(tctx context.Context) error {
+		id := ref.ID
+		if !ref.Resolved || id == "" {
+			found, err := seam.FindIDByName(tctx, ref.Name, ref.DatacenterID)
+			if err != nil {
+				return err
+			}
+			if found == "" {
+				return nil // never created / already gone → idempotent success
+			}
+			id = found
+		}
+		_ = seam.PowerOffAndWait(tctx, id) // best-effort: a powered-on VM may refuse delete
+		return seam.DeleteAndWait(tctx, id)
+	})
+}
+
+type computeVMwareVMSeam struct{ c *client.Client }
+
+func (s computeVMwareVMSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().VirtualMachine().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err) // 404 → already gone; other surfaced
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr // a failed delete activity is a real teardown failure
+}
+
+func (s computeVMwareVMSeam) PowerOffAndWait(ctx context.Context, id string) error {
+	vm, err := s.c.Compute().VirtualMachine().Read(ctx, id)
+	if err != nil || vm == nil {
+		return nil // best-effort: absent or unreadable → the subsequent delete decides
+	}
+	if vm.PowerState != "running" {
+		return nil // already off → nothing to do
+	}
+	activityID, perr := s.c.Compute().VirtualMachine().Power(ctx, &client.PowerRequest{
+		ID:           id,
+		DatacenterId: vm.Datacenter.ID,
+		PowerAction:  "off",
+	})
+	if perr != nil {
+		return nil // best-effort; the subsequent delete surfaces a real problem
+	}
+	_, _ = s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return nil
+}
+
+func (s computeVMwareVMSeam) FindIDByName(ctx context.Context, name, datacenterID string) (string, error) {
+	vms, err := s.c.Compute().VirtualMachine().ListStrict(ctx,
+		&client.VirtualMachineFilter{Datacenters: []string{datacenterID}})
+	if err != nil {
+		return "", err
+	}
+	var found string
+	for _, vm := range vms {
+		if vm != nil && vm.Name == name && vm.ID != "" {
+			if found != "" {
+				// Ambiguous: the run-unique name should match at most one. More than
+				// one means an anomaly — fail closed (surface), never delete a
+				// possibly-wrong VM.
+				return "", fmt.Errorf("ambiguous: more than one VMware virtual machine named %q", name)
+			}
+			found = vm.ID
+		}
+	}
+	return found, nil
+}
+
+// --- VMware virtual disk ------------------------------------------------------
+
+// vmwareDiskSeam is the subset of the VMware virtual-disk client a disk teardown
+// needs. CRITICAL: CreateVirtualDiskRequest carries NO name (unlike OpenIaaS) and
+// REQUIRES a virtualMachineId — a VMware disk is always created ATTACHED to a VM
+// and gets a platform-assigned name. So a created-but-id-unresolved disk cannot
+// be found by a name we chose; it is recovered by listing the VM's disks and
+// deleting them. The VM is run-unique and ours, and the cycle creates it via the
+// bare Create (no template/clone/library) — which yields a VM with no disks until
+// this cycle attaches one — so every disk subsequently on it was attached by this
+// cycle. Hence the delete-all-on-VM strategy (same as the adapter) cannot remove a
+// foreign disk. There is no unattached-disk orphan window (the API cannot create a
+// VMware disk without a VM), so a VM-scoped listing is complete.
+type vmwareDiskSeam interface {
+	FindIDsByVM(ctx context.Context, vmID string) ([]string, error)
+	DeleteAndWait(ctx context.Context, id string) error
+}
+
+type vmwareDiskTeardownRef struct {
+	VMID     string
+	ID       string
+	Resolved bool
+}
+
+// registerVMwareDiskTeardown registers the user data-disk teardown (a leaf; runs
+// before the VM teardown under LIFO — a VM delete must not be relied on to remove
+// a user disk cleanly). When the id resolved, delete it; otherwise delete every
+// disk on the (run-unique, ours, created-diskless) VM. Registered before the disk
+// create (F3).
+func registerVMwareDiskTeardown(cl *Cleanup, seam vmwareDiskSeam, ref *vmwareDiskTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.vmware.virtual_disk on %s", ref.VMID), func(tctx context.Context) error {
+		if ref.Resolved && ref.ID != "" {
+			return seam.DeleteAndWait(tctx, ref.ID)
+		}
+		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+				return derr
+			}
+		}
+		return nil
+	})
+}
+
+type computeVMwareDiskSeam struct{ c *client.Client }
+
+func (s computeVMwareDiskSeam) FindIDsByVM(ctx context.Context, vmID string) ([]string, error) {
+	disks, err := s.c.Compute().VirtualDisk().ListStrict(ctx, &client.VirtualDiskFilter{VirtualMachineID: vmID})
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, d := range disks {
+		if d != nil && d.ID != "" {
+			ids = append(ids, d.ID)
+		}
+	}
+	return ids, nil
+}
+
+func (s computeVMwareDiskSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().VirtualDisk().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err)
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}
+
+// --- VMware network adapter ---------------------------------------------------
+
+// vmwareAdapterSeam is the subset of the VMware network-adapter client an adapter
+// teardown needs.
+type vmwareAdapterSeam interface {
+	// FindIDsByVM returns the ids of EVERY adapter on the VM. For a
+	// created-but-unresolved adapter the teardown deletes all of them: the VM is
+	// run-unique and ours and is being destroyed, so removing its adapters is safe,
+	// and there is no MAC to match on (the platform assigns it).
+	FindIDsByVM(ctx context.Context, vmID string) ([]string, error)
+	DeleteAndWait(ctx context.Context, id string) error
+}
+
+type vmwareAdapterTeardownRef struct {
+	VMID     string
+	ID       string
+	Resolved bool
+}
+
+// registerVMwareNetworkAdapterTeardown registers the adapter teardown (a network
+// leaf; runs FIRST under LIFO). When the id resolved, delete it; otherwise delete
+// every adapter on the (run-unique, ours) VM.
+func registerVMwareNetworkAdapterTeardown(cl *Cleanup, seam vmwareAdapterSeam, ref *vmwareAdapterTeardownRef) {
+	cl.Register(fmt.Sprintf("compute.vmware.network_adapter %s", ref.VMID), func(tctx context.Context) error {
+		if ref.Resolved && ref.ID != "" {
+			return seam.DeleteAndWait(tctx, ref.ID)
+		}
+		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+				return derr
+			}
+		}
+		return nil
+	})
+}
+
+type computeVMwareAdapterSeam struct{ c *client.Client }
+
+func (s computeVMwareAdapterSeam) FindIDsByVM(ctx context.Context, vmID string) ([]string, error) {
+	adapters, err := s.c.Compute().NetworkAdapter().ListStrict(ctx,
+		&client.NetworkAdapterFilter{VirtualMachineID: vmID})
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, a := range adapters {
+		if a != nil && a.ID != "" {
+			ids = append(ids, a.ID)
+		}
+	}
+	return ids, nil
+}
+
+func (s computeVMwareAdapterSeam) DeleteAndWait(ctx context.Context, id string) error {
+	activityID, err := s.c.Compute().NetworkAdapter().Delete(ctx, id)
+	if err != nil {
+		return idempotentDeleteErr(err)
+	}
+	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+	return werr
+}

--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -85,7 +85,10 @@ func (r *Run) op(c Cycle, endpoint string, fn func() error) error {
 		Latency:  latency,
 		Category: cat,
 	})
-	r.Breaker.Record(cat.isFailure())
+	// The breaker trips on DISTRESS only (5xx, 502, timeout, transient, 429),
+	// NOT on deterministic client errors (4xx): a 4xx is recorded as a failure
+	// in the report but must not latch the breaker and mask the rest of the map.
+	r.Breaker.Record(cat.isDistress())
 	return err
 }
 

--- a/cmd/ct-validate/cycle_compute_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// newRunToken returns a 128-bit hex token, mixed into every created resource's
+// name so identities are collision-free across runs/workers: a stale orphan from
+// a previous run can never be confused with — and wrongly deleted instead of — a
+// fresh resource by the find-by-name teardown fallback. It FAILS rather than
+// fall back to a constant: a non-unique identity on a destructive write cycle is
+// unsafe, so the cycle aborts (creating nothing) if randomness is unavailable.
+func newRunToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// computeLifecycleCycle is the end-to-end OpenIaaS compute WRITE business cycle:
+// create a VM from a template, attach a user data disk, attach + connect a user
+// network adapter, then deprovision the whole stack leaves-first. It is the
+// realization of the #316 TODO and the cycle to replay (with -runs/-concurrency)
+// for a BOUNDED, breaker-guarded load probe ("how far does it hold").
+//
+// Every created resource has its teardown REGISTERED BEFORE the create (F3),
+// keyed by a deterministic per-(iteration,worker) identity, so a created-but-
+// unresolved resource is still swept; the deferred TeardownAll re-runs them
+// idempotently (404-only) even if the explicit deprovision below already ran.
+// Teardown order is leaves-first by construction (register VM, then disk, then
+// adapter → LIFO removes adapter, then disk, then VM): a VM delete never cascades
+// a user disk/adapter, so those must be gone first.
+//
+// v1 scope: lean and load-friendly — no power-on / driver wait / resize /
+// relocate / VPC edge (those widen the failure surface and slow the cycle); they
+// are deferred to a richer variant.
+type computeLifecycleCycle struct {
+	// tokenFunc overrides the run-identity generator (nil → newRunToken); used by
+	// tests to exercise the identity-failure path.
+	tokenFunc func() (string, error)
+}
+
+func (computeLifecycleCycle) Name() string { return "compute_lifecycle" }
+func (computeLifecycleCycle) Kind() Kind   { return KindWrite }
+
+func (cyc computeLifecycleCycle) mkToken() (string, error) {
+	if cyc.tokenFunc != nil {
+		return cyc.tokenFunc()
+	}
+	return newRunToken()
+}
+
+const (
+	clVMCPU    = 1
+	clVMMemory = 1073741824 // 1 GiB, in bytes
+	clDiskSize = 1073741824 // 1 GiB, in bytes
+)
+
+// resolveActivityResultID returns the single activity-state Result (the created
+// resource id), or "" when the activity is nil or did not resolve to exactly one
+// state — mirrors setIdFromActivityState (internal/provider/provider.go) so the
+// harness reads the create id the same way the provider does.
+func resolveActivityResultID(act *client.Activity) string {
+	if act == nil || len(act.State) != 1 {
+		return ""
+	}
+	for _, st := range act.State {
+		return st.Result
+	}
+	return ""
+}
+
+func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	// Collision-free identity: a 128-bit run token + full (Iteration, Worker)
+	// integers (no byte() truncation). The find-by-name teardown fallback relies
+	// on this being unique across runs and concurrent workers. If randomness is
+	// unavailable we abort BEFORE creating anything (no non-unique identity). The
+	// network adapter's MAC is left to the platform (omitted on create) so there
+	// is no MAC-collision surface; the adapter teardown is scoped to THIS VM.
+	var token string
+	if r.op(cyc, "compute.openiaas.run_identity", func() error {
+		t, e := cyc.mkToken()
+		token = t
+		return e
+	}) != nil {
+		// Identity generation failed: recorded as a FAILURE op (so the run exits
+		// non-zero — observable), and NOTHING is created.
+		return nil
+	}
+	name := fmt.Sprintf("ct-validate-%s-%d-%d", token, r.Iteration, r.Worker)
+
+	oi := c.Compute().OpenIaaS()
+
+	// --- PHASE 0: substrate (all read-discovered; SKIP write steps when absent,
+	// never guess) ---
+	var mmID string
+	_ = r.op(cyc, "compute.openiaas.machine_managers.list", func() error {
+		mms, err := oi.MachineManager().List(ctx)
+		if err != nil {
+			return err
+		}
+		for _, mm := range mms {
+			if mm != nil && mm.ID != "" {
+				mmID = mm.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	// Every write/deprovision step, in order — used to skip-record the whole
+	// cycle when there is no machine manager / template to deploy from.
+	writeSteps := []string{
+		"compute.openiaas.virtual_machine.create",
+		"compute.openiaas.virtual_disk.create",
+		"compute.openiaas.network_adapter.create",
+		"compute.openiaas.network_adapter.connect",
+		"compute.openiaas.virtual_machine.read",
+		"compute.openiaas.network_adapter.delete",
+		"compute.openiaas.virtual_disk.disconnect",
+		"compute.openiaas.virtual_disk.delete",
+		"compute.openiaas.virtual_machine.delete",
+	}
+	skipAll := func() {
+		for _, ep := range writeSteps {
+			r.skip(cyc, ep)
+		}
+	}
+
+	if mmID == "" {
+		r.skip(cyc, "compute.openiaas.templates.list")
+		r.skip(cyc, "compute.openiaas.storage_repositories.list")
+		r.skip(cyc, "compute.openiaas.networks.list")
+		skipAll()
+		return nil
+	}
+
+	var tmplID string
+	_ = r.op(cyc, "compute.openiaas.templates.list", func() error {
+		tmpls, err := oi.Template().List(ctx, &client.OpenIaaSTemplateFilter{MachineManagerId: mmID})
+		if err != nil {
+			return err
+		}
+		for _, t := range tmpls {
+			if t != nil && t.ID != "" {
+				tmplID = t.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	// A storage repository and a network are OPTIONAL: without them the disk and
+	// adapter sub-steps are skipped, but the VM create+delete still run.
+	var srID string
+	_ = r.op(cyc, "compute.openiaas.storage_repositories.list", func() error {
+		srs, err := oi.StorageRepository().List(ctx, &client.StorageRepositoryFilter{MachineManagerId: mmID})
+		if err != nil {
+			return err
+		}
+		for _, sr := range srs {
+			if sr != nil && sr.ID != "" && !sr.MaintenanceMode {
+				srID = sr.ID
+				break
+			}
+		}
+		return nil
+	})
+	var networkID string
+	_ = r.op(cyc, "compute.openiaas.networks.list", func() error {
+		nets, err := oi.Network().List(ctx, &client.OpenIaaSNetworkFilter{MachineManagerID: mmID})
+		if err != nil {
+			return err
+		}
+		for _, n := range nets {
+			if n != nil && n.ID != "" {
+				networkID = n.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	if tmplID == "" {
+		skipAll() // nothing to deploy from → not a failure
+		return nil
+	}
+
+	// --- PHASE 1: provision the VM (teardown registered BEFORE the create) ---
+	vmRef := &vmTeardownRef{Name: name, MachineManagerID: mmID}
+	registerVMTeardown(r.Cleanup, computeVMSeam{c}, vmRef)
+	var vmID string
+	_ = r.op(cyc, "compute.openiaas.virtual_machine.create", func() error {
+		activityID, err := oi.VirtualMachine().Create(ctx, &client.CreateOpenIaasVirtualMachineRequest{
+			Name:       name,
+			TemplateID: tmplID,
+			CPU:        clVMCPU,
+			Memory:     clVMMemory,
+		})
+		if err != nil {
+			return err
+		}
+		act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		if werr != nil {
+			return werr
+		}
+		vmID = resolveActivityResultID(act)
+		return nil
+	})
+	if vmID == "" {
+		// Create failed or its id did not resolve: the deferred VM teardown (by
+		// name) sweeps it. Nothing further to provision/deprovision explicitly.
+		for _, ep := range []string{
+			"compute.openiaas.virtual_disk.create", "compute.openiaas.network_adapter.create",
+			"compute.openiaas.network_adapter.connect", "compute.openiaas.virtual_machine.read",
+			"compute.openiaas.network_adapter.delete", "compute.openiaas.virtual_disk.disconnect",
+			"compute.openiaas.virtual_disk.delete", "compute.openiaas.virtual_machine.delete",
+		} {
+			r.skip(cyc, ep)
+		}
+		return nil
+	}
+	vmRef.ID, vmRef.Resolved = vmID, true
+
+	// --- PHASE 2: storage variation — attach a user data disk (optional) ---
+	var diskID string
+	if srID != "" {
+		diskRef := &diskTeardownRef{Name: name + "-data", VMID: vmID}
+		registerVirtualDiskTeardown(r.Cleanup, computeVirtualDiskSeam{c}, diskRef)
+		_ = r.op(cyc, "compute.openiaas.virtual_disk.create", func() error {
+			activityID, err := oi.VirtualDisk().Create(ctx, &client.OpenIaaSVirtualDiskCreateRequest{
+				Name:                name + "-data",
+				Size:                clDiskSize,
+				Mode:                "RW",
+				StorageRepositoryID: srID,
+				VirtualMachineID:    vmID,
+			})
+			if err != nil {
+				return err
+			}
+			act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			if werr != nil {
+				return werr
+			}
+			diskID = resolveActivityResultID(act)
+			return nil
+		})
+		if diskID != "" {
+			diskRef.ID, diskRef.Resolved = diskID, true
+		}
+	} else {
+		r.skip(cyc, "compute.openiaas.virtual_disk.create")
+	}
+
+	// --- PHASE 3: network connection — attach + connect a user adapter (optional) ---
+	var adapterID string
+	if networkID != "" {
+		adapterRef := &adapterTeardownRef{VMID: vmID}
+		registerNetworkAdapterTeardown(r.Cleanup, computeNetworkAdapterSeam{c}, adapterRef)
+		_ = r.op(cyc, "compute.openiaas.network_adapter.create", func() error {
+			activityID, err := oi.NetworkAdapter().Create(ctx, &client.CreateOpenIaasNetworkAdapterRequest{
+				VirtualMachineID: vmID,
+				NetworkID:        networkID,
+				// MAC omitted: the platform assigns it (no MAC-collision surface).
+			})
+			if err != nil {
+				return err
+			}
+			act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			if werr != nil {
+				return werr
+			}
+			adapterID = resolveActivityResultID(act)
+			return nil
+		})
+		if adapterID != "" {
+			adapterRef.ID, adapterRef.Resolved = adapterID, true
+			_ = r.op(cyc, "compute.openiaas.network_adapter.connect", func() error {
+				activityID, err := oi.NetworkAdapter().Connect(ctx, adapterID)
+				if err != nil {
+					return err
+				}
+				_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+				return werr
+			})
+		} else {
+			r.skip(cyc, "compute.openiaas.network_adapter.connect")
+		}
+	} else {
+		r.skip(cyc, "compute.openiaas.network_adapter.create")
+		r.skip(cyc, "compute.openiaas.network_adapter.connect")
+	}
+
+	// Observational read of the assembled VM.
+	_ = r.op(cyc, "compute.openiaas.virtual_machine.read", func() error {
+		_, err := oi.VirtualMachine().Read(ctx, vmID)
+		return err
+	})
+
+	// --- PHASE 4: deprovision (explicit + recorded; leaves-first). Overlaps the
+	// deferred teardowns by design — idempotent (404-only), so a double delete is
+	// not a false failure. Every op is breaker-gated, so once tripped these become
+	// recorded skips and the deferred TeardownAll still sweeps everything. ---
+	if adapterID != "" {
+		_ = r.op(cyc, "compute.openiaas.network_adapter.delete", func() error {
+			activityID, err := oi.NetworkAdapter().Delete(ctx, adapterID)
+			if err != nil {
+				return idempotentDeleteErr(err)
+			}
+			_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			return werr
+		})
+	} else {
+		r.skip(cyc, "compute.openiaas.network_adapter.delete")
+	}
+
+	if diskID != "" {
+		_ = r.op(cyc, "compute.openiaas.virtual_disk.disconnect", func() error {
+			activityID, err := oi.VirtualDisk().Disconnect(ctx, diskID,
+				&client.OpenIaaSVirtualDiskConnectionRequest{VirtualMachineID: vmID})
+			if err != nil {
+				return idempotentDeleteErr(err)
+			}
+			_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			return werr
+		})
+		_ = r.op(cyc, "compute.openiaas.virtual_disk.delete", func() error {
+			activityID, err := oi.VirtualDisk().Delete(ctx, diskID)
+			if err != nil {
+				return idempotentDeleteErr(err)
+			}
+			_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			return werr
+		})
+	} else {
+		r.skip(cyc, "compute.openiaas.virtual_disk.disconnect")
+		r.skip(cyc, "compute.openiaas.virtual_disk.delete")
+	}
+
+	_ = r.op(cyc, "compute.openiaas.virtual_machine.delete", func() error {
+		activityID, err := oi.VirtualMachine().Delete(ctx, vmID)
+		if err != nil {
+			return idempotentDeleteErr(err)
+		}
+		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		return werr
+	})
+
+	return nil
+}

--- a/cmd/ct-validate/cycle_compute_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// --- recording fake seams (offline, no client) ---
+
+type fakeVMSeam struct {
+	log     *[]string
+	findID  string
+	findErr error
+}
+
+func (f fakeVMSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "vm.delete:"+id)
+	return nil
+}
+func (f fakeVMSeam) PowerOffAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "vm.poweroff:"+id)
+	return nil
+}
+func (f fakeVMSeam) FindIDByName(_ context.Context, name, mmID string) (string, error) {
+	*f.log = append(*f.log, "vm.find:"+name+"@"+mmID)
+	return f.findID, f.findErr
+}
+
+type fakeDiskSeam struct {
+	log         *[]string
+	connections []string
+	findID      string
+}
+
+func (f fakeDiskSeam) ReadConnections(_ context.Context, id string) ([]string, error) {
+	return f.connections, nil
+}
+func (f fakeDiskSeam) DisconnectAndWait(_ context.Context, id, vmID string) error {
+	*f.log = append(*f.log, "disk.disconnect:"+id+"/"+vmID)
+	return nil
+}
+func (f fakeDiskSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "disk.delete:"+id)
+	return nil
+}
+func (f fakeDiskSeam) FindIDByName(_ context.Context, name, vmID string) (string, error) {
+	*f.log = append(*f.log, "disk.find:"+name)
+	return f.findID, nil
+}
+
+type fakeAdapterSeam struct {
+	log *[]string
+	ids []string // FindIDsByVM returns these
+}
+
+func (f fakeAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
+	*f.log = append(*f.log, "adapter.find:"+vmID)
+	return f.ids, nil
+}
+func (f fakeAdapterSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "adapter.delete:"+id)
+	return nil
+}
+
+func indexOf(log []string, prefix string) int {
+	for i, s := range log {
+		if strings.HasPrefix(s, prefix) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestRegisterVMTeardownResolvedDeletesByID: a resolved ref deletes by id
+// (power-off best-effort first), never falling back to find-by-name. Mutation:
+// drop the `ref.Resolved` check → find-by-name is used → "vm.find" appears.
+func TestRegisterVMTeardownResolvedDeletesByID(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMTeardown(cl, fakeVMSeam{log: &log, findID: "should-not-be-used"},
+		&vmTeardownRef{Name: "vm-a", MachineManagerID: "mm-1", ID: "vm-id-1", Resolved: true})
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "vm.find") != -1 {
+		t.Fatalf("a resolved ref must delete by id, not find by name; log=%v", log)
+	}
+	if indexOf(log, "vm.delete:vm-id-1") == -1 {
+		t.Fatalf("must delete by the resolved id; log=%v", log)
+	}
+}
+
+// TestRegisterVMTeardownUnresolvedFindsByName: an UNRESOLVED ref (create id
+// never came back) finds the VM by its deterministic name and deletes it — this
+// is why the teardown is registered BEFORE the create. Mutation: register after
+// the create (so the ref is never set) is exactly this path; dropping find →
+// orphan survives.
+func TestRegisterVMTeardownUnresolvedFindsByName(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMTeardown(cl, fakeVMSeam{log: &log, findID: "found-vm-9"},
+		&vmTeardownRef{Name: "vm-b", MachineManagerID: "mm-1"}) // not resolved
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "vm.find:vm-b@mm-1") == -1 || indexOf(log, "vm.delete:found-vm-9") == -1 {
+		t.Fatalf("unresolved ref must find-by-name then delete; log=%v", log)
+	}
+}
+
+// TestRegisterVMTeardownNotFoundIsNoop: unresolved + not found → nothing to do,
+// no delete (idempotent: never created / already gone).
+func TestRegisterVMTeardownNotFoundIsNoop(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMTeardown(cl, fakeVMSeam{log: &log, findID: ""},
+		&vmTeardownRef{Name: "vm-c", MachineManagerID: "mm-1"})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("not-found teardown must be a no-op success, got failures %v", f)
+	}
+	if indexOf(log, "vm.delete") != -1 {
+		t.Fatalf("nothing must be deleted when not found; log=%v", log)
+	}
+}
+
+// TestRegisterVirtualDiskTeardownDisconnectsEveryConnectionThenDeletes pins the
+// disk doctrine: a user disk is disconnected from EVERY connected VM BEFORE
+// delete (a VM delete never cascades it). Mutation: drop the disconnect loop →
+// the "disconnect before delete" assertion goes RED.
+func TestRegisterVirtualDiskTeardownDisconnectsEveryConnectionThenDeletes(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVirtualDiskTeardown(cl, fakeDiskSeam{log: &log, connections: []string{"vm-1", "vm-2"}},
+		&diskTeardownRef{Name: "d-data", VMID: "vm-1", ID: "disk-7", Resolved: true})
+	cl.TeardownAll(context.Background())
+	d1 := indexOf(log, "disk.disconnect:disk-7/vm-1")
+	d2 := indexOf(log, "disk.disconnect:disk-7/vm-2")
+	del := indexOf(log, "disk.delete:disk-7")
+	if d1 == -1 || d2 == -1 || del == -1 || d1 > del || d2 > del {
+		t.Fatalf("disk must disconnect EVERY connection before delete; log=%v", log)
+	}
+}
+
+// TestRegisterNetworkAdapterTeardownResolvedDeletesByID: a resolved adapter is
+// deleted by id, no VM-wide listing.
+func TestRegisterNetworkAdapterTeardownResolvedDeletesByID(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerNetworkAdapterTeardown(cl, fakeAdapterSeam{log: &log, ids: []string{"should-not-be-used"}},
+		&adapterTeardownRef{VMID: "vm-1", ID: "ad-3", Resolved: true})
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "adapter.find") != -1 {
+		t.Fatalf("a resolved adapter must delete by id, not list the VM; log=%v", log)
+	}
+	if indexOf(log, "adapter.delete:ad-3") == -1 {
+		t.Fatalf("must delete the resolved adapter id; log=%v", log)
+	}
+}
+
+// TestRegisterNetworkAdapterTeardownUnresolvedDeletesAllOnVM: an UNRESOLVED
+// adapter (create id never came back, and no MAC since the platform assigns it)
+// is recovered by deleting EVERY adapter on the (run-unique, ours) VM. Mutation:
+// drop the find/delete-all loop → the created-but-unresolved adapter orphans.
+func TestRegisterNetworkAdapterTeardownUnresolvedDeletesAllOnVM(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerNetworkAdapterTeardown(cl, fakeAdapterSeam{log: &log, ids: []string{"ad-1", "ad-2"}},
+		&adapterTeardownRef{VMID: "vm-1"}) // unresolved
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "adapter.find:vm-1") == -1 || indexOf(log, "adapter.delete:ad-1") == -1 || indexOf(log, "adapter.delete:ad-2") == -1 {
+		t.Fatalf("unresolved adapter must list the VM and delete every adapter; log=%v", log)
+	}
+}
+
+// TestComputeLifecycleTeardownLIFOOrder pins leaves-first: registering VM, then
+// disk, then adapter (the cycle's creation order) makes TeardownAll remove them
+// in REVERSE — adapter, then disk, then VM (anchor last). Mutation: register the
+// VM teardown AFTER the disk/adapter → LIFO would delete the VM before its
+// devices → this order assertion goes RED.
+func TestComputeLifecycleTeardownLIFOOrder(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMTeardown(cl, fakeVMSeam{log: &log}, &vmTeardownRef{Name: "vm", ID: "vm-1", Resolved: true})
+	registerVirtualDiskTeardown(cl, fakeDiskSeam{log: &log}, &diskTeardownRef{Name: "d", VMID: "vm-1", ID: "disk-1", Resolved: true})
+	registerNetworkAdapterTeardown(cl, fakeAdapterSeam{log: &log}, &adapterTeardownRef{VMID: "vm-1", ID: "ad-1", Resolved: true})
+
+	cl.TeardownAll(context.Background())
+
+	a, d, v := indexOf(log, "adapter.delete"), indexOf(log, "disk.delete"), indexOf(log, "vm.delete")
+	if a == -1 || d == -1 || v == -1 || !(a < d && d < v) {
+		t.Fatalf("LIFO must tear down leaves-first (adapter < disk < vm), got order %v", log)
+	}
+}
+
+// TestRegistryHasComputeLifecycleGated: the cycle is registered, write-typed, and
+// gated out unless -write is set.
+func TestRegistryHasComputeLifecycleGated(t *testing.T) {
+	reg := buildRegistry()
+	sel, gated, err := reg.Select("compute_lifecycle", false)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if len(sel) != 0 {
+		t.Fatalf("compute_lifecycle must be GATED without -write, got selected %v", sel)
+	}
+	if len(gated) != 1 || gated[0] != "compute_lifecycle" {
+		t.Fatalf("compute_lifecycle must be the gated write cycle, got %v", gated)
+	}
+	sel, _, _ = reg.Select("compute_lifecycle", true)
+	if len(sel) != 1 || sel[0].Name() != "compute_lifecycle" || sel[0].Kind() != KindWrite {
+		t.Fatalf("compute_lifecycle must be selectable (write) with -write, got %v", sel)
+	}
+}
+
+// TestComputeLifecycleSkipsWithoutSubstrate pins that with NO machine manager,
+// the cycle records every write step as SKIPPED and attempts ZERO create — it
+// never guesses or fires a create blindly. Mutation: turn a skip into a create
+// attempt → the stub flags the unexpected POST.
+func TestComputeLifecycleSkipsWithoutSubstrate(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("no write/create call expected without a machine manager, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if isOpenIaaSMachineManagers(r.URL.Path) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`)) // no machine manager
+			return
+		}
+		t.Errorf("only the machine-managers list should be called, got GET %s", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	if err := (computeLifecycleCycle{}).Run(context.Background(), c, r); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if cl := r.Cleanup.Pending(); cl != 0 {
+		t.Fatalf("no teardown must be registered when there is no substrate, got %d pending", cl)
+	}
+	for _, o := range r.Recorder.Ops() {
+		if strings.Contains(o.Endpoint, ".create") || strings.Contains(o.Endpoint, ".delete") || strings.Contains(o.Endpoint, ".connect") {
+			if !o.Skipped {
+				t.Fatalf("%s must be SKIPPED without substrate, got %+v", o.Endpoint, o)
+			}
+		}
+	}
+}
+
+// TestComputeVMSeamFindIDByNameFailsHardOnDuplicate pins that the unresolved
+// find-by-name REFUSES to pick a VM when more than one shares the (run-unique)
+// name — it fails closed rather than risk deleting the wrong VM. Mutation: have
+// FindIDByName return the first match → no error → RED.
+func TestComputeVMSeamFindIDByNameFailsHardOnDuplicate(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"a","name":"dup"},{"id":"b","name":"dup"}]`))
+	})
+	if _, err := (computeVMSeam{c}).FindIDByName(context.Background(), "dup", "mm-1"); err == nil {
+		t.Fatal("two VMs sharing the name must fail closed (refuse to delete the wrong one), got nil error")
+	}
+}
+
+// TestComputeVirtualDiskSeamFindTenantWideWhenUnattached pins the anti-orphan
+// fallback: a created-but-UNATTACHED disk (absent from the VM-scoped listing) is
+// still found tenant-wide by its run-unique name. Mutation: drop the tenant-wide
+// pass → the unattached disk is not found → would orphan → RED.
+func TestComputeVirtualDiskSeamFindTenantWideWhenUnattached(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Get("virtualMachineId") != "" {
+			_, _ = w.Write([]byte(`[]`)) // VM-scoped: not attached → empty
+			return
+		}
+		_, _ = w.Write([]byte(`[{"id":"disk-9","name":"d-data"}]`)) // tenant-wide: found
+	})
+	id, err := (computeVirtualDiskSeam{c}).FindIDByName(context.Background(), "d-data", "vm-1")
+	if err != nil || id != "disk-9" {
+		t.Fatalf("a created-but-unattached disk must be found tenant-wide, got id=%q err=%v", id, err)
+	}
+}
+
+// TestComputeVirtualDiskSeamFindFailsHardOnDuplicate pins fail-closed on a
+// duplicate disk name (refuse to delete the wrong disk).
+func TestComputeVirtualDiskSeamFindFailsHardOnDuplicate(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Get("virtualMachineId") != "" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"id":"a","name":"d-data"},{"id":"b","name":"d-data"}]`))
+	})
+	if _, err := (computeVirtualDiskSeam{c}).FindIDByName(context.Background(), "d-data", "vm-1"); err == nil {
+		t.Fatal("two disks sharing the name must fail closed, got nil error")
+	}
+}
+
+// TestComputeLifecycleIdentityFailureIsObservable pins that a run-identity
+// generation failure (no entropy) creates NOTHING and is recorded as a FAILURE
+// op (so the run exits non-zero) — not a silent exit-0. Mutation: revert the
+// token step to a bare `return err` (engine-swallowed) → no failure op recorded
+// → RED.
+func TestComputeLifecycleIdentityFailureIsObservable(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no call expected when identity generation fails, got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	cyc := computeLifecycleCycle{tokenFunc: func() (string, error) { return "", errors.New("no entropy") }}
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	_ = cyc.Run(context.Background(), c, r)
+
+	if r.Cleanup.Pending() != 0 {
+		t.Fatalf("nothing must be created/registered on an identity failure, got %d pending", r.Cleanup.Pending())
+	}
+	var failed bool
+	for _, o := range r.Recorder.Ops() {
+		if o.Endpoint == "compute.openiaas.run_identity" && !o.OK && !o.Skipped {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Fatal("identity failure must be recorded as a failed op (observable, exit non-zero)")
+	}
+}
+
+// TestFlagsValidateRejectsRunawayLoad pins the hard ceilings on the load knobs: a
+// typo'd -concurrency / -runs is refused before anything runs. Mutation: drop the
+// upper-bound checks in validate() → these are accepted → RED.
+func TestFlagsValidateRejectsRunawayLoad(t *testing.T) {
+	out, err := os.CreateTemp(t.TempDir(), "usage")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer out.Close()
+	if _, err := parseFlags([]string{"-concurrency", "5000"}, out); err == nil {
+		t.Fatal("-concurrency 5000 must be rejected (runaway load)")
+	}
+	if _, err := parseFlags([]string{"-runs", "100000000"}, out); err == nil {
+		t.Fatal("-runs 100000000 must be rejected (runaway load)")
+	}
+}

--- a/cmd/ct-validate/cycle_compute_vmware_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_vmware_lifecycle.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// computeVMwareLifecycleCycle is the end-to-end VMware (vCenter) compute WRITE
+// business cycle, the sibling of computeLifecycleCycle (OpenIaaS): create a VM
+// from scratch on a discovered datacenter/host-cluster/datastore, attach a user
+// data disk, attach a user network adapter, read the assembled VM, then
+// deprovision the whole stack leaves-first.
+//
+// It is structurally IDENTICAL to the OpenIaaS cycle (register-before-create F3,
+// LIFO leaves-first teardown, run-unique 128-bit identity, find-by-name fail-
+// closed, 404-only idempotent deletes) so the two platforms get the SAME safety
+// guarantees. Only the client surface differs:
+//   - VMware mutations are async and resolve the created id from the activity's
+//     CONCERNED ITEMS (setIdFromActivityConcernedItems, internal/provider/
+//     provider.go) — NOT from a single State Result as OpenIaaS does. Hence the
+//     dedicated resolveActivityConcernedItemID below.
+//   - a VMware VM is created from substrate (datacenter + host + datastore +
+//     guest-OS moref), not from a template id.
+//   - a VMware data disk delete removes it outright (no separate disconnect step
+//     like the OpenIaaS shared-disk model).
+//
+// v1 scope: lean and load-friendly — no power-on / guest customization / resize /
+// relocate / backup SLA (those widen the failure surface and slow the cycle).
+// The VM is created powered-off, so the explicit delete needs no power cycle; the
+// deferred teardown still powers off best-effort as a belt-and-suspenders.
+type computeVMwareLifecycleCycle struct {
+	// tokenFunc overrides the run-identity generator (nil → newRunToken); used by
+	// tests to exercise the identity-failure path.
+	tokenFunc func() (string, error)
+}
+
+func (computeVMwareLifecycleCycle) Name() string { return "compute_vmware_lifecycle" }
+func (computeVMwareLifecycleCycle) Kind() Kind   { return KindWrite }
+
+func (cyc computeVMwareLifecycleCycle) mkToken() (string, error) {
+	if cyc.tokenFunc != nil {
+		return cyc.tokenFunc()
+	}
+	return newRunToken()
+}
+
+const (
+	vmwVMCPU       = 1
+	vmwVMMemory    = 1073741824  // 1 GiB, in bytes
+	vmwDiskSize    = 10737418240 // 10 GiB, in bytes; "dynamic" provisioning is thin so the real footprint is ~0
+	vmwAdapterType = "VMXNET3"   // a modern adapter type accepted by the common guest OSes
+	vmwDiskProvKey = "dynamic"   // thin provisioning (provisioning_type enum: dynamic|staticImmediate|staticDiffered)
+	vmwDiskMode    = "persistent"
+)
+
+// resolveActivityConcernedItemID returns the id of the created resource from a
+// completed VMware create activity: the concerned item whose Type matches
+// expectedType. It is FAIL-CLOSED — it requires EXACTLY ONE such item and errors
+// otherwise:
+//   - a nil activity, or no concerned item of the type, means the create
+//     succeeded server-side but its id could not be resolved → the caller must
+//     surface this as a FAILURE (observable, run exits non-zero) rather than
+//     record a misleading OK; the teardown (registered before the create) still
+//     sweeps the created resource by name (VM) or VM-scope (disk/adapter);
+//   - MORE THAN ONE matching item is ambiguous (a stale/duplicate concerned item)
+//     → refuse to guess which is ours and error, so the caller never deletes a
+//     possibly-wrong resource by a mis-resolved id (it falls back to the safe
+//     VM-scoped delete-all instead).
+//
+// This is deliberately STRICTER than the provider's setIdFromActivityConcernedItems
+// (which takes the first match): a destructive load cycle must not act on an
+// ambiguous or unverifiable id.
+func resolveActivityConcernedItemID(act *client.Activity, expectedType string) (string, error) {
+	if act == nil {
+		return "", fmt.Errorf("create activity is nil: cannot resolve the %s id", expectedType)
+	}
+	var found string
+	for _, ci := range act.ConcernedItems {
+		if ci.Type == expectedType && ci.ID != "" {
+			if found != "" {
+				return "", fmt.Errorf("ambiguous create activity: more than one %s concerned item", expectedType)
+			}
+			found = ci.ID
+		}
+	}
+	if found == "" {
+		return "", fmt.Errorf("create activity carried no %s concerned item: created id unresolved", expectedType)
+	}
+	return found, nil
+}
+
+func (cyc computeVMwareLifecycleCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	// Collision-free identity, same contract as the OpenIaaS cycle: abort BEFORE
+	// creating anything if randomness is unavailable (no non-unique identity on a
+	// destructive write cycle). Recorded as a FAILURE op so the run exits non-zero.
+	var token string
+	if r.op(cyc, "compute.vmware.run_identity", func() error {
+		t, e := cyc.mkToken()
+		token = t
+		return e
+	}) != nil {
+		return nil
+	}
+	name := fmt.Sprintf("ct-validate-%s-%d-%d", token, r.Iteration, r.Worker)
+
+	cm := c.Compute()
+
+	// Every write/deprovision step, in order — used to skip-record the whole cycle
+	// when the substrate is absent (VMware not on this tenant, or no usable
+	// datacenter/host/datastore/guest-OS).
+	writeSteps := []string{
+		"compute.vmware.virtual_machine.create",
+		"compute.vmware.virtual_disk.create",
+		"compute.vmware.network_adapter.create",
+		"compute.vmware.virtual_machine.read",
+		"compute.vmware.network_adapter.delete",
+		"compute.vmware.virtual_disk.delete",
+		"compute.vmware.virtual_machine.delete",
+	}
+	skipAll := func() {
+		for _, ep := range writeSteps {
+			r.skip(cyc, ep)
+		}
+	}
+
+	// --- PHASE 0: substrate (all read-discovered; never guess) ------------------
+	// Probe the datacenter list once: a 4xx means VMware is not available/usable on
+	// this tenant (e.g. an OpenIaaS-only tenant), so SKIP the whole cycle rather
+	// than emit a false "squeak" per write step. A 5xx/timeout still surfaces as a
+	// real failure on the probe (and trips the breaker).
+	var dcID, mmID string
+	dcErr := r.op(cyc, "compute.vmware.virtual_datacenters.list", func() error {
+		dcs, err := cm.VirtualDatacenter().List(ctx, nil)
+		if err != nil {
+			return err
+		}
+		for _, dc := range dcs {
+			if dc != nil && dc.ID != "" {
+				dcID = dc.ID
+				mmID = dc.MachineManager.ID // the vCenter (machineManagerId) this datacenter belongs to
+				break
+			}
+		}
+		return nil
+	})
+	if categorize(dcErr) == CategoryHTTP4xx || dcID == "" {
+		r.skip(cyc, "compute.vmware.host_clusters.list")
+		r.skip(cyc, "compute.vmware.datastores.list")
+		r.skip(cyc, "compute.vmware.networks.list")
+		r.skip(cyc, "compute.vmware.guest_operating_systems.list")
+		skipAll()
+		return nil
+	}
+
+	// Placement: a HOST CLUSTER. The provider makes host_cluster_id mandatory for
+	// every VMware create path (an individual host_id is optional), so the cluster
+	// is the required placement unit; we let the cluster choose the host. Every
+	// substrate list is scoped by both machineManagerId (the vCenter) and
+	// datacenterId — the documented VMware id-chaining tree.
+	var hostClusterID string
+	_ = r.op(cyc, "compute.vmware.host_clusters.list", func() error {
+		hcs, err := cm.HostCluster().List(ctx, &client.HostClusterFilter{MachineManagerId: mmID, DatacenterId: dcID})
+		if err != nil {
+			return err
+		}
+		for _, hc := range hcs {
+			if hc != nil && hc.ID != "" {
+				hostClusterID = hc.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	var datastoreID string
+	_ = r.op(cyc, "compute.vmware.datastores.list", func() error {
+		dss, err := cm.Datastore().List(ctx, &client.DatastoreFilter{MachineManagerId: mmID, DatacenterId: dcID})
+		if err != nil {
+			return err
+		}
+		for _, ds := range dss {
+			// Only an accessible, non-maintenance datastore with room for the disk.
+			if ds != nil && ds.ID != "" && !ds.MaintenanceMode && ds.Accessible != 0 && ds.FreeCapacity >= vmwDiskSize {
+				datastoreID = ds.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	// A network is OPTIONAL: without one the adapter sub-steps are skipped, but the
+	// VM create+disk+delete still run.
+	var networkID string
+	_ = r.op(cyc, "compute.vmware.networks.list", func() error {
+		nets, err := cm.Network().List(ctx, &client.NetworkFilter{MachineManagerId: mmID, DatacenterId: dcID})
+		if err != nil {
+			return err
+		}
+		for _, n := range nets {
+			if n != nil && n.ID != "" {
+				networkID = n.ID
+				break
+			}
+		}
+		return nil
+	})
+
+	// Guest-OS moref needs a host-cluster (or host) scope.
+	var osMoref string
+	if hostClusterID != "" {
+		_ = r.op(cyc, "compute.vmware.guest_operating_systems.list", func() error {
+			oses, err := cm.GuestOperatingSystem().List(ctx, &client.GuestOperatingSystemFilter{HostClusterID: hostClusterID})
+			if err != nil {
+				return err
+			}
+			for _, os := range oses {
+				if os != nil && os.Moref != "" {
+					osMoref = os.Moref
+					break
+				}
+			}
+			return nil
+		})
+	} else {
+		r.skip(cyc, "compute.vmware.guest_operating_systems.list")
+	}
+
+	// A VM create needs datacenter + host cluster + datastore + guest-OS moref. Any
+	// missing → nothing to deploy from → skip the write block (not a failure).
+	if hostClusterID == "" || datastoreID == "" || osMoref == "" {
+		skipAll()
+		return nil
+	}
+
+	// --- PHASE 1: provision the VM (teardown registered BEFORE the create) ------
+	vmRef := &vmwareVMTeardownRef{Name: name, DatacenterID: dcID}
+	registerVMwareVMTeardown(r.Cleanup, computeVMwareVMSeam{c}, vmRef)
+	var vmID string
+	_ = r.op(cyc, "compute.vmware.virtual_machine.create", func() error {
+		activityID, err := cm.VirtualMachine().Create(ctx, &client.CreateVirtualMachineRequest{
+			Name:                      name,
+			DatacenterId:              dcID,
+			HostClusterId:             hostClusterID,
+			DatastoreId:               datastoreID,
+			CPU:                       vmwVMCPU,
+			Memory:                    vmwVMMemory,
+			GuestOperatingSystemMoref: osMoref,
+		})
+		if err != nil {
+			return err
+		}
+		act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		if werr != nil {
+			return werr
+		}
+		id, rerr := resolveActivityConcernedItemID(act, "virtual_machine")
+		if rerr != nil {
+			return rerr // observable failure; the pre-registered VM teardown sweeps it by name
+		}
+		vmID = id
+		return nil
+	})
+	if vmID == "" {
+		// Create failed or its id did not resolve: the deferred VM teardown (by
+		// name) sweeps it. Nothing further to provision/deprovision explicitly.
+		for _, ep := range []string{
+			"compute.vmware.virtual_disk.create", "compute.vmware.network_adapter.create",
+			"compute.vmware.virtual_machine.read",
+			"compute.vmware.network_adapter.delete", "compute.vmware.virtual_disk.delete",
+			"compute.vmware.virtual_machine.delete",
+		} {
+			r.skip(cyc, ep)
+		}
+		return nil
+	}
+	vmRef.ID, vmRef.Resolved = vmID, true
+
+	// --- PHASE 2: storage variation — attach a user data disk ------------------
+	// The disk carries no caller-chosen name (the VMware API assigns one), so the
+	// teardown recovers it by the VM it is attached to, not by name.
+	diskRef := &vmwareDiskTeardownRef{VMID: vmID}
+	registerVMwareDiskTeardown(r.Cleanup, computeVMwareDiskSeam{c}, diskRef)
+	var diskID string
+	_ = r.op(cyc, "compute.vmware.virtual_disk.create", func() error {
+		activityID, err := cm.VirtualDisk().Create(ctx, &client.CreateVirtualDiskRequest{
+			ProvisioningType: vmwDiskProvKey,
+			DiskMode:         vmwDiskMode,
+			Capacity:         vmwDiskSize,
+			VirtualMachineId: vmID,
+			DatastoreId:      datastoreID,
+		})
+		if err != nil {
+			return err
+		}
+		act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+		if werr != nil {
+			return werr
+		}
+		id, rerr := resolveActivityConcernedItemID(act, "virtual_disk")
+		if rerr != nil {
+			// Observable failure; diskID stays "" so the deprovision falls back to
+			// the VM-scoped delete-all, which removes the created disk regardless.
+			return rerr
+		}
+		diskID = id
+		return nil
+	})
+	if diskID != "" {
+		diskRef.ID, diskRef.Resolved = diskID, true
+	}
+
+	// --- PHASE 3: network connection — attach a user adapter (optional) ---------
+	// On VMware the Create already attaches the adapter to the network (unlike the
+	// OpenIaaS flow, which needs a separate Connect). Connect/Disconnect only flip
+	// the live link state and are needlessly fragile on a fresh VM, so the cycle
+	// stops at Create — the network connection is realized at provision time.
+	var adapterID string
+	if networkID != "" {
+		adapterRef := &vmwareAdapterTeardownRef{VMID: vmID}
+		registerVMwareNetworkAdapterTeardown(r.Cleanup, computeVMwareAdapterSeam{c}, adapterRef)
+		_ = r.op(cyc, "compute.vmware.network_adapter.create", func() error {
+			activityID, err := cm.NetworkAdapter().Create(ctx, &client.CreateNetworkAdapterRequest{
+				VirtualMachineId: vmID,
+				NetworkId:        networkID,
+				Type:             vmwAdapterType,
+				// MAC omitted: the platform assigns it (no MAC-collision surface).
+			})
+			if err != nil {
+				return err
+			}
+			act, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
+			if werr != nil {
+				return werr
+			}
+			id, rerr := resolveActivityConcernedItemID(act, "network_adapter")
+			if rerr != nil {
+				// Observable failure; adapterID stays "" so the deprovision falls back
+				// to the VM-scoped delete-all, which removes the created adapter.
+				return rerr
+			}
+			adapterID = id
+			return nil
+		})
+		if adapterID != "" {
+			adapterRef.ID, adapterRef.Resolved = adapterID, true
+		}
+	} else {
+		r.skip(cyc, "compute.vmware.network_adapter.create")
+	}
+
+	// Observational read of the assembled VM.
+	_ = r.op(cyc, "compute.vmware.virtual_machine.read", func() error {
+		_, err := cm.VirtualMachine().Read(ctx, vmID)
+		return err
+	})
+
+	// --- PHASE 4: deprovision (explicit + recorded; leaves-first, WHILE THE VM
+	// STILL EXISTS) ---
+	vmwareDeprovision(ctx, r, cyc, vmID, networkID, adapterID, diskID,
+		computeVMwareAdapterSeam{c}, computeVMwareDiskSeam{c}, computeVMwareVMSeam{c})
+	return nil
+}
+
+// deleteVMwareLeaves removes a VM-scoped leaf (disk or adapter): the resolved id
+// when known, else EVERY such leaf the VM still carries (VM-scoped delete-all).
+// Idempotent via the seam's 404-only delete. The find-and-delete-all path is what
+// recovers a created-but-id-unresolved leaf — and it only works WHILE THE VM (the
+// only listing that can find a nameless VMware leaf) still exists, which is why
+// the caller runs this BEFORE deleting the VM.
+func deleteVMwareLeaves(ctx context.Context, resolvedID string, findIDsByVM func() ([]string, error), deleteAndWait func(context.Context, string) error) error {
+	if resolvedID != "" {
+		return deleteAndWait(ctx, resolvedID)
+	}
+	ids, err := findIDsByVM()
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if derr := deleteAndWait(ctx, id); derr != nil {
+			return derr
+		}
+	}
+	return nil
+}
+
+// vmwareDeprovision tears the assembled stack down leaves-first and, crucially,
+// removes every VM-scoped leaf BEFORE deleting the VM anchor. This closes an
+// orphan window the deferred teardown alone cannot: a created-but-id-unresolved
+// VMware disk/adapter has NO caller-chosen name, so once the VM (the only listing
+// that can find it) is gone it is unrecoverable. Sweeping while the VM still
+// exists guarantees it is caught — never relying on the VM delete to cascade it.
+//
+// Every step is breaker-gated and recorded; deletes are idempotent (404-only) via
+// the seams, so this safely overlaps the deferred TeardownAll (which remains the
+// backstop when the breaker trips mid-cycle and the VM is therefore NOT deleted
+// here, so its leaves are still listable). networkID == "" means no adapter was
+// attached, so its delete step is a recorded skip.
+func vmwareDeprovision(ctx context.Context, r *Run, cyc Cycle, vmID, networkID, adapterID, diskID string,
+	adapterSeam vmwareAdapterSeam, diskSeam vmwareDiskSeam, vmSeam vmwareVMSeam) {
+
+	// Track whether EVERY leaf removal was confirmed. A leaf op that ran and
+	// returned an error (r.op returns non-nil only when fn actually ran and
+	// failed; a breaker-skip returns nil) means a nameless leaf may still exist —
+	// we must NOT then destroy the VM anchor, or that leaf becomes unrecoverable
+	// (no name, and the VM-scoped listing that finds it is gone). Keep the VM so
+	// the deferred TeardownAll can retry the sweep (and the VM) while it still
+	// exists.
+	leavesSwept := true
+
+	if networkID != "" {
+		if r.op(cyc, "compute.vmware.network_adapter.delete", func() error {
+			return deleteVMwareLeaves(ctx, adapterID,
+				func() ([]string, error) { return adapterSeam.FindIDsByVM(ctx, vmID) },
+				adapterSeam.DeleteAndWait)
+		}) != nil {
+			leavesSwept = false
+		}
+	} else {
+		r.skip(cyc, "compute.vmware.network_adapter.delete")
+	}
+
+	if r.op(cyc, "compute.vmware.virtual_disk.delete", func() error {
+		return deleteVMwareLeaves(ctx, diskID,
+			func() ([]string, error) { return diskSeam.FindIDsByVM(ctx, vmID) },
+			diskSeam.DeleteAndWait)
+	}) != nil {
+		leavesSwept = false
+	}
+
+	// The VM anchor LAST — and ONLY if every leaf was confirmed gone. A failed leaf
+	// removal leaves the VM in place (recorded skip) as the anchor for the deferred
+	// retry; never destroy the anchor while a nameless leaf might still hang off it.
+	if leavesSwept {
+		_ = r.op(cyc, "compute.vmware.virtual_machine.delete", func() error {
+			return vmSeam.DeleteAndWait(ctx, vmID)
+		})
+	} else {
+		r.skip(cyc, "compute.vmware.virtual_machine.delete")
+	}
+}

--- a/cmd/ct-validate/cycle_compute_vmware_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_vmware_lifecycle_test.go
@@ -1,0 +1,473 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// --- recording fake seams (offline, no client) — VMware siblings of the OpenIaaS
+// fakes in cycle_compute_lifecycle_test.go (distinct names, same package). ---
+
+type fakeVMwareVMSeam struct {
+	log     *[]string
+	findID  string
+	findErr error
+}
+
+func (f fakeVMwareVMSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "vm.delete:"+id)
+	return nil
+}
+func (f fakeVMwareVMSeam) PowerOffAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "vm.poweroff:"+id)
+	return nil
+}
+func (f fakeVMwareVMSeam) FindIDByName(_ context.Context, name, dcID string) (string, error) {
+	*f.log = append(*f.log, "vm.find:"+name+"@"+dcID)
+	return f.findID, f.findErr
+}
+
+type fakeVMwareDiskSeam struct {
+	log    *[]string
+	ids    []string // FindIDsByVM returns these
+	delErr error    // when non-nil, DeleteAndWait fails (e.g. a 409)
+}
+
+func (f fakeVMwareDiskSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
+	*f.log = append(*f.log, "disk.find:"+vmID)
+	return f.ids, nil
+}
+func (f fakeVMwareDiskSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "disk.delete:"+id)
+	return f.delErr
+}
+
+type fakeVMwareAdapterSeam struct {
+	log    *[]string
+	ids    []string // FindIDsByVM returns these
+	delErr error    // when non-nil, DeleteAndWait fails
+}
+
+func (f fakeVMwareAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
+	*f.log = append(*f.log, "adapter.find:"+vmID)
+	return f.ids, nil
+}
+func (f fakeVMwareAdapterSeam) DeleteAndWait(_ context.Context, id string) error {
+	*f.log = append(*f.log, "adapter.delete:"+id)
+	return f.delErr
+}
+
+// TestRegisterVMwareVMTeardownResolvedDeletesByID: a resolved ref deletes by id
+// (power-off best-effort first), never falling back to find-by-name. Mutation:
+// drop the `ref.Resolved` check → find-by-name is used → "vm.find" appears.
+func TestRegisterVMwareVMTeardownResolvedDeletesByID(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareVMTeardown(cl, fakeVMwareVMSeam{log: &log, findID: "should-not-be-used"},
+		&vmwareVMTeardownRef{Name: "vm-a", DatacenterID: "dc-1", ID: "vm-id-1", Resolved: true})
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "vm.find") != -1 {
+		t.Fatalf("a resolved ref must delete by id, not find by name; log=%v", log)
+	}
+	if indexOf(log, "vm.delete:vm-id-1") == -1 {
+		t.Fatalf("must delete by the resolved id; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareVMTeardownUnresolvedFindsByName: an UNRESOLVED ref (create id
+// never came back) finds the VM by its deterministic name within the datacenter
+// and deletes it — the reason the teardown is registered BEFORE the create.
+func TestRegisterVMwareVMTeardownUnresolvedFindsByName(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareVMTeardown(cl, fakeVMwareVMSeam{log: &log, findID: "found-vm-9"},
+		&vmwareVMTeardownRef{Name: "vm-b", DatacenterID: "dc-1"}) // not resolved
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "vm.find:vm-b@dc-1") == -1 || indexOf(log, "vm.delete:found-vm-9") == -1 {
+		t.Fatalf("unresolved ref must find-by-name then delete; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareVMTeardownNotFoundIsNoop: unresolved + not found → nothing to
+// do, no delete (idempotent: never created / already gone).
+func TestRegisterVMwareVMTeardownNotFoundIsNoop(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareVMTeardown(cl, fakeVMwareVMSeam{log: &log, findID: ""},
+		&vmwareVMTeardownRef{Name: "vm-c", DatacenterID: "dc-1"})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("not-found teardown must be a no-op success, got failures %v", f)
+	}
+	if indexOf(log, "vm.delete") != -1 {
+		t.Fatalf("nothing must be deleted when not found; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareDiskTeardownResolvedDeletesByID: a resolved disk deletes by
+// id, never listing the VM. Mutation: drop the Resolved check → "disk.find"
+// appears.
+func TestRegisterVMwareDiskTeardownResolvedDeletesByID(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareDiskTeardown(cl, fakeVMwareDiskSeam{log: &log, ids: []string{"should-not-be-used"}},
+		&vmwareDiskTeardownRef{VMID: "vm-1", ID: "disk-7", Resolved: true})
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "disk.find") != -1 {
+		t.Fatalf("a resolved disk must delete by id, not list the VM; log=%v", log)
+	}
+	if indexOf(log, "disk.delete:disk-7") == -1 {
+		t.Fatalf("must delete by the resolved id; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareDiskTeardownUnresolvedDeletesAllOnVM: an UNRESOLVED disk
+// (id never came back; the VMware create carries no name to find it by) is
+// recovered by deleting EVERY disk on the (run-unique, ours, created-diskless) VM.
+// Mutation: drop the find/delete-all loop → the created-but-unresolved disk
+// orphans.
+func TestRegisterVMwareDiskTeardownUnresolvedDeletesAllOnVM(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareDiskTeardown(cl, fakeVMwareDiskSeam{log: &log, ids: []string{"disk-1", "disk-2"}},
+		&vmwareDiskTeardownRef{VMID: "vm-1"}) // unresolved
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "disk.find:vm-1") == -1 || indexOf(log, "disk.delete:disk-1") == -1 || indexOf(log, "disk.delete:disk-2") == -1 {
+		t.Fatalf("unresolved disk must list the VM and delete every disk; log=%v", log)
+	}
+}
+
+// TestVMwareLeafTeardownDeferredNoopWhenVMGone pins the deferred-after-explicit
+// case: when the explicit deprovision already swept a leaf and deleted the VM, the
+// deferred (unresolved) disk/adapter teardown relists the now-gone VM. With the
+// realistic gone-VM listing (empty), the teardown is a clean NO-OP — no false
+// teardown failure, nothing deleted. (A non-200 listing on a gone VM would instead
+// surface as a failure: fail-safe, never an orphan, since the explicit phase
+// already removed the leaf while the VM existed.)
+func TestVMwareLeafTeardownDeferredNoopWhenVMGone(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareDiskTeardown(cl, fakeVMwareDiskSeam{log: &log, ids: nil}, // VM gone → empty listing
+		&vmwareDiskTeardownRef{VMID: "vm-gone"})
+	registerVMwareNetworkAdapterTeardown(cl, fakeVMwareAdapterSeam{log: &log, ids: nil},
+		&vmwareAdapterTeardownRef{VMID: "vm-gone"})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("deferred leaf teardown must be a clean no-op when the VM is gone, got failures %v", f)
+	}
+	if indexOf(log, "disk.delete") != -1 || indexOf(log, "adapter.delete") != -1 {
+		t.Fatalf("nothing to delete when the VM-scoped listing is empty; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareNetworkAdapterTeardownResolvedDeletesByID: a resolved adapter
+// is deleted by id, no VM-wide listing.
+func TestRegisterVMwareNetworkAdapterTeardownResolvedDeletesByID(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareNetworkAdapterTeardown(cl, fakeVMwareAdapterSeam{log: &log, ids: []string{"should-not-be-used"}},
+		&vmwareAdapterTeardownRef{VMID: "vm-1", ID: "ad-3", Resolved: true})
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "adapter.find") != -1 {
+		t.Fatalf("a resolved adapter must delete by id, not list the VM; log=%v", log)
+	}
+	if indexOf(log, "adapter.delete:ad-3") == -1 {
+		t.Fatalf("must delete the resolved adapter id; log=%v", log)
+	}
+}
+
+// TestRegisterVMwareNetworkAdapterTeardownUnresolvedDeletesAllOnVM: an UNRESOLVED
+// adapter (id never came back, MAC platform-assigned) is recovered by deleting
+// EVERY adapter on the (run-unique, ours) VM. Mutation: drop the delete-all loop →
+// the created-but-unresolved adapter orphans.
+func TestRegisterVMwareNetworkAdapterTeardownUnresolvedDeletesAllOnVM(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareNetworkAdapterTeardown(cl, fakeVMwareAdapterSeam{log: &log, ids: []string{"ad-1", "ad-2"}},
+		&vmwareAdapterTeardownRef{VMID: "vm-1"}) // unresolved
+	cl.TeardownAll(context.Background())
+	if indexOf(log, "adapter.find:vm-1") == -1 || indexOf(log, "adapter.delete:ad-1") == -1 || indexOf(log, "adapter.delete:ad-2") == -1 {
+		t.Fatalf("unresolved adapter must list the VM and delete every adapter; log=%v", log)
+	}
+}
+
+// TestVMwareLifecycleTeardownLIFOOrder pins leaves-first: registering VM, then
+// disk, then adapter (the cycle's creation order) makes TeardownAll remove them in
+// REVERSE — adapter, then disk, then VM (anchor last). Mutation: register the VM
+// teardown AFTER the disk/adapter → LIFO deletes the VM before its devices → RED.
+func TestVMwareLifecycleTeardownLIFOOrder(t *testing.T) {
+	var log []string
+	cl := NewCleanup()
+	registerVMwareVMTeardown(cl, fakeVMwareVMSeam{log: &log}, &vmwareVMTeardownRef{Name: "vm", DatacenterID: "dc-1", ID: "vm-1", Resolved: true})
+	registerVMwareDiskTeardown(cl, fakeVMwareDiskSeam{log: &log}, &vmwareDiskTeardownRef{VMID: "vm-1", ID: "disk-1", Resolved: true})
+	registerVMwareNetworkAdapterTeardown(cl, fakeVMwareAdapterSeam{log: &log}, &vmwareAdapterTeardownRef{VMID: "vm-1", ID: "ad-1", Resolved: true})
+
+	cl.TeardownAll(context.Background())
+
+	a, d, v := indexOf(log, "adapter.delete"), indexOf(log, "disk.delete"), indexOf(log, "vm.delete")
+	if a == -1 || d == -1 || v == -1 || !(a < d && d < v) {
+		t.Fatalf("LIFO must tear down leaves-first (adapter < disk < vm), got order %v", log)
+	}
+}
+
+// TestVMwareDeprovisionSweepsUnresolvedLeavesBeforeVMDelete pins the ordering
+// invariant: when a disk/adapter id never resolved, the explicit deprovision must
+// list the VM and delete EVERY leaf BEFORE deleting the VM — because a nameless
+// VMware leaf can only be found via the VM-scoped listing, which is impossible
+// once the VM is gone (the deferred teardown alone cannot save this case). Mutation:
+// reorder vmwareDeprovision to delete the VM first, or skip the unresolved sweep →
+// the "leaf before VM" assertion goes RED.
+func TestVMwareDeprovisionSweepsUnresolvedLeavesBeforeVMDelete(t *testing.T) {
+	var log []string
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	// adapterID and diskID empty (unresolved) — recovery must go VM-scoped.
+	vmwareDeprovision(context.Background(), r, computeVMwareLifecycleCycle{},
+		"vm-1", "net-1", "", "",
+		fakeVMwareAdapterSeam{log: &log, ids: []string{"ad-1"}},
+		fakeVMwareDiskSeam{log: &log, ids: []string{"disk-1"}},
+		fakeVMwareVMSeam{log: &log})
+
+	a := indexOf(log, "adapter.delete:ad-1")
+	d := indexOf(log, "disk.delete:disk-1")
+	v := indexOf(log, "vm.delete:vm-1")
+	if a == -1 || d == -1 || v == -1 {
+		t.Fatalf("every unresolved leaf and the VM must be deleted; log=%v", log)
+	}
+	if !(a < v && d < v) {
+		t.Fatalf("unresolved leaves MUST be swept BEFORE the VM delete (else they orphan); log=%v", log)
+	}
+}
+
+// TestVMwareDeprovisionKeepsVMWhenLeafDeleteFails pins the anchor-safety rule: if a
+// leaf removal FAILS (e.g. a 409), the VM anchor must NOT be deleted — destroying
+// it would strand the nameless leaf (no name, and the VM-scoped listing that finds
+// it would be gone). The VM is kept for the deferred TeardownAll to retry. Mutation:
+// delete the VM regardless of leaf-delete failures → "vm.delete" appears → RED.
+func TestVMwareDeprovisionKeepsVMWhenLeafDeleteFails(t *testing.T) {
+	var log []string
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	vmwareDeprovision(context.Background(), r, computeVMwareLifecycleCycle{},
+		"vm-1", "net-1", "ad-1", "disk-1",
+		fakeVMwareAdapterSeam{log: &log},
+		fakeVMwareDiskSeam{log: &log, delErr: errors.New("409 disk busy")},
+		fakeVMwareVMSeam{log: &log})
+	if indexOf(log, "disk.delete:disk-1") == -1 {
+		t.Fatalf("the disk delete must have been attempted; log=%v", log)
+	}
+	if indexOf(log, "vm.delete") != -1 {
+		t.Fatalf("a failed leaf delete MUST NOT delete the VM anchor (it would strand the nameless leaf); log=%v", log)
+	}
+}
+
+// TestVMwareDeprovisionResolvedDeletesByIDBeforeVM pins that resolved leaves are
+// deleted by id (no VM listing) and still before the VM.
+func TestVMwareDeprovisionResolvedDeletesByIDBeforeVM(t *testing.T) {
+	var log []string
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	vmwareDeprovision(context.Background(), r, computeVMwareLifecycleCycle{},
+		"vm-1", "net-1", "ad-9", "disk-9",
+		fakeVMwareAdapterSeam{log: &log, ids: []string{"should-not-be-listed"}},
+		fakeVMwareDiskSeam{log: &log, ids: []string{"should-not-be-listed"}},
+		fakeVMwareVMSeam{log: &log})
+	if indexOf(log, "adapter.find") != -1 || indexOf(log, "disk.find") != -1 {
+		t.Fatalf("resolved leaves must delete by id, not list the VM; log=%v", log)
+	}
+	a, d, v := indexOf(log, "adapter.delete:ad-9"), indexOf(log, "disk.delete:disk-9"), indexOf(log, "vm.delete:vm-1")
+	if a == -1 || d == -1 || v == -1 || !(a < v && d < v) {
+		t.Fatalf("resolved leaves must delete by id before the VM; log=%v", log)
+	}
+}
+
+// TestResolveActivityConcernedItemID pins the FAIL-CLOSED VMware create-id
+// resolution: exactly one matching-type concerned item returns its id; a nil
+// activity, a no-match, or MORE THAN ONE match all ERROR (never a silent "" the
+// caller could treat as OK, never a guessed id from an ambiguous activity).
+// Mutations: ignore the Type filter → wrong-type returns "n-1" not error → RED;
+// return "" instead of error on no-match → RED; take the first on duplicates → RED.
+func TestResolveActivityConcernedItemID(t *testing.T) {
+	act := &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+		{ID: "n-1", Type: "network_adapter"},
+		{ID: "vm-7", Type: "virtual_machine"},
+	}}
+	if id, err := resolveActivityConcernedItemID(act, "virtual_machine"); err != nil || id != "vm-7" {
+		t.Fatalf("exactly one match must return its id, got id=%q err=%v", id, err)
+	}
+	if _, err := resolveActivityConcernedItemID(act, "virtual_disk"); err == nil {
+		t.Fatal("a no-match must ERROR (created id unresolved), got nil — a silent \"\" would be a false OK")
+	}
+	if _, err := resolveActivityConcernedItemID(nil, "virtual_machine"); err == nil {
+		t.Fatal("a nil activity must ERROR, got nil")
+	}
+	dup := &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+		{ID: "d-1", Type: "virtual_disk"}, {ID: "d-2", Type: "virtual_disk"},
+	}}
+	if _, err := resolveActivityConcernedItemID(dup, "virtual_disk"); err == nil {
+		t.Fatal("two matching concerned items must fail closed (ambiguous), got nil — guessing could delete the wrong resource")
+	}
+}
+
+// TestComputeVMwareVMSeamFindIDByNameFailsHardOnDuplicate pins that the unresolved
+// find-by-name REFUSES to pick a VM when more than one shares the (run-unique)
+// name — it fails closed rather than risk deleting the wrong VM.
+func TestComputeVMwareVMSeamFindIDByNameFailsHardOnDuplicate(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"a","name":"dup"},{"id":"b","name":"dup"}]`))
+	})
+	if _, err := (computeVMwareVMSeam{c}).FindIDByName(context.Background(), "dup", "dc-1"); err == nil {
+		t.Fatal("two VMs sharing the name must fail closed (refuse to delete the wrong one), got nil error")
+	}
+}
+
+// TestComputeVMwareDiskSeamFindIDsByVM pins that the disk teardown recovers a
+// created-but-id-unresolved disk by listing the VM's disks (VM-scoped, strict),
+// since the VMware create carries no caller-chosen name. Every disk on the
+// run-unique, created-diskless VM is one we attached. Mutation: scope the listing
+// to the wrong key / drop a returned id → the orphan disk is missed → RED.
+func TestComputeVMwareDiskSeamFindIDsByVM(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("virtualMachineId"); got != "vm-1" {
+			t.Errorf("disk listing must be scoped to the VM, got virtualMachineId=%q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"disk-1"},{"id":"disk-2"}]`))
+	})
+	ids, err := (computeVMwareDiskSeam{c}).FindIDsByVM(context.Background(), "vm-1")
+	if err != nil || len(ids) != 2 || ids[0] != "disk-1" || ids[1] != "disk-2" {
+		t.Fatalf("must return every disk attached to the VM, got ids=%v err=%v", ids, err)
+	}
+}
+
+// TestRegistryHasComputeVMwareLifecycleGated: the cycle is registered, write-typed,
+// and gated out unless -write is set.
+func TestRegistryHasComputeVMwareLifecycleGated(t *testing.T) {
+	reg := buildRegistry()
+	sel, gated, err := reg.Select("compute_vmware_lifecycle", false)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if len(sel) != 0 {
+		t.Fatalf("compute_vmware_lifecycle must be GATED without -write, got selected %v", sel)
+	}
+	if len(gated) != 1 || gated[0] != "compute_vmware_lifecycle" {
+		t.Fatalf("compute_vmware_lifecycle must be the gated write cycle, got %v", gated)
+	}
+	sel, _, _ = reg.Select("compute_vmware_lifecycle", true)
+	if len(sel) != 1 || sel[0].Name() != "compute_vmware_lifecycle" || sel[0].Kind() != KindWrite {
+		t.Fatalf("compute_vmware_lifecycle must be selectable (write) with -write, got %v", sel)
+	}
+}
+
+// TestComputeVMwareLifecycleSkipsWhenVMwareAbsent pins the probe-skip: a 4xx on the
+// datacenter list (VMware not available on this tenant) records every write step as
+// SKIPPED, attempts ZERO create, and registers ZERO teardown — it never fires a
+// create blindly. Mutation: remove the 4xx/empty skip guard → the cycle proceeds to
+// list hosts/datastores and beyond → the stub flags the unexpected extra call.
+func TestComputeVMwareLifecycleSkipsWhenVMwareAbsent(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("no write/create call expected when VMware is absent, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/vcenters/virtual_datacenters") {
+			w.WriteHeader(http.StatusForbidden) // VMware not on this tenant
+			return
+		}
+		t.Errorf("only the datacenter list should be called on a VMware-absent tenant, got GET %s", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	if err := (computeVMwareLifecycleCycle{}).Run(context.Background(), c, r); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if cl := r.Cleanup.Pending(); cl != 0 {
+		t.Fatalf("no teardown must be registered when VMware is absent, got %d pending", cl)
+	}
+	// The failure surface must be EXACTLY the datacenter probe — every other op is a
+	// clean skip (no per-step false squeak, no create/delete attempt). So the only
+	// non-skipped, non-OK op is the datacenter list itself.
+	for _, o := range r.Recorder.Ops() {
+		if o.Skipped || o.OK {
+			continue
+		}
+		if o.Endpoint != "compute.vmware.virtual_datacenters.list" {
+			t.Fatalf("the only failure when VMware is absent must be the datacenter probe, got a failed %s (%+v)", o.Endpoint, o)
+		}
+	}
+	for _, o := range r.Recorder.Ops() {
+		if strings.Contains(o.Endpoint, ".create") || strings.Contains(o.Endpoint, ".delete") || strings.Contains(o.Endpoint, ".connect") {
+			if !o.Skipped {
+				t.Fatalf("%s must be SKIPPED when VMware is absent, got %+v", o.Endpoint, o)
+			}
+		}
+	}
+}
+
+// TestComputeVMwareLifecycleSkipsWithoutUsableSubstrate pins that a present
+// datacenter with NO host (so no guest-OS moref can be discovered) skips every
+// write step and fires ZERO create — it refuses to create a VM without the
+// substrate it needs. Mutation: drop the `hostClusterID/datastoreID/osMoref` guard → a
+// create POST fires → the stub flags it.
+func TestComputeVMwareLifecycleSkipsWithoutUsableSubstrate(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("no create expected without a usable host, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/vcenters/virtual_datacenters"):
+			_, _ = w.Write([]byte(`[{"id":"dc-1","name":"DC"}]`)) // a datacenter exists
+		default:
+			_, _ = w.Write([]byte(`[]`)) // but no host / datastore / network / guest-OS
+		}
+	})
+
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	if err := (computeVMwareLifecycleCycle{}).Run(context.Background(), c, r); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if cl := r.Cleanup.Pending(); cl != 0 {
+		t.Fatalf("no teardown must be registered without a usable substrate, got %d pending", cl)
+	}
+	for _, o := range r.Recorder.Ops() {
+		if strings.Contains(o.Endpoint, ".create") || strings.Contains(o.Endpoint, ".delete") || strings.Contains(o.Endpoint, ".connect") {
+			if !o.Skipped {
+				t.Fatalf("%s must be SKIPPED without a usable substrate, got %+v", o.Endpoint, o)
+			}
+		}
+	}
+}
+
+// TestComputeVMwareLifecycleIdentityFailureIsObservable pins that a run-identity
+// generation failure creates NOTHING and is recorded as a FAILURE op (so the run
+// exits non-zero) — not a silent exit-0.
+func TestComputeVMwareLifecycleIdentityFailureIsObservable(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no call expected when identity generation fails, got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	cyc := computeVMwareLifecycleCycle{tokenFunc: func() (string, error) { return "", errors.New("no entropy") }}
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	_ = cyc.Run(context.Background(), c, r)
+
+	if r.Cleanup.Pending() != 0 {
+		t.Fatalf("nothing must be created/registered on an identity failure, got %d pending", r.Cleanup.Pending())
+	}
+	var failed bool
+	for _, o := range r.Recorder.Ops() {
+		if o.Endpoint == "compute.vmware.run_identity" && !o.OK && !o.Skipped {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Fatal("identity failure must be recorded as a failed op (observable, exit non-zero)")
+	}
+}

--- a/cmd/ct-validate/cycle_readonly.go
+++ b/cmd/ct-validate/cycle_readonly.go
@@ -164,51 +164,91 @@ func (rc readonlyCycle) runVPC(ctx context.Context, c *client.Client, r *Run) {
 }
 
 func (rc readonlyCycle) runCompute(ctx context.Context, c *client.Client, r *Run) {
-	// VMware compute.
+	// VMware compute. These lists need a machine_manager_id scope that this
+	// read-only smoke test cannot discover (the client exposes no VMware
+	// machine-manager listing). Probe the entry list once: a 4xx means VMware is
+	// not available/usable on this tenant, so SKIP the rest of the block rather
+	// than emit a false "squeak" per endpoint. A 5xx/timeout/transient still
+	// surfaces as a real failure on the probe.
 	var vms []*client.VirtualMachine
-	_ = r.op(rc, "compute.virtual_machines.list", func() error {
+	vmwareErr := r.op(rc, "compute.virtual_machines.list", func() error {
 		var err error
 		vms, err = c.Compute().VirtualMachine().List(ctx, nil)
 		return err
 	})
-	if len(vms) > 0 {
-		_ = r.op(rc, "compute.virtual_machines.read", func() error {
-			_, err := c.Compute().VirtualMachine().Read(ctx, vms[0].ID)
+	vmwareRest := []string{
+		"compute.virtual_machines.read", "compute.datastores.list",
+		"compute.hosts.list", "compute.networks.list",
+		"compute.virtual_datacenters.list", "compute.folders.list",
+		"compute.virtual_disks.list",
+	}
+	if categorize(vmwareErr) == CategoryHTTP4xx {
+		for _, ep := range vmwareRest {
+			r.skip(rc, ep)
+		}
+	} else {
+		if len(vms) > 0 {
+			_ = r.op(rc, "compute.virtual_machines.read", func() error {
+				_, err := c.Compute().VirtualMachine().Read(ctx, vms[0].ID)
+				return err
+			})
+		} else {
+			r.skip(rc, "compute.virtual_machines.read")
+		}
+		_ = r.op(rc, "compute.datastores.list", func() error {
+			_, err := c.Compute().Datastore().List(ctx, nil)
 			return err
 		})
-	} else {
-		r.skip(rc, "compute.virtual_machines.read")
+		_ = r.op(rc, "compute.hosts.list", func() error {
+			_, err := c.Compute().Host().List(ctx, nil)
+			return err
+		})
+		_ = r.op(rc, "compute.networks.list", func() error {
+			_, err := c.Compute().Network().List(ctx, nil)
+			return err
+		})
+		_ = r.op(rc, "compute.virtual_datacenters.list", func() error {
+			_, err := c.Compute().VirtualDatacenter().List(ctx, nil)
+			return err
+		})
+		_ = r.op(rc, "compute.folders.list", func() error {
+			_, err := c.Compute().Folder().List(ctx, nil)
+			return err
+		})
+		_ = r.op(rc, "compute.virtual_disks.list", func() error {
+			_, err := c.Compute().VirtualDisk().List(ctx, nil)
+			return err
+		})
 	}
-	_ = r.op(rc, "compute.datastores.list", func() error {
-		_, err := c.Compute().Datastore().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.hosts.list", func() error {
-		_, err := c.Compute().Host().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.networks.list", func() error {
-		_, err := c.Compute().Network().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.virtual_datacenters.list", func() error {
-		_, err := c.Compute().VirtualDatacenter().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.folders.list", func() error {
-		_, err := c.Compute().Folder().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.virtual_disks.list", func() error {
-		_, err := c.Compute().VirtualDisk().List(ctx, nil)
-		return err
-	})
 
-	// OpenIaaS compute.
+	// OpenIaaS compute. Discover the machine manager FIRST: EVERY OpenIaaS list
+	// (virtual_machines, networks, storage_repositories, templates, hosts,
+	// pools) is scoped by machine_manager_id — the API answers 5xx (sometimes
+	// intermittently) without it. Scope them all to the first machine manager;
+	// if the tenant has none, skip them.
+	var mms []*client.OpenIaaSMachineManager
+	_ = r.op(rc, "compute.openiaas.machine_managers.list", func() error {
+		var err error
+		mms, err = c.Compute().OpenIaaS().MachineManager().List(ctx)
+		return err
+	})
+	if len(mms) == 0 {
+		for _, ep := range []string{
+			"compute.openiaas.virtual_machines.list", "compute.openiaas.virtual_machines.read",
+			"compute.openiaas.networks.list", "compute.openiaas.storage_repositories.list",
+			"compute.openiaas.templates.list", "compute.openiaas.hosts.list", "compute.openiaas.pools.list",
+		} {
+			r.skip(rc, ep)
+		}
+		return
+	}
+	// Smoke read-only scope: the FIRST machine manager. On a multi-machine-manager
+	// tenant this maps one MM, not all of them (a fuller sweep would iterate mms).
+	mmID := mms[0].ID
 	var oVMs []*client.OpenIaaSVirtualMachine
 	_ = r.op(rc, "compute.openiaas.virtual_machines.list", func() error {
 		var err error
-		oVMs, err = c.Compute().OpenIaaS().VirtualMachine().ListStrict(ctx, nil)
+		oVMs, err = c.Compute().OpenIaaS().VirtualMachine().ListStrict(ctx, &client.OpenIaaSVirtualMachineFilter{MachineManagerID: mmID})
 		return err
 	})
 	if len(oVMs) > 0 {
@@ -219,37 +259,42 @@ func (rc readonlyCycle) runCompute(ctx context.Context, c *client.Client, r *Run
 	} else {
 		r.skip(rc, "compute.openiaas.virtual_machines.read")
 	}
-	_ = r.op(rc, "compute.openiaas.machine_managers.list", func() error {
-		_, err := c.Compute().OpenIaaS().MachineManager().List(ctx)
-		return err
-	})
 	_ = r.op(rc, "compute.openiaas.networks.list", func() error {
-		_, err := c.Compute().OpenIaaS().Network().List(ctx, nil)
+		_, err := c.Compute().OpenIaaS().Network().List(ctx, &client.OpenIaaSNetworkFilter{MachineManagerID: mmID})
 		return err
 	})
 	_ = r.op(rc, "compute.openiaas.storage_repositories.list", func() error {
-		_, err := c.Compute().OpenIaaS().StorageRepository().List(ctx, nil)
-		return err
-	})
-	_ = r.op(rc, "compute.openiaas.hosts.list", func() error {
-		_, err := c.Compute().OpenIaaS().Host().List(ctx, nil)
+		_, err := c.Compute().OpenIaaS().StorageRepository().List(ctx, &client.StorageRepositoryFilter{MachineManagerId: mmID})
 		return err
 	})
 	_ = r.op(rc, "compute.openiaas.templates.list", func() error {
-		_, err := c.Compute().OpenIaaS().Template().List(ctx, nil)
+		_, err := c.Compute().OpenIaaS().Template().List(ctx, &client.OpenIaaSTemplateFilter{MachineManagerId: mmID})
+		return err
+	})
+	_ = r.op(rc, "compute.openiaas.hosts.list", func() error {
+		_, err := c.Compute().OpenIaaS().Host().List(ctx, &client.OpenIaasHostFilter{MachineManagerId: mmID})
 		return err
 	})
 	_ = r.op(rc, "compute.openiaas.pools.list", func() error {
-		_, err := c.Compute().OpenIaaS().Pool().List(ctx, nil)
+		_, err := c.Compute().OpenIaaS().Pool().List(ctx, &client.OpenIaasPoolFilter{MachineManagerId: mmID})
 		return err
 	})
 }
 
 func (rc readonlyCycle) runBackup(ctx context.Context, c *client.Client, r *Run) {
-	_ = r.op(rc, "backup.sla_policies.list", func() error {
+	// Backup may be absent on a tenant. Probe once; a 4xx means "not available
+	// on this tenant", so skip the rest instead of emitting a squeak per
+	// endpoint. A 5xx/timeout still surfaces as a real failure on the probe.
+	backupErr := r.op(rc, "backup.sla_policies.list", func() error {
 		_, err := c.Backup().SLAPolicy().List(ctx, nil)
 		return err
 	})
+	if categorize(backupErr) == CategoryHTTP4xx {
+		for _, ep := range []string{"backup.sites.list", "backup.storages.list", "backup.spp_servers.list"} {
+			r.skip(rc, ep)
+		}
+		return
+	}
 	_ = r.op(rc, "backup.sites.list", func() error {
 		_, err := c.Backup().Site().List(ctx)
 		return err

--- a/cmd/ct-validate/cycle_readonly_test.go
+++ b/cmd/ct-validate/cycle_readonly_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// newReadonlyTestClient wires a Client to a stub HTTP server with a pre-seeded
+// far-future JWT, so the cycle exercises the real request/decoding path without
+// any auth network call.
+func newReadonlyTestClient(t *testing.T, h http.HandlerFunc) *client.Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	c, err := client.NewClient(&client.Config{Address: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.SavedToken = &jwt.Token{Claims: jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}}
+	return c
+}
+
+func opsByEndpoint(r *Run) map[string]Op {
+	m := map[string]Op{}
+	for _, o := range r.Recorder.Ops() {
+		m[o.Endpoint] = o
+	}
+	return m
+}
+
+// isVMwareVMList matches the VMware virtual-machines list (path
+// /compute/v1/vcenters/virtual_machines), NOT the OpenIaaS one.
+func isVMwareVMList(p string) bool {
+	return strings.Contains(p, "/vcenters/virtual_machines")
+}
+
+// isOpenIaaSMachineManagers matches the OpenIaaS machine-managers list, whose
+// path is the bare /compute/v1/open_iaas (no resource suffix).
+func isOpenIaaSMachineManagers(p string) bool {
+	return strings.HasSuffix(p, "/open_iaas")
+}
+
+// TestReadonlyComputeVMwareProbeSkips pins that a 4xx on the VMware probe
+// (compute.virtual_machines.list) SKIPS the rest of the VMware block instead of
+// emitting a failure per endpoint — a tenant without VMware must not produce
+// seven false "squeaks". Mutation proof: remove the
+// `categorize(vmwareErr)==CategoryHTTP4xx` skip branch in runCompute and those
+// endpoints are ATTEMPTED (recorded as failures, not skips) → RED.
+func TestReadonlyComputeVMwareProbeSkips(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case isVMwareVMList(p):
+			w.WriteHeader(http.StatusBadRequest) // 4xx → probe-skip the rest
+		case isOpenIaaSMachineManagers(p):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`)) // no machine manager → OpenIaaS scoped skipped too
+		default:
+			t.Errorf("unexpected call after probe-skip: %s %s", r.Method, p)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		}
+	})
+
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	readonlyCycle{}.runCompute(context.Background(), c, r)
+
+	ops := opsByEndpoint(r)
+	for _, ep := range []string{
+		"compute.virtual_machines.read", "compute.datastores.list", "compute.hosts.list",
+		"compute.networks.list", "compute.virtual_datacenters.list", "compute.folders.list",
+		"compute.virtual_disks.list",
+	} {
+		o, ok := ops[ep]
+		if !ok || !o.Skipped {
+			t.Fatalf("%s must be SKIPPED after the VMware probe 4xx, got %+v (present=%v)", ep, o, ok)
+		}
+	}
+	if o := ops["compute.virtual_machines.list"]; o.Skipped || o.Category != CategoryHTTP4xx {
+		t.Fatalf("the VMware probe must be recorded as a 4xx failure, got %+v", o)
+	}
+}
+
+// TestReadonlyComputeOpenIaaSScoped pins that every OpenIaaS list is scoped by
+// the discovered machine_manager_id (the API answers 5xx without it). Mutation
+// proof: pass a nil filter (drop the MachineManagerID) on any of these calls and
+// the "must carry machineManagerId=mm-1" assertion goes RED.
+func TestReadonlyComputeOpenIaaSScoped(t *testing.T) {
+	var mu sync.Mutex
+	scopedSeen := map[string]string{}
+
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case isOpenIaaSMachineManagers(p):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"mm-1"}]`))
+		case strings.Contains(p, "/open_iaas/"):
+			mu.Lock()
+			scopedSeen[p[strings.Index(p, "/open_iaas/"):]] = r.URL.Query().Get("machineManagerId")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default: // VMware block (probe ok-empty so it runs harmlessly) and anything else.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		}
+	})
+
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	readonlyCycle{}.runCompute(context.Background(), c, r)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, suffix := range []string{
+		"/open_iaas/virtual_machines", "/open_iaas/networks", "/open_iaas/storage_repositories",
+		"/open_iaas/templates", "/open_iaas/hosts", "/open_iaas/pools",
+	} {
+		if got := scopedSeen[suffix]; got != "mm-1" {
+			t.Fatalf("OpenIaaS list %s must be scoped by machineManagerId=mm-1, got %q (seen=%v)", suffix, got, scopedSeen)
+		}
+	}
+}
+
+// TestReadonlyBackupProbeSkips pins the same probe-and-skip on the backup block:
+// a 4xx on the entry list (backup.sla_policies.list) SKIPS the rest instead of
+// emitting a squeak per endpoint (tenant without backup). Mutation proof: remove
+// the `categorize(backupErr)==CategoryHTTP4xx` skip branch in runBackup and
+// sites/storages/spp_servers are ATTEMPTED (recorded as failures) → RED.
+func TestReadonlyBackupProbeSkips(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest) // runBackup only hits backup endpoints; 4xx on the probe
+	})
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	readonlyCycle{}.runBackup(context.Background(), c, r)
+
+	ops := opsByEndpoint(r)
+	if o := ops["backup.sla_policies.list"]; o.Skipped || o.Category != CategoryHTTP4xx {
+		t.Fatalf("the backup probe must be recorded as a 4xx failure, got %+v", o)
+	}
+	for _, ep := range []string{"backup.sites.list", "backup.storages.list", "backup.spp_servers.list"} {
+		o, ok := ops[ep]
+		if !ok || !o.Skipped {
+			t.Fatalf("%s must be SKIPPED after the backup probe 4xx, got %+v (present=%v)", ep, o, ok)
+		}
+	}
+}

--- a/cmd/ct-validate/cycle_test.go
+++ b/cmd/ct-validate/cycle_test.go
@@ -253,3 +253,48 @@ func TestRunOpSkipDoesNotFeedBreaker(t *testing.T) {
 		}
 	}
 }
+
+// TestRunOpBreakerTripsOnDistressNot4xx pins the breaker-distress fix: op()
+// feeds the breaker cat.isDistress(), NOT cat.isFailure(). A burst of
+// deterministic 4xx (client errors) must NOT trip the breaker — they are real
+// failures in the report but not API distress, and tripping would mask the rest
+// of the map. A 429 (rate-limited) and a 5xx MUST trip.
+//
+// Mutation proof: revert Run.op to feed cat.isFailure() and the 4xx burst trips
+// the breaker, so the "must NOT trip" assertion goes RED.
+func TestRunOpBreakerTripsOnDistressNot4xx(t *testing.T) {
+	c := fakeCycle{"readonly", KindRead}
+
+	t.Run("4xx burst does NOT trip", func(t *testing.T) {
+		b := NewBreaker(3, 1.0, 100)
+		r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+		for i := 0; i < 10; i++ {
+			_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 403} })
+		}
+		if b.Tripped() {
+			t.Fatal("a burst of deterministic 4xx must NOT trip the breaker (not API distress)")
+		}
+	})
+
+	t.Run("429 burst trips (rate limiting is distress)", func(t *testing.T) {
+		b := NewBreaker(3, 1.0, 100)
+		r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+		for i := 0; i < 3; i++ {
+			_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 429} })
+		}
+		if !b.Tripped() {
+			t.Fatal("429 (rate limiting) IS distress and must trip the breaker")
+		}
+	})
+
+	t.Run("5xx burst trips", func(t *testing.T) {
+		b := NewBreaker(3, 1.0, 100)
+		r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+		for i := 0; i < 3; i++ {
+			_ = r.op(c, "x.list", func() error { return client.StatusError{Code: 503} })
+		}
+		if !b.Tripped() {
+			t.Fatal("a 5xx burst must trip the breaker (real distress)")
+		}
+	})
+}

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -55,6 +55,7 @@ type flags struct {
 	jsonOut       bool
 	list          bool
 	apiSuffix     bool
+	quiet         bool
 }
 
 func parseFlags(args []string, out *os.File) (*flags, error) {
@@ -72,6 +73,7 @@ func parseFlags(args []string, out *os.File) (*flags, error) {
 	fs.BoolVar(&f.jsonOut, "json", false, "emit the report as JSON")
 	fs.BoolVar(&f.list, "list", false, "list available cycles and exit (no network)")
 	fs.BoolVar(&f.apiSuffix, "api-suffix", true, "prefix request paths with /api (client ApiSuffix)")
+	fs.BoolVar(&f.quiet, "quiet", false, "suppress the live per-operation progress lines (only print the final report)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(out, "ct-validate — endpoint validation & resilience harness (reads through internal/client)\n\n")
@@ -242,7 +244,18 @@ func run(args []string, stdout, stderr *os.File) int {
 	defer cancel()
 
 	breaker := NewBreaker(f.abortConsec, f.abortFailRate, f.abortWindow)
+	// Live progress goes to stderr (stdout stays reserved for the report/JSON),
+	// so the operator sees each endpoint as it runs. -quiet turns it off.
 	rec := NewRecorder()
+	if !f.quiet {
+		rec = NewRecorderWithProgress(stderr)
+		names := make([]string, 0, len(selected))
+		for _, cy := range selected {
+			names = append(names, cy.Name())
+		}
+		fmt.Fprintf(stderr, "Running %s — %d run(s), concurrency %d (live progress below; -quiet to silence)\n",
+			strings.Join(names, ", "), f.runs, f.concurrency)
+	}
 	cleanup := NewCleanup()
 	engine := NewEngine(EngineConfig{Runs: f.runs, Concurrency: f.concurrency}, breaker, rec, cleanup)
 

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -36,6 +36,7 @@ func buildRegistry() *Registry {
 		readonlyCycle{},
 		backupCycle{},
 		computeOpenIaaSCycle{},
+		computeLifecycleCycle{},
 		vpcCycle{},
 		objectStorageCycle{},
 		iamPATCycle{},
@@ -96,12 +97,27 @@ func parseFlags(args []string, out *os.File) (*flags, error) {
 	return f, nil
 }
 
+// Hard ceilings on the load knobs: a CLI warning is not enough for a tool that
+// can issue WRITE business cycles against a SHARED API. These guard against a
+// typo (e.g. -concurrency 5000); the circuit breaker is still the real-time
+// safety net. Raise deliberately in code if a genuine need arises.
+const (
+	maxRuns        = 10000
+	maxConcurrency = 64
+)
+
 func (f *flags) validate() error {
 	if f.runs < 1 {
 		return fmt.Errorf("-runs must be >= 1 (got %d)", f.runs)
 	}
+	if f.runs > maxRuns {
+		return fmt.Errorf("-runs must be <= %d (got %d): refusing a runaway load against a shared API", maxRuns, f.runs)
+	}
 	if f.concurrency < 1 {
 		return fmt.Errorf("-concurrency must be >= 1 (got %d)", f.concurrency)
+	}
+	if f.concurrency > maxConcurrency {
+		return fmt.Errorf("-concurrency must be <= %d (got %d): high concurrency on a shared API is dangerous", maxConcurrency, f.concurrency)
 	}
 	if f.timeout <= 0 {
 		return fmt.Errorf("-timeout must be > 0 (got %s)", f.timeout)

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
@@ -116,6 +118,53 @@ func (f *flags) validate() error {
 	return nil
 }
 
+// resolveTarget computes the scheme and host the client will ACTUALLY use,
+// mirroring NewClient's handling of a "scheme://" prefix embedded in the
+// address (internal/client/api.go). Precondition: cfg has already been resolved
+// by client.DefaultConfig() (as run() does), so cfg.Scheme/cfg.Address already
+// reflect the environment; under that precondition it prints/checks the exact
+// same target the requests will hit. An empty scheme defaults to https, matching
+// DefaultConfig.
+func resolveTarget(cfg *client.Config) (scheme, host string) {
+	scheme, host = cfg.Scheme, cfg.Address
+	if parts := strings.SplitN(cfg.Address, "://", 2); len(parts) == 2 {
+		scheme, host = parts[0], parts[1]
+	}
+	if scheme == "" {
+		scheme = "https"
+	}
+	return scheme, host
+}
+
+// preflight enforces the live-run safety guards the #316 audit flagged before
+// any request is issued against the SHARED recette API:
+//   - it PRINTS the resolved target (scheme://host) so the operator can confirm
+//     it is the intended recette host — the binary otherwise never shows where
+//     it is about to fire, and the default address looks production-like;
+//   - it REFUSES a non-HTTPS scheme: the credential exchange carries the PAT
+//     id/secret and must never travel in cleartext;
+//   - it FAILS FAST when credentials are missing, instead of firing
+//     empty-credential auth calls.
+//
+// The target line goes to w (stderr in run()); stdout stays reserved for the
+// report / JSON.
+func preflight(cfg *client.Config, w io.Writer) error {
+	scheme, host := resolveTarget(cfg)
+	fmt.Fprintf(w, "ct-validate: target = %s://%s (apiSuffix=%t) — confirm this is the intended RECETTE host\n",
+		scheme, host, cfg.ApiSuffix)
+
+	if scheme != "https" {
+		return fmt.Errorf("refusing to run over %q: the credential exchange would travel in cleartext; "+
+			"use https (unset %s or set it to https, and drop any \"http://\" prefix in %s)",
+			scheme, client.HTTPSchemeEnvName, client.HTTPAddrEnvName)
+	}
+	if strings.TrimSpace(cfg.ClientID) == "" || strings.TrimSpace(cfg.SecretID) == "" {
+		return fmt.Errorf("credentials not set: export %s and %s before running cycles",
+			client.HTTPClientIDEnvName, client.HTTPClientSecretEnvName)
+	}
+	return nil
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
@@ -159,6 +208,14 @@ func run(args []string, stdout, stderr *os.File) int {
 	// network and no credentials.
 	cfg := client.DefaultConfig()
 	cfg.ApiSuffix = f.apiSuffix
+
+	// Safety preflight: print the resolved target, refuse cleartext, and require
+	// credentials BEFORE building the client or firing any request (#316 audit).
+	if err := preflight(cfg, stderr); err != nil {
+		fmt.Fprintf(stderr, "ct-validate: %v\n", err)
+		return 2
+	}
+
 	c, err := client.NewClient(cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "ct-validate: building client: %v\n", err)

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -37,6 +37,7 @@ func buildRegistry() *Registry {
 		backupCycle{},
 		computeOpenIaaSCycle{},
 		computeLifecycleCycle{},
+		computeVMwareLifecycleCycle{},
 		vpcCycle{},
 		objectStorageCycle{},
 		iamPATCycle{},

--- a/cmd/ct-validate/main_preflight_test.go
+++ b/cmd/ct-validate/main_preflight_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestResolveTarget pins that resolveTarget reports the scheme/host the client
+// will ACTUALLY use, including the "scheme://" prefix override that NewClient
+// applies (api.go) — the exact path by which an http:// address silently
+// downgrades the transport. Mutation proof: drop the SplitN handling and the
+// "http://h" case resolves to scheme="https" (the cfg.Scheme), so the assertion
+// scheme=="http" goes RED.
+func TestResolveTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        client.Config
+		wantScheme string
+		wantHost   string
+	}{
+		{"plain host keeps scheme", client.Config{Address: "recette.example", Scheme: "https"}, "https", "recette.example"},
+		{"http scheme honored", client.Config{Address: "recette.example", Scheme: "http"}, "http", "recette.example"},
+		{"scheme prefix overrides", client.Config{Address: "http://recette.example", Scheme: "https"}, "http", "recette.example"},
+		{"empty scheme defaults https", client.Config{Address: "recette.example", Scheme: ""}, "https", "recette.example"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			scheme, host := resolveTarget(&cfg)
+			if scheme != tt.wantScheme || host != tt.wantHost {
+				t.Fatalf("resolveTarget = %q://%q, want %q://%q", scheme, host, tt.wantScheme, tt.wantHost)
+			}
+		})
+	}
+}
+
+// TestPreflightPrintsTarget pins that the resolved target is ALWAYS printed
+// before firing (the #316 must-fix mitigation: the operator must see where the
+// run is about to hit). Mutation proof: remove the Fprintf and the buffer no
+// longer contains the target line, so this goes RED.
+func TestPreflightPrintsTarget(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := &client.Config{Address: "recette.example", Scheme: "https", ClientID: "id", SecretID: "sec", ApiSuffix: true}
+	if err := preflight(cfg, &buf); err != nil {
+		t.Fatalf("a https target with creds must pass preflight, got: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "target = https://recette.example") || !strings.Contains(got, "apiSuffix=true") {
+		t.Fatalf("preflight must print the resolved target, got %q", got)
+	}
+}
+
+// TestPreflightRefusesNonHTTPS pins that a cleartext scheme is refused so the
+// PAT id/secret can never be sent in the open — both via CLOUDTEMPLE_HTTP_SCHEME
+// and via an http:// prefix in the address. Mutation proof: remove the scheme
+// check and both cases return nil, so the "expected an error" assertions go RED.
+func TestPreflightRefusesNonHTTPS(t *testing.T) {
+	cases := []client.Config{
+		{Address: "recette.example", Scheme: "http", ClientID: "id", SecretID: "sec"},
+		{Address: "http://recette.example", Scheme: "https", ClientID: "id", SecretID: "sec"},
+	}
+	for _, cfg := range cases {
+		var buf bytes.Buffer
+		c := cfg
+		err := preflight(&c, &buf)
+		if err == nil {
+			t.Fatalf("preflight must refuse a non-https target %q", cfg.Address)
+		}
+		if !strings.Contains(err.Error(), "cleartext") {
+			t.Fatalf("error should explain the cleartext risk, got: %v", err)
+		}
+		// The target is still printed even when refusing.
+		if !strings.Contains(buf.String(), "target =") {
+			t.Fatalf("preflight must print the target even when refusing, got %q", buf.String())
+		}
+	}
+}
+
+// TestPreflightRequiresCredentials pins fail-fast on missing creds (so the run
+// does not fire empty-credential auth calls). Mutation proof: remove the creds
+// check and a https target with empty creds returns nil, so this goes RED.
+func TestPreflightRequiresCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  client.Config
+	}{
+		{"no client id", client.Config{Address: "recette.example", Scheme: "https", SecretID: "sec"}},
+		{"no secret id", client.Config{Address: "recette.example", Scheme: "https", ClientID: "id"}},
+		{"neither", client.Config{Address: "recette.example", Scheme: "https"}},
+		{"whitespace only", client.Config{Address: "recette.example", Scheme: "https", ClientID: "  ", SecretID: "\t"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cfg := tt.cfg
+			err := preflight(&cfg, &buf)
+			if err == nil {
+				t.Fatal("preflight must fail fast when credentials are missing")
+			}
+			if !strings.Contains(err.Error(), "credentials not set") {
+				t.Fatalf("error should name the missing credentials, got: %v", err)
+			}
+		})
+	}
+}
+
+// captureRun drives the real harness entrypoint (run takes *os.File) against
+// temp files and returns the exit code plus captured stdout/stderr, so the
+// preflight WIRING — not just preflight() in isolation — is exercised.
+func captureRun(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	mk := func(name string) (*os.File, func() string) {
+		f, err := os.CreateTemp(t.TempDir(), name)
+		if err != nil {
+			t.Fatalf("temp %s: %v", name, err)
+		}
+		return f, func() string {
+			b, _ := os.ReadFile(f.Name())
+			return string(b)
+		}
+	}
+	outF, readOut := mk("stdout")
+	errF, readErr := mk("stderr")
+	code := run(args, outF, errF)
+	_ = outF.Close()
+	_ = errF.Close()
+	return code, readOut(), readErr()
+}
+
+// TestRunListBypassesPreflight pins that -list exits 0 WITHOUT reaching the
+// preflight (no resolved target printed, no client built, no network). Mutation
+// proof: move the preflight ahead of the -list early return and -list then
+// prints a "target =" line, so the "must not reach preflight" assertion goes RED.
+func TestRunListBypassesPreflight(t *testing.T) {
+	code, out, errOut := captureRun(t, "-list")
+	if code != 0 {
+		t.Fatalf("-list must exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(out, "Available cycles") {
+		t.Fatalf("-list must list cycles, got %q", out)
+	}
+	if strings.Contains(errOut, "target =") {
+		t.Fatalf("-list must not reach the preflight, but a target was printed: %q", errOut)
+	}
+}
+
+// TestRunMissingCredsFailsFastNoNetwork pins the end-to-end wiring: a real cycle
+// selection with missing credentials PRINTS the resolved target, then fails fast
+// with exit code 2 (config error) BEFORE the client is built or any request is
+// sent. The target is forced to a .example host so the test never depends on the
+// production-looking default and never reaches the network (preflight returns
+// before NewClient). Mutation proof: remove the preflight call in run() and a
+// missing-creds invocation no longer exits 2 nor prints "credentials not set".
+func TestRunMissingCredsFailsFastNoNetwork(t *testing.T) {
+	t.Setenv(client.HTTPAddrEnvName, "recette.example")
+	t.Setenv(client.HTTPSchemeEnvName, "https")
+	t.Setenv(client.HTTPClientIDEnvName, "")
+	t.Setenv(client.HTTPClientSecretEnvName, "")
+
+	code, _, errOut := captureRun(t, "-cycles", "readonly")
+	if code != 2 {
+		t.Fatalf("missing creds must exit 2 (config error), got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(errOut, "target = https://recette.example") {
+		t.Fatalf("run must print the resolved target before failing, got %q", errOut)
+	}
+	if !strings.Contains(errOut, "credentials not set") {
+		t.Fatalf("run must fail fast on missing creds, got %q", errOut)
+	}
+}

--- a/cmd/ct-validate/progress_test.go
+++ b/cmd/ct-validate/progress_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRecorderLiveProgress pins that a recorder with progress prints one
+// readable line per operation (OK with latency, skip, FAIL with category), so
+// the operator sees advancement. Mutation: drop the writeProgressLine call in
+// Record → the buffer is empty → RED.
+func TestRecorderLiveProgress(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRecorderWithProgress(&buf)
+	r.Record(Op{Cycle: "readonly", Endpoint: "iam.token.read", OK: true, Latency: 730 * time.Millisecond, Category: CategoryOK})
+	r.Record(Op{Cycle: "readonly", Endpoint: "compute.openiaas.virtual_machines.read", Skipped: true, Category: CategorySkipped})
+	r.Record(Op{Cycle: "readonly", Endpoint: "compute.openiaas.networks.list", OK: false, Category: CategoryHTTP5xx})
+
+	out := buf.String()
+	for _, want := range []string{
+		"iam.token.read", "730 ms", "ok",
+		"compute.openiaas.virtual_machines.read", "skip",
+		"compute.openiaas.networks.list", "FAIL", "http_5xx",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("live progress must contain %q; got:\n%s", want, out)
+		}
+	}
+	// Three operations → three lines.
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 3 {
+		t.Fatalf("expected 3 progress lines, got %d:\n%s", got, out)
+	}
+}
+
+// TestRecorderNoProgressIsSilent pins that the default recorder (no writer)
+// prints nothing — progress is strictly opt-in.
+func TestRecorderNoProgressIsSilent(t *testing.T) {
+	r := NewRecorder() // no progress writer
+	r.Record(Op{Endpoint: "x", OK: true})
+	if len(r.Ops()) != 1 {
+		t.Fatalf("the op must still be recorded, got %d", len(r.Ops()))
+	}
+}

--- a/cmd/ct-validate/stats.go
+++ b/cmd/ct-validate/stats.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -26,18 +28,49 @@ type Op struct {
 type Recorder struct {
 	mu  sync.Mutex
 	ops []Op
+	// progress, when set, receives one human-readable line per recorded
+	// operation as it happens (live advancement). Writing happens under the
+	// lock so concurrent workers never interleave a line.
+	progress io.Writer
 }
 
-// NewRecorder returns an empty recorder.
+// NewRecorder returns an empty recorder (no live progress).
 func NewRecorder() *Recorder {
 	return &Recorder{}
+}
+
+// NewRecorderWithProgress returns a recorder that also prints one line per
+// operation to w as it is recorded, so the operator sees what is running.
+func NewRecorderWithProgress(w io.Writer) *Recorder {
+	return &Recorder{progress: w}
 }
 
 // Record appends a single operation. Safe for concurrent callers.
 func (r *Recorder) Record(op Op) {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.ops = append(r.ops, op)
-	r.mu.Unlock()
+	if r.progress != nil {
+		writeProgressLine(r.progress, len(r.ops), op)
+	}
+}
+
+// writeProgressLine renders one live advancement line:
+//
+//	12  ok    iam.token.read                          730 ms
+//	18  skip  compute.openiaas.virtual_machines.read
+//	21  FAIL  compute.openiaas.networks.list          http_5xx
+func writeProgressLine(w io.Writer, n int, op Op) {
+	tag, extra := "ok", ""
+	switch {
+	case op.Skipped:
+		tag = "skip"
+	case !op.OK:
+		tag, extra = "FAIL", string(op.Category)
+	case op.Latency > 0:
+		extra = fmt.Sprintf("%d ms", op.Latency.Milliseconds())
+	}
+	fmt.Fprintf(w, "  %3d  %-4s  %-44s  %s\n", n, tag, op.Endpoint, extra)
 }
 
 // Ops returns a copy of the recorded operations, in insertion order.

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# ct-test — run a business scenario against the API OR via Terraform.
+#
+#   ct-test list                 list the scenarios and which modes are ready
+#   ct-test api  <scenario>      play the scenario directly against the API
+#   ct-test tf   <scenario>      play the same scenario via Terraform (apply + destroy)
+#
+# It loads the agentic credentials, targets the confirmed API host, runs the
+# scenario, prints PASS/FAIL, and cleans up after itself. No flags to remember.
+#
+# Overridable via env:
+#   CT_TEST_ENV    path to the credentials env file (CLOUDTEMPLE_CLIENT_ID/SECRET_ID)
+#   CT_TEST_HOST   API host (default: shiva.cloud-temple.com — the confirmed API endpoint)
+set -euo pipefail
+
+CT_TEST_ENV="${CT_TEST_ENV:-/Users/clesur/PROJETS/AGENTIC-PLATFORM/vault/rendered/cloudtemple.env}"
+CT_TEST_HOST="${CT_TEST_HOST:-shiva.cloud-temple.com}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CTV_BIN="${CTV_BIN:-/tmp/ct-validate-bin}"
+
+# scenario -> api cycle name (ct-validate), and whether it writes.
+# ready=1 means the scenario is wired and runnable today.
+#   name|api_cycle|write|ready|description
+scenarios() {
+  cat <<'EOF'
+readonly|readonly|0|1|Read every service (no create/destroy). The safest scenario, validates the tool.
+vpc|vpc|1|1|Create a VPC static IP + floating-IP binding, verify, then destroy.
+storage|object_storage|1|1|Create an object-storage bucket + account + ACL, verify, then destroy.
+vm|compute_lifecycle|1|0|Create a VM, add a disk, connect the network, then destroy. (api: cycle being built)
+EOF
+}
+
+die() { echo "ct-test: $*" >&2; exit 2; }
+
+load_creds() {
+  [ -f "$CT_TEST_ENV" ] || die "credentials file not found: $CT_TEST_ENV (set CT_TEST_ENV)"
+  set -a; . "$CT_TEST_ENV" 2>/dev/null; set +a
+  export CLOUDTEMPLE_HTTP_ADDR="$CT_TEST_HOST"
+  export CLOUDTEMPLE_HTTP_SCHEME="https"
+  [ -n "${CLOUDTEMPLE_CLIENT_ID:-}" ] && [ -n "${CLOUDTEMPLE_SECRET_ID:-}" ] \
+    || die "credentials not set in $CT_TEST_ENV (CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID)"
+}
+
+lookup() { # $1=scenario -> echoes "cycle write ready desc" or empty
+  scenarios | awk -F'|' -v s="$1" '$1==s {print $2"\t"$3"\t"$4"\t"$5}'
+}
+
+cmd_list() {
+  echo "Scenarios (use: ct-test api <name>  |  ct-test tf <name>):"
+  scenarios | awk -F'|' '{
+    ready = ($4==1) ? "ready" : "coming";
+    printf "  %-10s [%-6s] %s\n", $1, ready, $5
+  }'
+  echo
+  echo "Host (API): ${CT_TEST_HOST}   Creds file: ${CT_TEST_ENV}"
+}
+
+cmd_api() {
+  local scenario="$1"; [ -n "$scenario" ] || die "usage: ct-test api <scenario> (see 'ct-test list')"
+  local row; row="$(lookup "$scenario")" || true
+  [ -n "$row" ] || die "unknown scenario '$scenario' (see 'ct-test list')"
+  local cycle write ready desc
+  cycle="$(echo "$row" | cut -f1)"; write="$(echo "$row" | cut -f2)"; ready="$(echo "$row" | cut -f3)"
+  [ "$ready" = "1" ] || die "scenario '$scenario' (api) is not ready yet — being built"
+
+  echo ">> Building the API runner..."
+  ( cd "$REPO_ROOT" && go build -o "$CTV_BIN" ./cmd/ct-validate )
+  load_creds
+
+  local args=( -cycles "$cycle" -runs 1 -concurrency 1 -timeout 5m )
+  [ "$write" = "1" ] && args+=( -write )
+  echo ">> API scenario '$scenario'  (cycle=$cycle, write=$write)"
+  "$CTV_BIN" "${args[@]}"
+}
+
+cmd_tf() {
+  local scenario="$1"; [ -n "$scenario" ] || die "usage: ct-test tf <scenario> (see 'ct-test list')"
+  local row; row="$(lookup "$scenario")" || true
+  [ -n "$row" ] || die "unknown scenario '$scenario' (see 'ct-test list')"
+  local dir="$REPO_ROOT/examples/ct-test/$scenario"
+  [ -d "$dir" ] || die "scenario '$scenario' (tf) is not ready yet — no example at examples/ct-test/$scenario"
+  command -v terraform >/dev/null || die "terraform not found in PATH"
+  load_creds
+
+  echo ">> TF scenario '$scenario'  (apply then destroy)  dir=$dir"
+  ( cd "$dir"
+    terraform init -input=false >/dev/null
+    set +e
+    terraform apply -auto-approve -input=false; apply_rc=$?
+    echo ">> Destroying (always, even on apply failure)..."
+    terraform destroy -auto-approve -input=false; destroy_rc=$?
+    # A failed destroy is a hard failure (possible orphan) — never report PASS
+    # just because apply succeeded. Surface both codes.
+    if [ "$apply_rc" -ne 0 ] || [ "$destroy_rc" -ne 0 ]; then
+      echo ">> FAIL (apply=$apply_rc destroy=$destroy_rc)$([ "$destroy_rc" -ne 0 ] && echo ' — DESTROY FAILED, CHECK FOR ORPHANS')" >&2
+      exit 1
+    fi
+    echo ">> OK (apply + destroy both clean)"
+    exit 0
+  )
+}
+
+main() {
+  local cmd="${1:-}"; shift || true
+  case "$cmd" in
+    list)        cmd_list ;;
+    api)         cmd_api "${1:-}" ;;
+    tf)          cmd_tf  "${1:-}" ;;
+    ""|-h|--help) echo "usage: ct-test {list | api <scenario> | tf <scenario>}"; echo "       ct-test list   # see scenarios" ;;
+    *)           die "unknown command '$cmd' (use: list | api <scenario> | tf <scenario>)" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -2,19 +2,35 @@
 #
 # ct-test — run a business scenario against the API OR via Terraform.
 #
-#   ct-test list                 list the scenarios and which modes are ready
-#   ct-test api  <scenario>      play the scenario directly against the API
-#   ct-test tf   <scenario>      play the same scenario via Terraform (apply + destroy)
+#   ct-test list                          list the scenarios and which modes are ready
+#   ct-test api  <scenario> [flags...]    play the scenario directly against the API
+#   ct-test tf   <scenario>               play the same scenario via Terraform (apply + destroy)
 #
-# It loads the agentic credentials, targets the confirmed API host, runs the
-# scenario, prints PASS/FAIL, and cleans up after itself. No flags to remember.
+# It loads the chosen tenant's credentials, targets the API host, runs the
+# scenario, prints PASS/FAIL, and cleans up after itself.
+#
+# TENANT SELECTION (which credentials, hence which platform you exercise):
+#   --tenant openiaas   (default) use $CT_ENV_OPENIAAS
+#   --tenant vmware               use $CT_ENV_VMWARE
+#   ... or set CT_TENANT=openiaas|vmware, or CT_TEST_ENV=<file> to point at one directly.
+# The API host is the same for every tenant (shiva.cloud-temple.com); the tenant
+# is determined by the credentials, not by the URL.
+#
+# LOAD KNOBS (api mode): any extra flags after the scenario are forwarded verbatim
+# to the runner, so you can drive repetition and parallelism:
+#   ct-test --tenant vmware api vm-vmware -runs 20 -concurrency 4
+#   (-runs N, -concurrency M, -timeout D ; the circuit breaker still guards the API.)
 #
 # Overridable via env:
-#   CT_TEST_ENV    path to the credentials env file (CLOUDTEMPLE_CLIENT_ID/SECRET_ID)
-#   CT_TEST_HOST   API host (default: shiva.cloud-temple.com — the confirmed API endpoint)
+#   CT_ENV_OPENIAAS  creds file for the openiaas tenant (default: agentic cloudtemple.env)
+#   CT_ENV_VMWARE    creds file for the vmware tenant   (no default — set it)
+#   CT_TEST_ENV      explicit creds file (wins over --tenant; KEY=value format)
+#   CT_TEST_HOST     API host (default: shiva.cloud-temple.com — the confirmed API endpoint)
 set -euo pipefail
 
-CT_TEST_ENV="${CT_TEST_ENV:-/Users/clesur/PROJETS/AGENTIC-PLATFORM/vault/rendered/cloudtemple.env}"
+CT_ENV_OPENIAAS="${CT_ENV_OPENIAAS:-/Users/clesur/PROJETS/AGENTIC-PLATFORM/vault/rendered/cloudtemple.env}"
+CT_ENV_VMWARE="${CT_ENV_VMWARE:-}"
+CT_TENANT="${CT_TENANT:-openiaas}"
 CT_TEST_HOST="${CT_TEST_HOST:-shiva.cloud-temple.com}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,19 +44,36 @@ scenarios() {
 readonly|readonly|0|1|Read every service (no create/destroy). The safest scenario, validates the tool.
 vpc|vpc|1|1|Create a VPC static IP + floating-IP binding, verify, then destroy.
 storage|object_storage|1|1|Create an object-storage bucket + account + ACL, verify, then destroy.
-vm|compute_lifecycle|1|1|Create a VM from a template, add a disk, connect the network, then destroy.
+vm|compute_lifecycle|1|1|OpenIaaS: create a VM from a template, add a disk, connect the network, then destroy.
+vm-vmware|compute_vmware_lifecycle|1|1|VMware: create a VM (datacenter/host/datastore/guest-OS), add a disk, connect a NIC, then destroy.
 EOF
 }
 
 die() { echo "ct-test: $*" >&2; exit 2; }
 
+# resolve_env_file echoes the creds file to load, honouring (in priority order)
+# an explicit CT_TEST_ENV, then the selected tenant's file.
+resolve_env_file() {
+  if [ -n "${CT_TEST_ENV:-}" ]; then
+    echo "$CT_TEST_ENV"; return
+  fi
+  case "$CT_TENANT" in
+    openiaas) echo "$CT_ENV_OPENIAAS" ;;
+    vmware)
+      [ -n "$CT_ENV_VMWARE" ] || die "tenant 'vmware' selected but CT_ENV_VMWARE is not set — point it at a KEY=value creds file (CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID), or pass CT_TEST_ENV=<file>"
+      echo "$CT_ENV_VMWARE" ;;
+    *) die "unknown tenant '$CT_TENANT' (use openiaas|vmware)" ;;
+  esac
+}
+
 load_creds() {
-  [ -f "$CT_TEST_ENV" ] || die "credentials file not found: $CT_TEST_ENV (set CT_TEST_ENV)"
-  set -a; . "$CT_TEST_ENV" 2>/dev/null; set +a
+  local env_file; env_file="$(resolve_env_file)"
+  [ -f "$env_file" ] || die "credentials file not found: $env_file"
+  set -a; . "$env_file" 2>/dev/null; set +a
   export CLOUDTEMPLE_HTTP_ADDR="$CT_TEST_HOST"
   export CLOUDTEMPLE_HTTP_SCHEME="https"
   [ -n "${CLOUDTEMPLE_CLIENT_ID:-}" ] && [ -n "${CLOUDTEMPLE_SECRET_ID:-}" ] \
-    || die "credentials not set in $CT_TEST_ENV (CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID)"
+    || die "credentials not set in $env_file (need CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID)"
 }
 
 lookup() { # $1=scenario -> echoes "cycle write ready desc" or empty
@@ -48,20 +81,23 @@ lookup() { # $1=scenario -> echoes "cycle write ready desc" or empty
 }
 
 cmd_list() {
-  echo "Scenarios (use: ct-test api <name>  |  ct-test tf <name>):"
+  echo "Scenarios (use: ct-test [--tenant openiaas|vmware] api <name>  |  ct-test tf <name>):"
   scenarios | awk -F'|' '{
     ready = ($4==1) ? "ready" : "coming";
     printf "  %-10s [%-6s] %s\n", $1, ready, $5
   }'
   echo
-  echo "Host (API): ${CT_TEST_HOST}   Creds file: ${CT_TEST_ENV}"
+  echo "Tenant: ${CT_TENANT}   Host (API): ${CT_TEST_HOST}"
+  echo "Creds : openiaas=${CT_ENV_OPENIAAS}"
+  echo "        vmware=${CT_ENV_VMWARE:-<unset: set CT_ENV_VMWARE>}"
 }
 
 cmd_api() {
-  local scenario="$1"; [ -n "$scenario" ] || die "usage: ct-test api <scenario> (see 'ct-test list')"
+  local scenario="${1:-}"; shift || true
+  [ -n "$scenario" ] || die "usage: ct-test api <scenario> [flags...] (see 'ct-test list')"
   local row; row="$(lookup "$scenario")" || true
   [ -n "$row" ] || die "unknown scenario '$scenario' (see 'ct-test list')"
-  local cycle write ready desc
+  local cycle write ready
   cycle="$(echo "$row" | cut -f1)"; write="$(echo "$row" | cut -f2)"; ready="$(echo "$row" | cut -f3)"
   [ "$ready" = "1" ] || die "scenario '$scenario' (api) is not ready yet — being built"
 
@@ -69,14 +105,18 @@ cmd_api() {
   ( cd "$REPO_ROOT" && go build -o "$CTV_BIN" ./cmd/ct-validate )
   load_creds
 
-  local args=( -cycles "$cycle" -runs 1 -concurrency 1 -timeout 5m )
+  # Conservative defaults; any extra flags passed after the scenario (e.g.
+  # -runs 20 -concurrency 4) are forwarded verbatim and override these
+  # (Go's flag package keeps the last occurrence).
+  local args=( -cycles "$cycle" -runs 1 -concurrency 1 -timeout 10m )
   [ "$write" = "1" ] && args+=( -write )
-  echo ">> API scenario '$scenario'  (cycle=$cycle, write=$write)"
+  args+=( "$@" )
+  echo ">> API scenario '$scenario'  (tenant=$CT_TENANT, cycle=$cycle, write=$write)  flags: ${*:-<defaults>}"
   "$CTV_BIN" "${args[@]}"
 }
 
 cmd_tf() {
-  local scenario="$1"; [ -n "$scenario" ] || die "usage: ct-test tf <scenario> (see 'ct-test list')"
+  local scenario="${1:-}"; [ -n "$scenario" ] || die "usage: ct-test tf <scenario> (see 'ct-test list')"
   local row; row="$(lookup "$scenario")" || true
   [ -n "$row" ] || die "unknown scenario '$scenario' (see 'ct-test list')"
   local dir="$REPO_ROOT/examples/ct-test/$scenario"
@@ -103,12 +143,28 @@ cmd_tf() {
 }
 
 main() {
+  # Peel off the global --tenant/-t option wherever it appears before the command.
+  local positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --tenant|-t) [ -n "${2:-}" ] || die "--tenant needs a value (openiaas|vmware)"; CT_TENANT="$2"; shift 2 ;;
+      --tenant=*)  CT_TENANT="${1#*=}"; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  set -- "${positional[@]}"
+
   local cmd="${1:-}"; shift || true
   case "$cmd" in
     list)        cmd_list ;;
-    api)         cmd_api "${1:-}" ;;
+    api)         cmd_api "$@" ;;
     tf)          cmd_tf  "${1:-}" ;;
-    ""|-h|--help) echo "usage: ct-test {list | api <scenario> | tf <scenario>}"; echo "       ct-test list   # see scenarios" ;;
+    ""|-h|--help)
+      echo "usage: ct-test [--tenant openiaas|vmware] {list | api <scenario> [flags...] | tf <scenario>}"
+      echo "       ct-test list                                  # see scenarios"
+      echo "       ct-test --tenant vmware api vm-vmware          # full VMware VM lifecycle"
+      echo "       ct-test --tenant vmware api vm-vmware -runs 20 -concurrency 4   # bounded load"
+      ;;
     *)           die "unknown command '$cmd' (use: list | api <scenario> | tf <scenario>)" ;;
   esac
 }

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -28,7 +28,7 @@ scenarios() {
 readonly|readonly|0|1|Read every service (no create/destroy). The safest scenario, validates the tool.
 vpc|vpc|1|1|Create a VPC static IP + floating-IP binding, verify, then destroy.
 storage|object_storage|1|1|Create an object-storage bucket + account + ACL, verify, then destroy.
-vm|compute_lifecycle|1|0|Create a VM, add a disk, connect the network, then destroy. (api: cycle being built)
+vm|compute_lifecycle|1|1|Create a VM from a template, add a disk, connect the network, then destroy.
 EOF
 }
 


### PR DESCRIPTION
Refs #327, #316. Brings `cmd/ct-validate` to a complete, safe API test tool. Three cohesive commits, each adversarially reviewed GO:

## 1. Preflight guards (#327)
`run()` prints the resolved `scheme://host` before any request, refuses non-HTTPS (PAT never in cleartext), fails fast (exit 2) on missing/whitespace creds. `-list`/`-help` stay network-free.

## 2. Trustworthy read-only map + ct-test runner (#316)
A squeak now means a real API problem, not a harness calling bug nor an absent service (validated live on OpenIaaS + VMware tenants: 0 real 5xx). Breaker trips on distress only (5xx/502/timeout/429), not deterministic 4xx; OpenIaaS lists scoped by `machine_manager_id`; VMware/backup probe-and-skip. `scripts/ct-test.sh` runner (a failed `terraform destroy` is a hard FAIL).

## 3. compute_lifecycle write business cycle (#316)
End-to-end VM lifecycle (create VM → attach disk → attach+connect adapter → deprovision leaves-first) to replay under `-runs`/`-concurrency` for a **bounded, breaker-guarded load probe** ("how far does it hold"). Never-orphan teardown hardened over 4 review rounds: 128-bit per-run identity (fail-fast, observable), teardown registered before create, LIFO leaves-first, find fail-closed on duplicates, disk search VM-scoped+tenant-wide, MAC platform-assigned, 404-only idempotent, hard caps on -runs/-concurrency. Gated behind `-write`.

## Proof
Mutation-proven unit + httptest tests across all three; `vet` / `-race` / `staticcheck@2025.1.1` green.

> Running write cycles live is a separate, GO-gated step (bounded, breaker-armed, progressive ramp). Train RC — not for production.