### PR TITLE
ct-validate: surface failed-op error body (redacted) in the report

### DIFF
--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -78,18 +79,76 @@ func (r *Run) op(c Cycle, endpoint string, fn func() error) error {
 	err := fn()
 	latency := time.Since(start)
 	cat := categorize(err)
+	detail := ""
+	if cat != CategoryOK && err != nil {
+		// Keep the failure reason (e.g. the 4xx/5xx body) so the report can show
+		// WHY it squeaked. Redact obvious secret carriers FIRST (defence-in-depth
+		// for a report that may be shared), then bound it so a huge body cannot
+		// bloat the recording.
+		detail = truncate(redactSecrets(err.Error()), 300)
+	}
 	r.Recorder.Record(Op{
 		Cycle:    c.Name(),
 		Endpoint: endpoint,
 		OK:       cat == CategoryOK,
 		Latency:  latency,
 		Category: cat,
+		Detail:   detail,
 	})
 	// The breaker trips on DISTRESS only (5xx, 502, timeout, transient, 429),
 	// NOT on deterministic client errors (4xx): a 4xx is recorded as a failure
 	// in the report but must not latch the breaker and mask the rest of the map.
 	r.Breaker.Record(cat.isDistress())
 	return err
+}
+
+// secret-bearing patterns scrubbed from recorded error text before it is stored
+// or printed. The PAT travels in the Authorization header and is not normally
+// echoed in an API response body, but a proxy/debug body could reflect request
+// metadata — so mask the obvious carriers rather than trust that it never will.
+var (
+	// An Authorization value of ANY scheme (Bearer/Basic/Token/ApiKey/…): mask the
+	// WHOLE value (scheme AND credential) up to a value delimiter. A scheme alone
+	// (e.g. "Basic") must never leave the credential after it exposed.
+	authHeaderRe = regexp.MustCompile(`(?i)authorization\s*["']?\s*[:=]\s*["']?[^\r\n"',}&]*`)
+	// A bare bearer token not preceded by an Authorization key.
+	bearerTokenRe = regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._~+/=-]+`)
+	// Named secret carriers; the value may be a quoted string (spaces allowed) or a
+	// single delimiter-bounded token. Names cover the common OAuth/secret variants.
+	kvSecretRe = regexp.MustCompile(`(?i)\b(password|passwd|secret|client_secret|access_token|refresh_token|id_token|token|api[_-]?key|apikey|signature|credential)\b(\s*["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s"',}&]+)`)
+	// The catch-all: any LONG opaque run (base64/hex/JWT-like, >=20 chars) is
+	// credential material regardless of surrounding key/scheme/format — mask it.
+	// Ordinary error words are far shorter, so this rarely touches useful text;
+	// when in doubt it OVER-redacts, which is the safe direction.
+	opaqueTokenRe = regexp.MustCompile(`[A-Za-z0-9+/=_~.-]{20,}`)
+)
+
+// redactSecrets scrubs credential material from text that may be recorded or
+// printed (an API error body). It layers an Authorization-value mask, a bare
+// bearer mask, named secret carriers (quoted or single-token), and finally a
+// catch-all long-opaque-token mask — so no credential survives regardless of
+// format. It deliberately errs toward OVER-redaction over leaking.
+func redactSecrets(s string) string {
+	s = authHeaderRe.ReplaceAllString(s, "Authorization: ***REDACTED***")
+	s = bearerTokenRe.ReplaceAllString(s, "Bearer ***REDACTED***")
+	s = kvSecretRe.ReplaceAllString(s, "${1}=***REDACTED***")
+	s = opaqueTokenRe.ReplaceAllString(s, "***REDACTED***")
+	return s
+}
+
+// truncate collapses newlines (so a recorded error stays one readable line) and
+// bounds the result to n runes PLUS a trailing ellipsis when it had to cut. n<=0
+// yields an empty string (defensive; call sites pass a positive bound).
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " ")
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }
 
 // skip records an endpoint as deliberately skipped (no attempt made). It never

--- a/cmd/ct-validate/report.go
+++ b/cmd/ct-validate/report.go
@@ -31,6 +31,7 @@ type squeak struct {
 	Endpoint    string  `json:"endpoint"`
 	SuccessRate float64 `json:"success_rate"`
 	Total       int     `json:"total"`
+	SampleError string  `json:"sample_error,omitempty"`
 }
 
 type jsonEndpoint struct {
@@ -43,6 +44,7 @@ type jsonEndpoint struct {
 	P50ms       float64          `json:"p50_ms"`
 	P95ms       float64          `json:"p95_ms"`
 	Reasons     map[Category]int `json:"reasons"`
+	SampleError string           `json:"sample_error,omitempty"`
 }
 
 type jsonTeardownFailure struct {
@@ -76,6 +78,7 @@ func squeaks(stats []EndpointStats) []squeak {
 				Endpoint:    s.Endpoint,
 				SuccessRate: rate,
 				Total:       s.Total,
+				SampleError: s.SampleError,
 			})
 		}
 	}
@@ -151,6 +154,9 @@ func PrintText(w io.Writer, res EngineResult) {
 	} else {
 		for _, s := range sq {
 			fmt.Fprintf(w, "  %-6.1f%%  %s / %s  (n=%d)\n", s.SuccessRate*100, s.Cycle, s.Endpoint, s.Total)
+			if s.SampleError != "" {
+				fmt.Fprintf(w, "           ↳ %s\n", s.SampleError)
+			}
 		}
 	}
 	fmt.Fprintln(w)
@@ -202,6 +208,7 @@ func PrintJSON(w io.Writer, res EngineResult) error {
 			P50ms:       msFloat(s.P50),
 			P95ms:       msFloat(s.P95),
 			Reasons:     s.Reasons,
+			SampleError: s.SampleError,
 		})
 	}
 	for _, f := range res.TeardownFailed {

--- a/cmd/ct-validate/report_test.go
+++ b/cmd/ct-validate/report_test.go
@@ -70,12 +70,127 @@ func TestPrintTextSurfacesTripAndSqueaks(t *testing.T) {
 	}
 }
 
+// TestAggregateCapturesFirstFailureDetail pins that the per-endpoint SampleError
+// is the FIRST failed op's Detail (the reason it squeaked), and that OK/skipped
+// ops never set or overwrite it. Mutation: drop the SampleError capture in
+// Aggregate → SampleError stays empty → RED.
+func TestAggregateCapturesFirstFailureDetail(t *testing.T) {
+	ops := []Op{
+		{Cycle: "c", Endpoint: "e", OK: true, Category: CategoryOK},
+		{Cycle: "c", Endpoint: "e", OK: false, Category: CategoryHTTP4xx, Detail: "Unexpected response code: 403 (Forbidden.)"},
+		{Cycle: "c", Endpoint: "e", OK: false, Category: CategoryHTTP4xx, Detail: "second failure, must NOT overwrite"},
+		{Cycle: "c", Endpoint: "e", Skipped: true, Category: CategorySkipped, Detail: "skips carry none"},
+	}
+	stats := Aggregate(ops)
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(stats))
+	}
+	if got := stats[0].SampleError; got != "Unexpected response code: 403 (Forbidden.)" {
+		t.Fatalf("SampleError must be the FIRST failure's detail, got %q", got)
+	}
+}
+
+// TestPrintTextShowsFailureDetail pins that a SampleError is rendered under WHERE
+// IT SQUEAKS so the operator sees WHY, not just the category. Mutation: drop the
+// SampleError render in PrintText → the body line disappears → RED.
+func TestPrintTextShowsFailureDetail(t *testing.T) {
+	res := EngineResult{
+		SelectedCycles: []string{"compute_vmware_lifecycle"},
+		Stats: []EndpointStats{
+			{Cycle: "compute_vmware_lifecycle", Endpoint: "compute.vmware.virtual_machine.create",
+				Total: 1, OK: 0, Reasons: map[Category]int{CategoryHTTP4xx: 1},
+				SampleError: "Unexpected response code: 403 (Forbidden.)"},
+		},
+	}
+	var buf bytes.Buffer
+	PrintText(&buf, res)
+	if !strings.Contains(buf.String(), "403 (Forbidden.)") {
+		t.Fatalf("the failure body must be surfaced under WHERE IT SQUEAKS\n---\n%s", buf.String())
+	}
+}
+
+// TestTruncateCollapsesAndBounds pins truncate: it collapses newlines to keep one
+// readable line and bounds the length with an ellipsis.
+func TestTruncateCollapsesAndBounds(t *testing.T) {
+	if got := truncate("a\nb\rc", 100); got != "a b c" {
+		t.Fatalf("newlines must collapse to spaces, got %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	got := truncate(long, 300)
+	if len([]rune(got)) != 301 || !strings.HasSuffix(got, "…") {
+		t.Fatalf("must bound to 300 runes + ellipsis, got len=%d suffix=%v", len([]rune(got)), strings.HasSuffix(got, "…"))
+	}
+	if got := truncate("short", 300); got != "short" {
+		t.Fatalf("a short string must be unchanged, got %q", got)
+	}
+	// n<=0 must be safe (no panic on r[:n]) and yield empty.
+	if got := truncate("x", 0); got != "" {
+		t.Fatalf("truncate(_,0) must be empty, got %q", got)
+	}
+	if got := truncate("x", -5); got != "" {
+		t.Fatalf("truncate(_,negative) must be empty (no panic), got %q", got)
+	}
+}
+
+// TestRedactSecretsMasksCredentials pins that recorded error text never surfaces a
+// credential: bearer tokens and password/secret/token/authorization carriers are
+// masked, while an ordinary error body is left intact. Mutation: make
+// redactSecrets a pass-through → the token leaks → RED.
+func TestRedactSecretsMasksCredentials(t *testing.T) {
+	cases := map[string]string{
+		"Authorization: Bearer eyJhbGciOiJ.payload.sig":              "eyJhbGciOiJ",
+		"Authorization: Basic dXNlcjpwYXNzd29yZGxvbmdlbm91Z2g":       "dXNlcjpwYXNzd29yZGxvbmdlbm91Z2g",
+		"Authorization: Token 0a1b2c3d4e5f6071829304a5b6c7":          "0a1b2c3d4e5f6071829304a5b6c7",
+		"Authorization: ApiKey deadbeefcafedeadbeefcafe":             "deadbeefcafedeadbeefcafe",
+		"{\"authorization\":\"Basic c2VjcmV0dmFsdWVsb25nZW5vdWdo\"}": "c2VjcmV0dmFsdWVsb25nZW5vdWdo",
+		"client_secret=8f5767aa-dead-beef&grant=x":                   "8f5767aa-dead-beef",
+		"access_token: ya29.A0ARrdaMlongtokenvalue":                  "ya29.A0ARrdaMlongtokenvalue",
+		"refresh_token=1//0longrefreshtokenvalue":                    "0longrefreshtokenvalue",
+		"signature=\"aGVsbG8gd29ybGQgc2lnbmF0dXJl\"":                 "aGVsbG8gd29ybGQgc2lnbmF0dXJl",
+		"\"token\": \"abcdef123456\"":                                "abcdef123456",
+		"password = hunter2":                                         "hunter2",
+		"password=\"correct horse battery staple\"":                  "battery",
+		"bearer eyJraw.token.here.long.enough.value":                 "eyJraw.token.here.long.enough.value",
+		"leaked raw blob 0123456789abcdef0123456789abcdef":           "0123456789abcdef0123456789abcdef",
+	}
+	for in, leak := range cases {
+		out := redactSecrets(in)
+		if strings.Contains(out, leak) {
+			t.Fatalf("redactSecrets leaked %q: in=%q out=%q", leak, in, out)
+		}
+		if !strings.Contains(out, "REDACTED") {
+			t.Fatalf("redactSecrets must mark a redaction: in=%q out=%q", in, out)
+		}
+	}
+	// A non-secret key after a secret query param must survive (no over-greedy match).
+	if out := redactSecrets("client_secret=abc&foo=bar"); !strings.Contains(out, "foo=bar") {
+		t.Fatalf("a benign trailing param must survive redaction, got %q", out)
+	}
+	// An ordinary API error body must be left intact (no false redaction).
+	if got := redactSecrets("Unexpected response code: 403 (Forbidden.)"); got != "Unexpected response code: 403 (Forbidden.)" {
+		t.Fatalf("an ordinary body must be unchanged, got %q", got)
+	}
+}
+
+// TestAggregateSkipBeforeFailureDoesNotSetSample pins that a skipped op preceding
+// a real failure does not become the sample (only a real failure's detail does).
+func TestAggregateSkipBeforeFailureDoesNotSetSample(t *testing.T) {
+	ops := []Op{
+		{Cycle: "c", Endpoint: "e", Skipped: true, Category: CategorySkipped, Detail: "must be ignored"},
+		{Cycle: "c", Endpoint: "e", OK: false, Category: CategoryHTTP5xx, Detail: "the real reason"},
+	}
+	stats := Aggregate(ops)
+	if stats[0].SampleError != "the real reason" {
+		t.Fatalf("a skip before the failure must not set the sample, got %q", stats[0].SampleError)
+	}
+}
+
 func TestPrintJSONShape(t *testing.T) {
 	res := EngineResult{
 		SelectedCycles:  []string{"readonly"},
 		GatedWriteSkips: []string{"vpc"},
 		Stats: []EndpointStats{
-			{Cycle: "readonly", Endpoint: "iam.users.list", Total: 2, OK: 1, Reasons: map[Category]int{CategoryHTTP5xx: 1, CategoryOK: 1}},
+			{Cycle: "readonly", Endpoint: "iam.users.list", Total: 2, OK: 1, Reasons: map[Category]int{CategoryHTTP5xx: 1, CategoryOK: 1}, SampleError: "boom 500"},
 		},
 	}
 	var buf bytes.Buffer
@@ -91,6 +206,9 @@ func TestPrintJSONShape(t *testing.T) {
 	}
 	if len(rep.Endpoints) != 1 || rep.Endpoints[0].SuccessRate != 0.5 {
 		t.Fatalf("JSON endpoint shape wrong: %+v", rep.Endpoints)
+	}
+	if rep.Endpoints[0].SampleError != "boom 500" {
+		t.Fatalf("JSON must carry sample_error, got %q", rep.Endpoints[0].SampleError)
 	}
 	if len(rep.GatedWrite) != 1 || rep.GatedWrite[0] != "vpc" {
 		t.Fatalf("JSON gated_write_cycles wrong: %+v", rep.GatedWrite)

--- a/cmd/ct-validate/stats.go
+++ b/cmd/ct-validate/stats.go
@@ -17,6 +17,10 @@ type Op struct {
 	Skipped  bool
 	Latency  time.Duration
 	Category Category
+	// Detail carries the (truncated) error message for a FAILED op — e.g. the
+	// 4xx/5xx response body — so the report can show WHY an endpoint squeaked,
+	// not just its category. Empty for OK/skipped ops.
+	Detail string
 }
 
 // Recorder collects Op records concurrently and aggregates them per
@@ -92,6 +96,9 @@ type EndpointStats struct {
 	P50      time.Duration    `json:"p50_ns"`
 	P95      time.Duration    `json:"p95_ns"`
 	Reasons  map[Category]int `json:"reasons"`
+	// SampleError is the first failed op's (truncated) error message for this
+	// endpoint — a representative reason it squeaked. Empty when none failed.
+	SampleError string `json:"sample_error,omitempty"`
 }
 
 // SuccessRate is the fraction of non-skipped attempts that succeeded, in
@@ -171,6 +178,9 @@ func Aggregate(ops []Op) []EndpointStats {
 		if op.OK {
 			b.stats.OK++
 			b.latencies = append(b.latencies, op.Latency)
+		} else if !op.Skipped && b.stats.SampleError == "" && op.Detail != "" {
+			// First real failure's detail is the representative reason it squeaked.
+			b.stats.SampleError = op.Detail
 		}
 		// Record the category for every op (including OK→CategoryOK and
 		// Skipped→CategorySkipped) so the histogram is complete.


### PR DESCRIPTION
## What
A failed endpoint previously showed only its category (e.g. `http_4xx`). This captures the failing op's error message — the **4xx/5xx response body** — and surfaces it under `WHERE IT SQUEAKS` (and in the JSON `sample_error`), so the operator sees **why** an endpoint squeaked.

This is what revealed, on the first live VMware run, that `compute.vmware.virtual_machine.create` fails with `403 (Forbidden.)` — i.e. the PAT lacks compute-write entitlement, not a tool bug.

## Safety: redaction (defence-in-depth)
The recorded text is scrubbed by `redactSecrets` before it is stored or printed, since a `ct-validate` report may be shared:
- Authorization values of **any** scheme (Bearer/Basic/Token/ApiKey/…) — whole value masked;
- bare bearer tokens;
- named carriers (password, secret, client_secret, access/refresh/id_token, token, api_key, signature, credential — quoted or single-token);
- a **catch-all** masking any opaque base64/hex/JWT-like run ≥ 20 chars, regardless of format.

It deliberately errs toward **over-redaction** (e.g. long UUIDs in a body get masked) over leaking. The error source is `client.StatusError` (the server response body); the PAT lives in the request header and is not echoed — redaction is belt-and-suspenders.

## Scope
Observability only — **no** create/delete/teardown/state-safety surface touched. Detail is redacted then truncated (300 runes, newlines collapsed; `n<=0` safe).

## Tests / review
Mutation-proven unit tests (redaction across carrier classes + opaque blob + query-delimiter survival + ordinary-body-unchanged; aggregation first-failure semantics; text + JSON surfacing; truncate bounds/edge). Adversarial review (Codex): GO after hardening the redaction.

Refs #316.