### PR TITLE
ct-validate: confirm VMware compute delete 403-as-absent (no false teardown alarms)

### DIFF
--- a/cmd/ct-validate/cleanup_seams_vmware.go
+++ b/cmd/ct-validate/cleanup_seams_vmware.go
@@ -3,9 +3,46 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
+
+// confirmComputeDeleteErr resolves a VMware compute delete outcome. A 404 is a
+// definitive not-found → success (idempotent). A 403 is AMBIGUOUS: the VMware
+// compute API returns 403 for an ABSENT resource as well as a forbidden one (the
+// #303 conflation) — typically when the explicit deprovision already deleted the
+// resource and the deferred backstop re-deletes it. The 403 is CONFIRMED by
+// re-checking the resource's OWN existence (a Read by id, which maps 403/404 →
+// not-found): accepted ONLY when it is proven absent; surfaced when it still
+// exists; failed CLOSED when existence cannot be determined (a 5xx/transport
+// error on the re-check). Any other delete error surfaces unchanged.
+//
+// The existence re-check is BY ID and independent of the parent VM — so it stays
+// valid even when the deferred leaf teardown runs AFTER the explicit deprovision
+// already deleted the parent VM (a VM-scoped listing would fail there). stillExists
+// is injected so this decision is unit-testable offline. Mirrors the VPC #312
+// confirm-before-accept doctrine: a 403-on-absent must not be a false "possible
+// orphan", and a 403-on-present must never be silently accepted.
+func confirmComputeDeleteErr(err error, stillExists func() (bool, error), id string) error {
+	if err == nil {
+		return nil
+	}
+	if isStatusCode(err, http.StatusNotFound) {
+		return nil
+	}
+	if isStatusCode(err, http.StatusForbidden) {
+		exists, cerr := stillExists()
+		if cerr != nil {
+			return fmt.Errorf("compute delete of %s returned 403 and the existence re-check to confirm absence failed: %w", id, cerr)
+		}
+		if exists {
+			return fmt.Errorf("compute resource %s could not be deleted (403) and still exists: %w", id, err)
+		}
+		return nil // re-check proves it is gone → idempotent success
+	}
+	return err
+}
 
 // VMware (vCenter) compute lifecycle teardowns — the sibling of the OpenIaaS
 // teardowns in cleanup_seams.go, with the SAME doctrine:
@@ -31,6 +68,9 @@ type vmwareVMSeam interface {
 	DeleteAndWait(ctx context.Context, id string) error
 	PowerOffAndWait(ctx context.Context, id string) error // best-effort, never fatal
 	FindIDByName(ctx context.Context, name, datacenterID string) (string, error)
+	// Exists reports whether the VM id is still present (a Read by id; a definitive
+	// not-found is false). Used to confirm a 403 delete is absent, not forbidden.
+	Exists(ctx context.Context, id string) (bool, error)
 }
 
 // vmwareVMTeardownRef carries the VM identity; ID is filled once the create
@@ -61,7 +101,13 @@ func registerVMwareVMTeardown(cl *Cleanup, seam vmwareVMSeam, ref *vmwareVMTeard
 			id = found
 		}
 		_ = seam.PowerOffAndWait(tctx, id) // best-effort: a powered-on VM may refuse delete
-		return seam.DeleteAndWait(tctx, id)
+		// A 403 here is the VMware "absent-or-forbidden" conflation (#303): the
+		// explicit deprovision may have already deleted this VM, and a re-delete of
+		// an absent VM answers 403, not 404. Confirm via a by-id existence re-check
+		// before treating it as a failure.
+		delID := id
+		return confirmComputeDeleteErr(seam.DeleteAndWait(tctx, delID),
+			func() (bool, error) { return seam.Exists(tctx, delID) }, delID)
 	})
 }
 
@@ -117,6 +163,16 @@ func (s computeVMwareVMSeam) FindIDByName(ctx context.Context, name, datacenterI
 	return found, nil
 }
 
+// Exists reads the VM by id; a definitive not-found (the client maps 403/404 → nil)
+// is reported as absent. A transport/5xx error surfaces so the caller fails closed.
+func (s computeVMwareVMSeam) Exists(ctx context.Context, id string) (bool, error) {
+	vm, err := s.c.Compute().VirtualMachine().Read(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return vm != nil, nil
+}
+
 // --- VMware virtual disk ------------------------------------------------------
 
 // vmwareDiskSeam is the subset of the VMware virtual-disk client a disk teardown
@@ -133,6 +189,9 @@ func (s computeVMwareVMSeam) FindIDByName(ctx context.Context, name, datacenterI
 type vmwareDiskSeam interface {
 	FindIDsByVM(ctx context.Context, vmID string) ([]string, error)
 	DeleteAndWait(ctx context.Context, id string) error
+	// Exists reports whether the disk id is still present (a Read by id). Used to
+	// confirm a 403 delete is absent, not forbidden — independent of the parent VM.
+	Exists(ctx context.Context, id string) (bool, error)
 }
 
 type vmwareDiskTeardownRef struct {
@@ -148,15 +207,23 @@ type vmwareDiskTeardownRef struct {
 // create (F3).
 func registerVMwareDiskTeardown(cl *Cleanup, seam vmwareDiskSeam, ref *vmwareDiskTeardownRef) {
 	cl.Register(fmt.Sprintf("compute.vmware.virtual_disk on %s", ref.VMID), func(tctx context.Context) error {
+		// A 403 on delete is the VMware absent-or-forbidden conflation (#303) — the
+		// explicit deprovision may have already removed this disk; confirm via a
+		// by-id existence re-check (independent of the parent VM, which may itself be
+		// gone by now) before treating it as a failure.
+		del := func(id string) error {
+			return confirmComputeDeleteErr(seam.DeleteAndWait(tctx, id),
+				func() (bool, error) { return seam.Exists(tctx, id) }, id)
+		}
 		if ref.Resolved && ref.ID != "" {
-			return seam.DeleteAndWait(tctx, ref.ID)
+			return del(ref.ID)
 		}
 		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
 		if err != nil {
 			return err
 		}
 		for _, id := range ids {
-			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+			if derr := del(id); derr != nil {
 				return derr
 			}
 		}
@@ -165,6 +232,15 @@ func registerVMwareDiskTeardown(cl *Cleanup, seam vmwareDiskSeam, ref *vmwareDis
 }
 
 type computeVMwareDiskSeam struct{ c *client.Client }
+
+// Exists reads the disk by id; a definitive not-found (403/404 → nil) is absent.
+func (s computeVMwareDiskSeam) Exists(ctx context.Context, id string) (bool, error) {
+	disk, err := s.c.Compute().VirtualDisk().Read(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return disk != nil, nil
+}
 
 func (s computeVMwareDiskSeam) FindIDsByVM(ctx context.Context, vmID string) ([]string, error) {
 	disks, err := s.c.Compute().VirtualDisk().ListStrict(ctx, &client.VirtualDiskFilter{VirtualMachineID: vmID})
@@ -200,6 +276,9 @@ type vmwareAdapterSeam interface {
 	// and there is no MAC to match on (the platform assigns it).
 	FindIDsByVM(ctx context.Context, vmID string) ([]string, error)
 	DeleteAndWait(ctx context.Context, id string) error
+	// Exists reports whether the adapter id is still present (a Read by id). Used to
+	// confirm a 403 delete is absent, not forbidden — independent of the parent VM.
+	Exists(ctx context.Context, id string) (bool, error)
 }
 
 type vmwareAdapterTeardownRef struct {
@@ -213,15 +292,23 @@ type vmwareAdapterTeardownRef struct {
 // every adapter on the (run-unique, ours) VM.
 func registerVMwareNetworkAdapterTeardown(cl *Cleanup, seam vmwareAdapterSeam, ref *vmwareAdapterTeardownRef) {
 	cl.Register(fmt.Sprintf("compute.vmware.network_adapter %s", ref.VMID), func(tctx context.Context) error {
+		// A 403 on delete is the VMware absent-or-forbidden conflation (#303) — the
+		// explicit deprovision may have already removed this adapter; confirm via a
+		// by-id existence re-check (independent of the parent VM, which may be gone)
+		// before treating it as a failure.
+		del := func(id string) error {
+			return confirmComputeDeleteErr(seam.DeleteAndWait(tctx, id),
+				func() (bool, error) { return seam.Exists(tctx, id) }, id)
+		}
 		if ref.Resolved && ref.ID != "" {
-			return seam.DeleteAndWait(tctx, ref.ID)
+			return del(ref.ID)
 		}
 		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
 		if err != nil {
 			return err
 		}
 		for _, id := range ids {
-			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+			if derr := del(id); derr != nil {
 				return derr
 			}
 		}
@@ -230,6 +317,15 @@ func registerVMwareNetworkAdapterTeardown(cl *Cleanup, seam vmwareAdapterSeam, r
 }
 
 type computeVMwareAdapterSeam struct{ c *client.Client }
+
+// Exists reads the adapter by id; a definitive not-found (403/404 → nil) is absent.
+func (s computeVMwareAdapterSeam) Exists(ctx context.Context, id string) (bool, error) {
+	adapter, err := s.c.Compute().NetworkAdapter().Read(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return adapter != nil, nil
+}
 
 func (s computeVMwareAdapterSeam) FindIDsByVM(ctx context.Context, vmID string) ([]string, error) {
 	adapters, err := s.c.Compute().NetworkAdapter().ListStrict(ctx,

--- a/cmd/ct-validate/cycle_compute_vmware_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_vmware_lifecycle_test.go
@@ -14,14 +14,21 @@ import (
 // fakes in cycle_compute_lifecycle_test.go (distinct names, same package). ---
 
 type fakeVMwareVMSeam struct {
-	log     *[]string
-	findID  string
-	findErr error
+	log       *[]string
+	findID    string
+	findErr   error
+	delErr    error // when non-nil, DeleteAndWait fails (e.g. a VMware 403-on-absent)
+	exists    bool  // Exists() result, used to confirm a 403 delete
+	existsErr error
 }
 
 func (f fakeVMwareVMSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "vm.delete:"+id)
-	return nil
+	return f.delErr
+}
+func (f fakeVMwareVMSeam) Exists(_ context.Context, id string) (bool, error) {
+	*f.log = append(*f.log, "vm.exists:"+id)
+	return f.exists, f.existsErr
 }
 func (f fakeVMwareVMSeam) PowerOffAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "vm.poweroff:"+id)
@@ -33,9 +40,11 @@ func (f fakeVMwareVMSeam) FindIDByName(_ context.Context, name, dcID string) (st
 }
 
 type fakeVMwareDiskSeam struct {
-	log    *[]string
-	ids    []string // FindIDsByVM returns these
-	delErr error    // when non-nil, DeleteAndWait fails (e.g. a 409)
+	log       *[]string
+	ids       []string // FindIDsByVM returns these
+	delErr    error    // when non-nil, DeleteAndWait fails (e.g. a 409)
+	exists    bool     // Exists() result
+	existsErr error
 }
 
 func (f fakeVMwareDiskSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
@@ -46,11 +55,17 @@ func (f fakeVMwareDiskSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "disk.delete:"+id)
 	return f.delErr
 }
+func (f fakeVMwareDiskSeam) Exists(_ context.Context, id string) (bool, error) {
+	*f.log = append(*f.log, "disk.exists:"+id)
+	return f.exists, f.existsErr
+}
 
 type fakeVMwareAdapterSeam struct {
-	log    *[]string
-	ids    []string // FindIDsByVM returns these
-	delErr error    // when non-nil, DeleteAndWait fails
+	log       *[]string
+	ids       []string // FindIDsByVM returns these
+	delErr    error    // when non-nil, DeleteAndWait fails
+	exists    bool     // Exists() result
+	existsErr error
 }
 
 func (f fakeVMwareAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
@@ -60,6 +75,109 @@ func (f fakeVMwareAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]st
 func (f fakeVMwareAdapterSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "adapter.delete:"+id)
 	return f.delErr
+}
+func (f fakeVMwareAdapterSeam) Exists(_ context.Context, id string) (bool, error) {
+	*f.log = append(*f.log, "adapter.exists:"+id)
+	return f.exists, f.existsErr
+}
+
+// TestConfirmComputeDeleteErr pins the VMware compute delete decision: 404 →
+// idempotent success; a 403 is CONFIRMED via a by-id existence re-check and
+// accepted ONLY when the id is proven absent (the false-"orphan" fix), surfaced
+// when it still exists, and failed-closed when the re-check itself errors; other
+// errors surface unchanged. Mutations: treat 403 as always-success → the
+// still-present case wrongly passes → RED; treat 403 as always-failure → the
+// absent case fails → RED.
+func TestConfirmComputeDeleteErr(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+	notFound := client.StatusError{Code: http.StatusNotFound}
+	serverErr := client.StatusError{Code: http.StatusInternalServerError}
+	absent := func() (bool, error) { return false, nil }
+	present := func() (bool, error) { return true, nil }
+	recheckFailed := func() (bool, error) { return false, errors.New("transport error: cannot confirm") }
+
+	if confirmComputeDeleteErr(nil, present, "id-x") != nil {
+		t.Fatal("nil error must be success")
+	}
+	if confirmComputeDeleteErr(notFound, present, "id-x") != nil {
+		t.Fatal("a 404 must be idempotent success without re-checking existence")
+	}
+	if err := confirmComputeDeleteErr(forbidden, absent, "id-x"); err != nil {
+		t.Fatalf("a 403 with the id confirmed ABSENT must be success (no false orphan), got %v", err)
+	}
+	if confirmComputeDeleteErr(forbidden, present, "id-x") == nil {
+		t.Fatal("a 403 with the id STILL existing must surface as a real failure")
+	}
+	if confirmComputeDeleteErr(forbidden, recheckFailed, "id-x") == nil {
+		t.Fatal("a 403 whose absence cannot be confirmed must fail closed")
+	}
+	if confirmComputeDeleteErr(serverErr, absent, "id-x") == nil {
+		t.Fatal("a 5xx must surface unchanged (never silently accepted)")
+	}
+}
+
+// TestVMwareVMTeardownConfirms403AsAbsent pins the wiring: when the deferred VM
+// teardown re-deletes an already-gone VM (VMware answers 403, not 404) and the
+// by-id existence re-check shows it absent, the teardown is a clean SUCCESS — not
+// a false "possible orphan". If the re-check still shows it present, it is a real
+// failure. A separate case pins fail-closed when the re-check itself errors.
+func TestVMwareVMTeardownConfirms403AsAbsent(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+
+	// VM already gone: delete 403s, the by-id existence re-check says absent → ok.
+	var log []string
+	cl := NewCleanup()
+	registerVMwareVMTeardown(cl, fakeVMwareVMSeam{log: &log, delErr: forbidden, exists: false},
+		&vmwareVMTeardownRef{Name: "vm-x", DatacenterID: "dc-1", ID: "vm-id", Resolved: true})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a 403 on an already-gone VM must be confirmed absent (no false orphan), got failures %v", f)
+	}
+
+	// VM still present: delete 403s, the re-check says it still exists → real failure.
+	var log2 []string
+	cl2 := NewCleanup()
+	registerVMwareVMTeardown(cl2, fakeVMwareVMSeam{log: &log2, delErr: forbidden, exists: true},
+		&vmwareVMTeardownRef{Name: "vm-x", DatacenterID: "dc-1", ID: "vm-id", Resolved: true})
+	if f := cl2.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("a 403 with the VM STILL present must be a real teardown failure, got %v", f)
+	}
+
+	// Re-check ITSELF errors (e.g. a 5xx on Read): unknown existence → FAIL CLOSED
+	// (a teardown failure), never silently accepted.
+	var log3 []string
+	cl3 := NewCleanup()
+	registerVMwareVMTeardown(cl3, fakeVMwareVMSeam{log: &log3, delErr: forbidden, existsErr: errors.New("503 on read")},
+		&vmwareVMTeardownRef{Name: "vm-x", DatacenterID: "dc-1", ID: "vm-id", Resolved: true})
+	if f := cl3.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("a 403 whose existence re-check errors must fail closed (teardown failure), got %v", f)
+	}
+}
+
+// TestVMwareLeafTeardownConfirms403WhenParentVMGone pins Codex's exact concern: a
+// deferred LEAF (disk/adapter) re-delete after the explicit deprovision already
+// removed the parent VM gets a 403; the confirm is a BY-ID existence re-check
+// (Exists), independent of the now-gone VM, so an absent leaf is a clean success
+// (not a false orphan), and a still-present leaf is a real failure.
+func TestVMwareLeafTeardownConfirms403WhenParentVMGone(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+
+	// Disk: resolved, delete 403s, Exists=false (gone with its VM) → success.
+	var dl []string
+	dcl := NewCleanup()
+	registerVMwareDiskTeardown(dcl, fakeVMwareDiskSeam{log: &dl, delErr: forbidden, exists: false},
+		&vmwareDiskTeardownRef{VMID: "vm-gone", ID: "disk-1", Resolved: true})
+	if f := dcl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a 403 disk delete confirmed absent by-id must succeed even when the VM is gone, got %v", f)
+	}
+
+	// Adapter: resolved, delete 403s, Exists=true (still there) → real failure.
+	var al []string
+	acl := NewCleanup()
+	registerVMwareNetworkAdapterTeardown(acl, fakeVMwareAdapterSeam{log: &al, delErr: forbidden, exists: true},
+		&vmwareAdapterTeardownRef{VMID: "vm-x", ID: "ad-1", Resolved: true})
+	if f := acl.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("a 403 adapter delete with the adapter still present must be a real failure, got %v", f)
+	}
 }
 
 // TestRegisterVMwareVMTeardownResolvedDeletesByID: a resolved ref deletes by id


### PR DESCRIPTION
## Symptom
A fully successful VMware write cycle (`compute_vmware_lifecycle`) — create + explicit deprovision all `200` — still printed 3 `TEARDOWN FAILURES (possible orphans — investigate)` and exited non-zero, with `403 (Forbidden.)` for the adapter, disk and VM. **No real orphan** existed.

## Root cause
The deferred teardown (the always-on backstop) re-deletes what the explicit deprovision already removed. The VMware compute API returns **`403` for an ABSENT resource** (it conflates absent/forbidden — the #303 pattern), but the teardown idempotency only treated **`404`** as "already gone", so a 403-on-absent surfaced as a false failure. Proof it is *absent* not *forbidden*: the explicit delete with the same PAT succeeded moments earlier.

## Fix
`confirmComputeDeleteErr(err, stillExists, id)`:
- `404` → idempotent success;
- `403` → **confirmed via a by-id existence re-check** (`seam.Exists` → `Read` by id, which maps 403/404 → not-found): accepted **only** when proven absent, surfaced when it **still exists**, failed **closed** when the re-check itself errors;
- other errors surface unchanged.

The re-check is **by id and independent of the parent VM**, so it stays valid when the deferred leaf teardown runs *after* the explicit deprovision already deleted the parent VM (a VM-scoped listing would fail there — the round-1 review caught this). Mirrors the VPC `staticIPDeleteErrResult` (#312) confirm-before-accept doctrine. Wired into the VM/disk/adapter deferred teardowns; the explicit deprovision path is unchanged (resources present there → `200`, never a 403-on-absent).

## Tests / review
Mutation-proven: helper decision (404/403-absent/403-present/recheck-error/5xx), wired VM + leaf 403 absent/present, and fail-closed when the re-check errors. Adversarial review (Codex): GO (round 1 NO-GO on parent-scoped confirmation → moved to by-id existence re-check).

Refs #316.