### PR TITLE
ct-validate: size OpenIaaS lifecycle VM from its template (fix MEMORY_CONSTRAINT_VIOLATION_ORDER)

### DIFF
--- a/cmd/ct-validate/cycle_compute_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle.go
@@ -49,6 +49,32 @@ type computeLifecycleCycle struct {
 func (computeLifecycleCycle) Name() string { return "compute_lifecycle" }
 func (computeLifecycleCycle) Kind() Kind   { return KindWrite }
 
+// vmSize returns the VM create size for one dimension (CPU or memory): the larger
+// of the floor and the template's own requirement. Deploying a template below its
+// defined CPU/RAM is rejected by the order layer (MEMORY_CONSTRAINT_VIOLATION_ORDER),
+// so the template's value must win when it exceeds the floor; the floor guards the
+// case where the listing reports 0.
+func vmSize(floor, fromTemplate int) int {
+	if fromTemplate > floor {
+		return fromTemplate
+	}
+	return floor
+}
+
+// openIaaSVMCreateReq builds the create request for the OpenIaaS lifecycle VM,
+// sizing CPU/RAM at max(floor, template) so the deploy satisfies the order layer's
+// "not below the template" constraint. Kept as a pure builder so a test can pin
+// that the SELECTED template's sizing actually reaches the create request (not the
+// bare floor constants).
+func openIaaSVMCreateReq(name, templateID string, tmplCPU, tmplMem int) *client.CreateOpenIaasVirtualMachineRequest {
+	return &client.CreateOpenIaasVirtualMachineRequest{
+		Name:       name,
+		TemplateID: templateID,
+		CPU:        vmSize(clVMCPU, tmplCPU),
+		Memory:     vmSize(clVMMemory, tmplMem),
+	}
+}
+
 func (cyc computeLifecycleCycle) mkToken() (string, error) {
 	if cyc.tokenFunc != nil {
 		return cyc.tokenFunc()
@@ -57,6 +83,9 @@ func (cyc computeLifecycleCycle) mkToken() (string, error) {
 }
 
 const (
+	// clVMCPU/clVMMemory are FLOORS: the VM is sized at max(floor, template's own
+	// CPU/RAM), because the order layer rejects deploying a template with less than
+	// its defined CPU/RAM (MEMORY_CONSTRAINT_VIOLATION_ORDER).
 	clVMCPU    = 1
 	clVMMemory = 1073741824 // 1 GiB, in bytes
 	clDiskSize = 1073741824 // 1 GiB, in bytes
@@ -142,6 +171,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	}
 
 	var tmplID string
+	var tmplCPU, tmplMem int
 	_ = r.op(cyc, "compute.openiaas.templates.list", func() error {
 		tmpls, err := oi.Template().List(ctx, &client.OpenIaaSTemplateFilter{MachineManagerId: mmID})
 		if err != nil {
@@ -149,7 +179,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		}
 		for _, t := range tmpls {
 			if t != nil && t.ID != "" {
-				tmplID = t.ID
+				tmplID, tmplCPU, tmplMem = t.ID, t.CPU, t.Memory
 				break
 			}
 		}
@@ -197,12 +227,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	registerVMTeardown(r.Cleanup, computeVMSeam{c}, vmRef)
 	var vmID string
 	_ = r.op(cyc, "compute.openiaas.virtual_machine.create", func() error {
-		activityID, err := oi.VirtualMachine().Create(ctx, &client.CreateOpenIaasVirtualMachineRequest{
-			Name:       name,
-			TemplateID: tmplID,
-			CPU:        clVMCPU,
-			Memory:     clVMMemory,
-		})
+		activityID, err := oi.VirtualMachine().Create(ctx, openIaaSVMCreateReq(name, tmplID, tmplCPU, tmplMem))
 		if err != nil {
 			return err
 		}

--- a/cmd/ct-validate/cycle_compute_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle_test.go
@@ -192,6 +192,48 @@ func TestComputeLifecycleTeardownLIFOOrder(t *testing.T) {
 	}
 }
 
+// TestVMSizeUsesTemplateWhenLarger pins the order-constraint fix: the create size
+// is max(floor, template). The template's own CPU/RAM must win when it exceeds the
+// floor (deploying a template under-sized is rejected: MEMORY_CONSTRAINT_VIOLATION_ORDER);
+// the floor guards a 0/absent template value. Mutation: always return the floor →
+// the "template larger" case goes RED (and the live create would 400/violate).
+func TestVMSizeUsesTemplateWhenLarger(t *testing.T) {
+	const floor = 1073741824 // 1 GiB
+	if got := vmSize(floor, 4*floor); got != 4*floor {
+		t.Fatalf("template larger than floor must win (avoids the order constraint), got %d", got)
+	}
+	if got := vmSize(floor, 0); got != floor {
+		t.Fatalf("a 0/absent template value must fall back to the floor, got %d", got)
+	}
+	if got := vmSize(floor, floor/2); got != floor {
+		t.Fatalf("a template smaller than the floor must keep the floor, got %d", got)
+	}
+	if got := vmSize(2, 8); got != 8 { // CPU dimension
+		t.Fatalf("cpu sizing must also take the larger, got %d", got)
+	}
+}
+
+// TestOpenIaaSVMCreateReqUsesSelectedTemplateSizing pins the integration the unit
+// test alone misses: the SELECTED template's id AND its CPU/Memory (sized to the
+// floor) actually reach the create request — a regression that hardcoded the floor
+// constants or read a different template would be caught here. Mutation: build the
+// request with clVMCPU/clVMMemory instead of the template values → RED.
+func TestOpenIaaSVMCreateReqUsesSelectedTemplateSizing(t *testing.T) {
+	const bigMem = 4 * clVMMemory // template wants 4 GiB, above the 1 GiB floor
+	req := openIaaSVMCreateReq("ct-validate-vm", "tmpl-selected", 4, bigMem)
+	if req.TemplateID != "tmpl-selected" {
+		t.Fatalf("must deploy from the selected template, got %q", req.TemplateID)
+	}
+	if req.CPU != 4 || req.Memory != bigMem {
+		t.Fatalf("must size from the template (cpu=4, mem=%d), got cpu=%d mem=%d", bigMem, req.CPU, req.Memory)
+	}
+	// A template reporting 0 (listing did not populate it) falls back to the floor.
+	floorReq := openIaaSVMCreateReq("ct-validate-vm", "tmpl-zero", 0, 0)
+	if floorReq.CPU != clVMCPU || floorReq.Memory != clVMMemory {
+		t.Fatalf("a 0 template must fall back to the floor, got cpu=%d mem=%d", floorReq.CPU, floorReq.Memory)
+	}
+}
+
 // TestRegistryHasComputeLifecycleGated: the cycle is registered, write-typed, and
 // gated out unless -write is set.
 func TestRegistryHasComputeLifecycleGated(t *testing.T) {


### PR DESCRIPTION
## Symptom
The OpenIaaS write cycle `compute_lifecycle` create failed on a live run: the activity ended `failed` with reason **`MEMORY_CONSTRAINT_VIOLATION_ORDER()`**.

## Root cause
The cycle deploys a VM from a discovered template but hardcoded **CPU=1 / Memory=1 GiB**. The order layer rejects deploying a template with **less** CPU/RAM than the template's own definition.

## Fix
Capture the selected template's own CPU/Memory (`OpenIaasTemplate` List already decodes them) and size the create at **`vmSize(floor, template) = max(floor, template)`** per dimension:
- the template's value (a known-valid config) satisfies the minimum constraint;
- the floor (1 vCPU / 1 GiB) guards a `0`/absent listing value.

`CreateOpenIaasVirtualMachineRequest.CPU/Memory` are not `omitempty` (always sent), so omitting them isn't an option. The request is built via the pure `openIaaSVMCreateReq()` so a test pins that the **selected** template's sizing reaches the create request (not the bare floor constants).

## Tests / review
Mutation-proven: `vmSize` (template-larger wins, 0 → floor, smaller → floor) and the builder integration (selected template id + sized CPU/Memory in the request). Adversarial review (Codex): GO (the by-id builder test added per its nit).

Note: this only fixes the OpenIaaS *create* failure; the OpenIaaS teardown 403-as-absent question is still open (no create had succeeded to exercise it) and tracked separately.

Refs #316.