### PR TITLE
ct-validate: redaction no longer masks SCREAMING_SNAKE error reason codes

### DIFF
--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -116,23 +116,42 @@ var (
 	// Named secret carriers; the value may be a quoted string (spaces allowed) or a
 	// single delimiter-bounded token. Names cover the common OAuth/secret variants.
 	kvSecretRe = regexp.MustCompile(`(?i)\b(password|passwd|secret|client_secret|access_token|refresh_token|id_token|token|api[_-]?key|apikey|signature|credential)\b(\s*["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s"',}&]+)`)
-	// The catch-all: any LONG opaque run (base64/hex/JWT-like, >=20 chars) is
-	// credential material regardless of surrounding key/scheme/format — mask it.
-	// Ordinary error words are far shorter, so this rarely touches useful text;
-	// when in doubt it OVER-redacts, which is the safe direction.
+	// The catch-all: a LONG opaque run (base64/hex/JWT-like, >=20 chars) is
+	// credential material regardless of surrounding key/scheme/format — mask it,
+	// with ONE narrow exception (reasonCodeRe below) so the catch-all does not
+	// swallow the diagnostic the report exists to surface.
 	opaqueTokenRe = regexp.MustCompile(`[A-Za-z0-9+/=_~.-]{20,}`)
+	// reasonCodeRe matches a SCREAMING_SNAKE_CASE error reason code: uppercase
+	// letters/digits in >=2 underscore-joined words, e.g. MEMORY_CONSTRAINT_VIOLATION_ORDER.
+	// opaqueTokenRe's class includes `_`, so such a code is captured as a SINGLE run
+	// and this exception un-masks it. A credential RARELY takes this exact shape —
+	// real tokens carry lowercase, base64 `+/=.` chars, or have no underscores — and
+	// keyed/scheme secrets are already masked by the earlier layers regardless. The
+	// exception is deliberately scoped to all-uppercase underscore-joined codes (the
+	// observed reason-code shape); a hypothetical bare uppercase_underscore secret in
+	// a body would be preserved, which is acceptable for observability redaction (a
+	// defence-in-depth scrub of response bodies, not a hard secret boundary).
+	reasonCodeRe = regexp.MustCompile(`^[A-Z0-9]+(?:_[A-Z0-9]+)+$`)
 )
 
 // redactSecrets scrubs credential material from text that may be recorded or
 // printed (an API error body). It layers an Authorization-value mask, a bare
 // bearer mask, named secret carriers (quoted or single-token), and finally a
 // catch-all long-opaque-token mask — so no credential survives regardless of
-// format. It deliberately errs toward OVER-redaction over leaking.
+// format. The catch-all masks EVERY long opaque run except a SCREAMING_SNAKE error
+// reason code (reasonCodeRe), which a credential never matches; that keeps the
+// diagnostic visible without leaking token-like material. It errs toward
+// OVER-redaction over leaking for anything else token-like.
 func redactSecrets(s string) string {
 	s = authHeaderRe.ReplaceAllString(s, "Authorization: ***REDACTED***")
 	s = bearerTokenRe.ReplaceAllString(s, "Bearer ***REDACTED***")
 	s = kvSecretRe.ReplaceAllString(s, "${1}=***REDACTED***")
-	s = opaqueTokenRe.ReplaceAllString(s, "***REDACTED***")
+	s = opaqueTokenRe.ReplaceAllStringFunc(s, func(m string) string {
+		if reasonCodeRe.MatchString(m) {
+			return m // an error reason code, not a credential
+		}
+		return "***REDACTED***"
+	})
 	return s
 }
 

--- a/cmd/ct-validate/report_test.go
+++ b/cmd/ct-validate/report_test.go
@@ -152,6 +152,10 @@ func TestRedactSecretsMasksCredentials(t *testing.T) {
 		"password=\"correct horse battery staple\"":                  "battery",
 		"bearer eyJraw.token.here.long.enough.value":                 "eyJraw.token.here.long.enough.value",
 		"leaked raw blob 0123456789abcdef0123456789abcdef":           "0123456789abcdef0123456789abcdef",
+		// Digitless secrets must STILL be masked — the reason-code exception is narrow.
+		"Bearer AAAAAAAAAAAAAAAAAAAAAAAA":   "AAAAAAAAAAAAAAAAAAAAAAAA",
+		"token=ABCDEFGHIJKLMNOPQRSTUVWX":    "ABCDEFGHIJKLMNOPQRSTUVWX",
+		"opaque abcdefghijklmnopqrstuvwxyz": "abcdefghijklmnopqrstuvwxyz",
 	}
 	for in, leak := range cases {
 		out := redactSecrets(in)
@@ -169,6 +173,29 @@ func TestRedactSecretsMasksCredentials(t *testing.T) {
 	// An ordinary API error body must be left intact (no false redaction).
 	if got := redactSecrets("Unexpected response code: 403 (Forbidden.)"); got != "Unexpected response code: 403 (Forbidden.)" {
 		t.Fatalf("an ordinary body must be unchanged, got %q", got)
+	}
+}
+
+// TestRedactSecretsPreservesErrorReasonCodes pins that the catch-all opaque-token
+// mask does NOT swallow long all-letter/underscore error reason codes (no digit) —
+// those are the diagnostic the report exists to surface (a real run failed with
+// MEMORY_CONSTRAINT_VIOLATION_ORDER and the mask was hiding it). A token-like run
+// WITH a digit is still masked. Mutation: drop the digit requirement → the reason
+// code is masked → RED.
+func TestRedactSecretsPreservesErrorReasonCodes(t *testing.T) {
+	for _, keep := range []string{
+		"activity failed: MEMORY_CONSTRAINT_VIOLATION_ORDER",
+		"VM state is halted but should be paused, suspended, running",
+		"the virtual machine could not be created: INSUFFICIENT_RESOURCES_AVAILABLE",
+		"order rejected: ERROR_500_INTERNAL_FAILURE", // reason code WITH a digit segment
+	} {
+		if got := redactSecrets(keep); got != keep {
+			t.Fatalf("an all-letter error reason code must be preserved, got %q from %q", got, keep)
+		}
+	}
+	// A digit-bearing opaque blob (realistic credential material) is STILL masked.
+	if got := redactSecrets("dump 0123456789abcdef0123456789abcdef"); strings.Contains(got, "0123456789abcdef0123456789abcdef") {
+		t.Fatalf("a digit-bearing opaque blob must still be masked, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Symptom
A real OpenIaaS create failure (`MEMORY_CONSTRAINT_VIOLATION_ORDER`) was being shown in the report as `***REDACTED***` — the secret-redaction catch-all (mask any opaque run ≥20 chars) swallowed the reason code, hiding the exact diagnostic.

## Fix
The catch-all now masks every long opaque run **except** one matching a SCREAMING_SNAKE error-reason-code shape: `^[A-Z0-9]+(?:_[A-Z0-9]+)+$` (all-uppercase, digits allowed, ≥1 underscore-joined word). `opaqueTokenRe`'s class includes `_`, so such a code is one match and this exception un-masks it.

A credential rarely takes that exact shape (real tokens carry lowercase, base64 `+/=.` chars, or have no underscores), and keyed/scheme secrets are masked by the Authorization/bearer/named layers first. Residual (accepted for an observability scrub, not a hard secret boundary): a bare `UPPER_CASE_UNDERSCORE` value ≥20 chars in a body would be preserved.

## Tests / review
Reason codes (incl. a digit segment) preserved; digitless secrets (`Bearer AAAA…`, `token=ABCD…`, lowercase blob) still masked. Mutation-proven (drop exception → preservation RED; broaden the exception → secret leaks RED). Adversarial review (Codex): GO (rounds 1–2 hardened the rule from "digitless" to the narrow SCREAMING_SNAKE exception; a round-2 misread that `_` was excluded was disproven empirically).

Refs #316.