### PR TITLE
ct-validate: OpenIaaS lifecycle — disk SR in the VM's pool, drop connect

### DIFF
--- a/cmd/ct-validate/cycle_compute_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle.go
@@ -24,8 +24,9 @@ func newRunToken() (string, error) {
 }
 
 // computeLifecycleCycle is the end-to-end OpenIaaS compute WRITE business cycle:
-// create a VM from a template, attach a user data disk, attach + connect a user
-// network adapter, then deprovision the whole stack leaves-first. It is the
+// create a VM from a template, attach a user data disk (on an SR in the VM's
+// pool), attach a user network adapter, then deprovision the whole stack
+// leaves-first. It is the
 // realization of the #316 TODO and the cycle to replay (with -runs/-concurrency)
 // for a BOUNDED, breaker-guarded load probe ("how far does it hold").
 //
@@ -66,6 +67,29 @@ func vmSize(floor, fromTemplate int) int {
 // "not below the template" constraint. Kept as a pure builder so a test can pin
 // that the SELECTED template's sizing actually reaches the create request (not the
 // bare floor constants).
+// selectOpenIaaSDiskSR picks a storage repository usable for a data disk on a VM
+// in the given pool/host. The disk-create rejects an SR the VM cannot reach
+// ("could not find storage repository with uuid …"), so the SR must be in the
+// VM's pool: a SHARED SR (reachable from any host in the pool) is preferred,
+// otherwise a non-shared SR LOCAL to the VM's host. Only accessible, non-
+// maintenance SRs with room for the disk qualify. Returns "" when none fits (the
+// disk sub-step is then skipped — not a failure).
+func selectOpenIaaSDiskSR(srs []*client.OpenIaaSStorageRepository, vmPoolID, vmHostID string, minFree int) string {
+	var hostLocal string
+	for _, sr := range srs {
+		if sr == nil || sr.ID == "" || sr.MaintenanceMode || sr.Accessible == 0 || sr.FreeCapacity < minFree {
+			continue
+		}
+		if sr.Shared && vmPoolID != "" && sr.Pool.ID == vmPoolID {
+			return sr.ID // shared SR in the VM's pool — reachable from its host
+		}
+		if !sr.Shared && vmHostID != "" && sr.Host.ID == vmHostID && hostLocal == "" {
+			hostLocal = sr.ID // fallback: a local SR on the VM's own host
+		}
+	}
+	return hostLocal
+}
+
 func openIaaSVMCreateReq(name, templateID string, tmplCPU, tmplMem int) *client.CreateOpenIaasVirtualMachineRequest {
 	return &client.CreateOpenIaasVirtualMachineRequest{
 		Name:       name,
@@ -149,7 +173,6 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		"compute.openiaas.virtual_machine.create",
 		"compute.openiaas.virtual_disk.create",
 		"compute.openiaas.network_adapter.create",
-		"compute.openiaas.network_adapter.connect",
 		"compute.openiaas.virtual_machine.read",
 		"compute.openiaas.network_adapter.delete",
 		"compute.openiaas.virtual_disk.disconnect",
@@ -187,20 +210,15 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	})
 
 	// A storage repository and a network are OPTIONAL: without them the disk and
-	// adapter sub-steps are skipped, but the VM create+delete still run.
-	var srID string
+	// adapter sub-steps are skipped, but the VM create+delete still run. The SR is
+	// SELECTED later (after the VM is created), once the VM's pool/host is known —
+	// the disk-create rejects an SR the VM cannot reach ("could not find storage
+	// repository"), so a usable SR must be in the VM's pool, not just any SR.
+	var srs []*client.OpenIaaSStorageRepository
 	_ = r.op(cyc, "compute.openiaas.storage_repositories.list", func() error {
-		srs, err := oi.StorageRepository().List(ctx, &client.StorageRepositoryFilter{MachineManagerId: mmID})
-		if err != nil {
-			return err
-		}
-		for _, sr := range srs {
-			if sr != nil && sr.ID != "" && !sr.MaintenanceMode {
-				srID = sr.ID
-				break
-			}
-		}
-		return nil
+		var err error
+		srs, err = oi.StorageRepository().List(ctx, &client.StorageRepositoryFilter{MachineManagerId: mmID})
+		return err
 	})
 	var networkID string
 	_ = r.op(cyc, "compute.openiaas.networks.list", func() error {
@@ -243,7 +261,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		// name) sweeps it. Nothing further to provision/deprovision explicitly.
 		for _, ep := range []string{
 			"compute.openiaas.virtual_disk.create", "compute.openiaas.network_adapter.create",
-			"compute.openiaas.network_adapter.connect", "compute.openiaas.virtual_machine.read",
+			"compute.openiaas.virtual_machine.read",
 			"compute.openiaas.network_adapter.delete", "compute.openiaas.virtual_disk.disconnect",
 			"compute.openiaas.virtual_disk.delete", "compute.openiaas.virtual_machine.delete",
 		} {
@@ -253,7 +271,23 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	}
 	vmRef.ID, vmRef.Resolved = vmID, true
 
+	// Read the created VM to learn its pool/host (doubles as the observational read
+	// of the VM). The disk-create rejects an SR the VM cannot reach, so the SR is
+	// selected against the VM's pool/host below — not blindly from the list.
+	var vmPoolID, vmHostID string
+	_ = r.op(cyc, "compute.openiaas.virtual_machine.read", func() error {
+		vm, err := oi.VirtualMachine().Read(ctx, vmID)
+		if err != nil {
+			return err
+		}
+		if vm != nil {
+			vmPoolID, vmHostID = vm.Pool.ID, vm.Host.ID
+		}
+		return nil
+	})
+
 	// --- PHASE 2: storage variation — attach a user data disk (optional) ---
+	srID := selectOpenIaaSDiskSR(srs, vmPoolID, vmHostID, clDiskSize)
 	var diskID string
 	if srID != "" {
 		diskRef := &diskTeardownRef{Name: name + "-data", VMID: vmID}
@@ -279,11 +313,26 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		if diskID != "" {
 			diskRef.ID, diskRef.Resolved = diskID, true
 		}
-	} else {
+	} else if len(srs) == 0 {
+		// No storage repository at all on the tenant → nothing to exercise.
 		r.skip(cyc, "compute.openiaas.virtual_disk.create")
+	} else {
+		// Candidate SRs EXIST but none is reachable for this VM (none shared in its
+		// pool, none local to its host, or the VM read did not yield a pool/host).
+		// Surface it as a recorded FAILURE rather than a silent skip: for a validation
+		// tool, a green run that quietly never exercised the disk path is worse, and
+		// the pool/host detail lets the reachability rule be refined.
+		_ = r.op(cyc, "compute.openiaas.virtual_disk.create", func() error {
+			return fmt.Errorf("no storage repository reachable for the VM (pool=%q host=%q; %d listed SR(s), none shared-in-pool nor host-local with >= %d bytes free)",
+				vmPoolID, vmHostID, len(srs), clDiskSize)
+		})
 	}
 
-	// --- PHASE 3: network connection — attach + connect a user adapter (optional) ---
+	// --- PHASE 3: network connection — attach a user adapter (optional) ---------
+	// The Create attaches the adapter to the network. No explicit Connect: bringing
+	// the link up requires a RUNNING VM ("VM state is halted but should be running"),
+	// and this lean cycle keeps the VM halted — the network attachment at provision
+	// time is what we exercise (mirrors the VMware cycle).
 	var adapterID string
 	if networkID != "" {
 		adapterRef := &adapterTeardownRef{VMID: vmID}
@@ -306,27 +355,10 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		})
 		if adapterID != "" {
 			adapterRef.ID, adapterRef.Resolved = adapterID, true
-			_ = r.op(cyc, "compute.openiaas.network_adapter.connect", func() error {
-				activityID, err := oi.NetworkAdapter().Connect(ctx, adapterID)
-				if err != nil {
-					return err
-				}
-				_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
-				return werr
-			})
-		} else {
-			r.skip(cyc, "compute.openiaas.network_adapter.connect")
 		}
 	} else {
 		r.skip(cyc, "compute.openiaas.network_adapter.create")
-		r.skip(cyc, "compute.openiaas.network_adapter.connect")
 	}
-
-	// Observational read of the assembled VM.
-	_ = r.op(cyc, "compute.openiaas.virtual_machine.read", func() error {
-		_, err := oi.VirtualMachine().Read(ctx, vmID)
-		return err
-	})
 
 	// --- PHASE 4: deprovision (explicit + recorded; leaves-first). Overlaps the
 	// deferred teardowns by design — idempotent (404-only), so a double delete is

--- a/cmd/ct-validate/cycle_compute_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 )
 
 // --- recording fake seams (offline, no client) ---
@@ -231,6 +233,69 @@ func TestOpenIaaSVMCreateReqUsesSelectedTemplateSizing(t *testing.T) {
 	floorReq := openIaaSVMCreateReq("ct-validate-vm", "tmpl-zero", 0, 0)
 	if floorReq.CPU != clVMCPU || floorReq.Memory != clVMMemory {
 		t.Fatalf("a 0 template must fall back to the floor, got cpu=%d mem=%d", floorReq.CPU, floorReq.Memory)
+	}
+}
+
+// TestSelectOpenIaaSDiskSR pins the disk-SR selection that fixes the live
+// "could not find storage repository" failure: a SHARED SR in the VM's pool is
+// preferred; a non-shared SR is only chosen when it is LOCAL to the VM's host;
+// SRs in another pool, in maintenance, inaccessible, or too small are rejected;
+// none-fits yields "". Mutation: ignore pool/host (return the first usable) → the
+// wrong-pool SR is chosen → RED.
+func TestSelectOpenIaaSDiskSR(t *testing.T) {
+	const need = 1073741824
+	bo := func(id string) client.BaseObject { return client.BaseObject{ID: id} }
+	srs := []*client.OpenIaaSStorageRepository{
+		{ID: "sr-othpool", Shared: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-OTHER")}, // shared but wrong pool
+		{ID: "sr-maint", Shared: true, MaintenanceMode: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-A")},
+		{ID: "sr-small", Shared: true, Accessible: 1, FreeCapacity: need / 2, Pool: bo("pool-A")},   // too small
+		{ID: "sr-shared", Shared: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-A")}, // the right one
+		{ID: "sr-local", Shared: false, Accessible: 1, FreeCapacity: 10 * need, Host: bo("host-1")},
+	}
+	if got := selectOpenIaaSDiskSR(srs, "pool-A", "host-1", need); got != "sr-shared" {
+		t.Fatalf("must pick the SHARED SR in the VM's pool, got %q", got)
+	}
+	// No shared SR in the pool → fall back to a local SR on the VM's host.
+	noShared := []*client.OpenIaaSStorageRepository{
+		{ID: "sr-othpool", Shared: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-OTHER")},
+		{ID: "sr-local", Shared: false, Accessible: 1, FreeCapacity: 10 * need, Host: bo("host-1")},
+	}
+	if got := selectOpenIaaSDiskSR(noShared, "pool-A", "host-1", need); got != "sr-local" {
+		t.Fatalf("must fall back to a host-local SR, got %q", got)
+	}
+	// Nothing in the VM's pool/host → "" (the cycle then surfaces it, not silent).
+	if got := selectOpenIaaSDiskSR(srs, "pool-NONE", "host-NONE", need); got != "" {
+		t.Fatalf("no reachable SR must yield \"\", got %q", got)
+	}
+	// VM read yielded no pool/host (empty) → "" even with otherwise-valid SRs (we
+	// must NOT fall back to an arbitrary SR — that is the original bug).
+	if got := selectOpenIaaSDiskSR(srs, "", "", need); got != "" {
+		t.Fatalf("an unknown VM pool/host must yield \"\" (no blind pick), got %q", got)
+	}
+	// An inaccessible shared SR in the pool is skipped in favour of the next valid one.
+	inacc := []*client.OpenIaaSStorageRepository{
+		{ID: "sr-inacc", Shared: true, Accessible: 0, FreeCapacity: 10 * need, Pool: bo("pool-A")}, // accessible=0 → rejected
+		{ID: "sr-ok", Shared: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-A")},
+	}
+	if got := selectOpenIaaSDiskSR(inacc, "pool-A", "host-1", need); got != "sr-ok" {
+		t.Fatalf("an inaccessible SR must be skipped for the next valid one, got %q", got)
+	}
+	// Host-local fallback must match the VM's OWN host, not another host's local SR.
+	hosts := []*client.OpenIaaSStorageRepository{
+		{ID: "sr-otherhost", Shared: false, Accessible: 1, FreeCapacity: 10 * need, Host: bo("host-2")},
+		{ID: "sr-myhost", Shared: false, Accessible: 1, FreeCapacity: 10 * need, Host: bo("host-1")},
+	}
+	if got := selectOpenIaaSDiskSR(hosts, "pool-A", "host-1", need); got != "sr-myhost" {
+		t.Fatalf("host-local fallback must match the VM's own host, got %q", got)
+	}
+	// A host-local SR appearing BEFORE a shared-in-pool SR must NOT win: shared-in-pool
+	// is always preferred regardless of list order.
+	order := []*client.OpenIaaSStorageRepository{
+		{ID: "sr-local-first", Shared: false, Accessible: 1, FreeCapacity: 10 * need, Host: bo("host-1")},
+		{ID: "sr-shared-later", Shared: true, Accessible: 1, FreeCapacity: 10 * need, Pool: bo("pool-A")},
+	}
+	if got := selectOpenIaaSDiskSR(order, "pool-A", "host-1", need); got != "sr-shared-later" {
+		t.Fatalf("shared-in-pool must win over an earlier host-local SR, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Live findings (OpenIaaS create now succeeds — sizing #331)
Two follow-on steps failed, now exercised for the first time:
1. **data-disk create** → `Could not find storage repository with uuid <id>`: the cycle picked the first non-maintenance SR tenant-wide, which the VM could not reach.
2. **network adapter connect** → `VM state is halted but should be running`: the lean cycle never powers the VM on.

## Fix
- **SR placement**: select the SR **after** the VM is created, against the VM's **pool/host** (read from the created VM). `selectOpenIaaSDiskSR` prefers a **shared** SR in the VM's pool, else a non-shared SR **local to the VM's host**; only accessible, non-maintenance SRs with room qualify. When SRs exist but none is reachable (or the VM read yields no pool/host), the disk step is a **recorded failure** (with pool/host) — never a silent skip that hides lost coverage; only a truly empty SR list is a clean skip.
- **Connect dropped**: the Create already attaches the adapter; Connect needs a running VM, and this lean cycle keeps the VM halted. Removed from the cycle, `writeSteps`, and the skip lists — mirrors the VMware cycle.

Never-orphan intact: the disk teardown is still registered before the disk create; the VM/adapter teardowns are unchanged.

## Tests / review
`selectOpenIaaSDiskSR`: shared-in-pool preference (incl. list order), host-local fallback (own host only), wrong-pool / maintenance / too-small / inaccessible / empty-pool all rejected. Mutation-proven (ignore pool → wrong SR → RED). Adversarial review (Codex): GO (round-1 NO-GO on silent coverage loss → now a visible recorded failure; shared-in-pool is the best offline model, and the failure path surfaces it live if the rule needs refining).

Note: the shared-in-pool reachability rule is validated by the next live run; if the disk-create needs stricter host-visibility, the new failure path makes it visible (no silent skip).

Refs #316.