### PR TITLE
fix(#316): OpenIaaS teardown — confirm 403-on-absent via same-cycle delete proof

### DIFF
--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -62,6 +62,44 @@ func idempotentDeleteErr(err error) error {
 	return err
 }
 
+// confirmComputeDeleteByPriorDelete resolves a DEFERRED OpenIaaS compute delete
+// outcome (VM / disk / adapter) WITHOUT a Read re-check. It handles the direct
+// delete-CALL error: a definitive 404 (the OpenIaaS delete is idempotent) means
+// the resource is already gone → success; a 403 is the absent/forbidden
+// conflation (#303) the OpenIaaS compute API returns when the deferred net
+// re-deletes a resource the explicit deprovision already removed. Any other error
+// (and an activity-completion failure, which surfaces as an ActivityCompletionError,
+// not a StatusError) is surfaced unchanged.
+//
+// A 403 is accepted as "already gone" ONLY on STRICT POSITIVE same-cycle evidence:
+// priorDeleteOK means THIS cycle's explicit delete of THIS exact id already
+// succeeded (a 200, or a definitive 404), so the resource is provably absent and
+// the deferred 403 is the conflation, not a real orphan. Without that proof the
+// 403 FAILS CLOSED (surfaced as a teardown failure) — never silently accepted.
+//
+// Why NOT a by-id Read re-check (unlike the VMware #330 confirmComputeDeleteErr):
+// the OpenIaaS Read maps BOTH 403 and 404 to "absent" (requireNotFoundOrOK(resp,
+// 403)), so a Read cannot distinguish a truly-absent resource from a
+// present-but-forbidden one — using it would let a real orphan (delete 403 +
+// read 403 on a still-present resource) be masked as success, exactly the
+// access-denied→absent inference the never-orphan doctrine forbids. The
+// same-cycle explicit-delete proof is the unambiguous positive signal instead.
+func confirmComputeDeleteByPriorDelete(err error, priorDeleteOK bool, id string) error {
+	if err == nil {
+		return nil
+	}
+	if isStatusCode(err, http.StatusNotFound) {
+		return nil
+	}
+	if isStatusCode(err, http.StatusForbidden) {
+		if priorDeleteOK {
+			return nil // this cycle's explicit delete of this id already succeeded → 403 is the conflation, not an orphan
+		}
+		return fmt.Errorf("compute delete of %s returned 403 and its absence could not be confirmed (no successful same-cycle explicit delete): %w", id, err)
+	}
+	return err
+}
+
 // staticIPDeleteErrResult is the SHARED static-IP delete idempotency decision
 // (#312): a 404 is idempotent success; a 403 is AMBIGUOUS (#303 conflates
 // absent/forbidden) and is confirmed via a strict 200-only listing of the
@@ -404,9 +442,17 @@ func (s iamPATSeam) FindIDByName(ctx context.Context, name string) (string, erro
 // still-connected disk can refuse deletion. Each teardown is registered BEFORE
 // the create it undoes (F3), keyed by a deterministic identity, and finds its
 // resource via a STRICT listing when the create's activity did not resolve the
-// id. Q4/#303 note: a compute DELETE that answered 403 for an absent resource
-// would surface here as a teardown FAILURE (a false alarm, never an orphan — the
-// safe direction); only a definitive 404 is idempotent success.
+// id.
+//
+// 403-on-absent (#303): the OpenIaaS compute DELETE answers 403 (not 404) for an
+// ALREADY-ABSENT resource — observed live when the deferred net re-deletes what
+// the explicit deprovision already removed. The deferred delete is therefore
+// resolved by confirmComputeDeleteByPriorDelete: a definitive 404 is success; a
+// 403 is accepted as "already gone" ONLY when this cycle's explicit delete of
+// this exact id already succeeded (ExplicitlyDeleted — strict positive same-cycle
+// proof of absence), otherwise it FAILS CLOSED (a 403 with no such proof surfaces
+// as a teardown failure, never a masked orphan). A by-id Read re-check is NOT used
+// because the OpenIaaS Read conflates 403/404 → absent and so cannot prove absence.
 
 // vmSeam is the subset of the VM client a VM teardown needs.
 type vmSeam interface {
@@ -423,6 +469,10 @@ type vmTeardownRef struct {
 	MachineManagerID string
 	ID               string
 	Resolved         bool
+	// ExplicitlyDeleted is set by the cycle once its explicit delete of the
+	// RESOLVED id succeeded this cycle: strict positive proof the resource is gone,
+	// so the deferred re-delete's 403-on-absent (#303) is accepted, not surfaced.
+	ExplicitlyDeleted bool
 }
 
 // registerVMTeardown registers the VM teardown (the anchor; runs LAST under LIFO).
@@ -443,7 +493,13 @@ func registerVMTeardown(cl *Cleanup, seam vmSeam, ref *vmTeardownRef) {
 			id = found
 		}
 		_ = seam.PowerOffAndWait(tctx, id) // best-effort: a powered-on VM may refuse delete
-		return seam.DeleteAndWait(tctx, id)
+		// A 403 here is the OpenIaaS absent/forbidden conflation (#303) on a resource
+		// the explicit deprovision already removed; accept it as gone ONLY on the
+		// same-cycle explicit-delete proof, else fail closed. A 404 is idempotent
+		// success. The proof is valid only for the RESOLVED id; a find-by-name
+		// fallback (ref not resolved) carries no proof → priorDeleteOK is false there.
+		priorDeleteOK := ref.Resolved && ref.ExplicitlyDeleted && id == ref.ID
+		return confirmComputeDeleteByPriorDelete(seam.DeleteAndWait(tctx, id), priorDeleteOK, id)
 	})
 }
 
@@ -502,6 +558,8 @@ type diskTeardownRef struct {
 	VMID     string
 	ID       string
 	Resolved bool
+	// ExplicitlyDeleted: see vmTeardownRef — same-cycle proof the disk was deleted.
+	ExplicitlyDeleted bool
 }
 
 // registerVirtualDiskTeardown registers the user data-disk teardown: disconnect
@@ -529,7 +587,10 @@ func registerVirtualDiskTeardown(cl *Cleanup, seam diskSeam, ref *diskTeardownRe
 				return derr
 			}
 		}
-		return seam.DeleteAndWait(tctx, id)
+		// 403-on-absent (#303): accept only on the same-cycle explicit-delete proof
+		// for the RESOLVED id (a find-by-name fallback carries no proof → fail closed).
+		priorDeleteOK := ref.Resolved && ref.ExplicitlyDeleted && id == ref.ID
+		return confirmComputeDeleteByPriorDelete(seam.DeleteAndWait(tctx, id), priorDeleteOK, id)
 	})
 }
 
@@ -621,6 +682,8 @@ type adapterTeardownRef struct {
 	VMID     string
 	ID       string
 	Resolved bool
+	// ExplicitlyDeleted: see vmTeardownRef — same-cycle proof the adapter was deleted.
+	ExplicitlyDeleted bool
 }
 
 // registerNetworkAdapterTeardown registers the adapter teardown (a network leaf;
@@ -629,14 +692,17 @@ type adapterTeardownRef struct {
 func registerNetworkAdapterTeardown(cl *Cleanup, seam adapterSeam, ref *adapterTeardownRef) {
 	cl.Register(fmt.Sprintf("compute.openiaas.network_adapter %s", ref.VMID), func(tctx context.Context) error {
 		if ref.Resolved && ref.ID != "" {
-			return seam.DeleteAndWait(tctx, ref.ID)
+			// 403-on-absent (#303): accept only on the same-cycle explicit-delete proof.
+			return confirmComputeDeleteByPriorDelete(seam.DeleteAndWait(tctx, ref.ID), ref.ExplicitlyDeleted, ref.ID)
 		}
 		ids, err := seam.FindIDsByVM(tctx, ref.VMID)
 		if err != nil {
 			return err
 		}
 		for _, id := range ids {
-			if derr := seam.DeleteAndWait(tctx, id); derr != nil {
+			// Unresolved delete-all-on-VM: no per-id explicit-delete proof, so a 403
+			// here FAILS CLOSED (priorDeleteOK=false) rather than mask a possible orphan.
+			if derr := confirmComputeDeleteByPriorDelete(seam.DeleteAndWait(tctx, id), false, id); derr != nil {
 				return derr
 			}
 		}

--- a/cmd/ct-validate/cycle_compute_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle.go
@@ -129,6 +129,25 @@ func resolveActivityResultID(act *client.Activity) string {
 	return ""
 }
 
+// explicitDelete runs the breaker-gated explicit delete op `do` and records STRICT
+// same-cycle proof of absence into *deleted. *deleted is set true ONLY when the op
+// actually RAN and the delete succeeded (a 200, or a definitive 404 the OpenIaaS
+// delete treats as already-gone). On a breaker skip r.op never invokes the closure,
+// so *deleted stays false and the deferred teardown fails closed on a later
+// 403-on-absent (#303) instead of masking a possible orphan. NEVER infer success
+// from r.op's return value: it is nil on a breaker skip too (the op did not run) —
+// the proof MUST be set from inside the closure, which only runs when the breaker
+// allows it.
+func (cyc computeLifecycleCycle) explicitDelete(r *Run, deleted *bool, endpoint string, do func() error) {
+	_ = r.op(cyc, endpoint, func() error {
+		err := do()
+		if err == nil {
+			*deleted = true
+		}
+		return err
+	})
+}
+
 func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 	// Collision-free identity: a 128-bit run token + full (Iteration, Worker)
 	// integers (no byte() truncation). The find-by-name teardown fallback relies
@@ -289,8 +308,9 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	// --- PHASE 2: storage variation — attach a user data disk (optional) ---
 	srID := selectOpenIaaSDiskSR(srs, vmPoolID, vmHostID, clDiskSize)
 	var diskID string
+	var diskRef *diskTeardownRef // function-scoped so PHASE 4 can record the explicit-delete proof
 	if srID != "" {
-		diskRef := &diskTeardownRef{Name: name + "-data", VMID: vmID}
+		diskRef = &diskTeardownRef{Name: name + "-data", VMID: vmID}
 		registerVirtualDiskTeardown(r.Cleanup, computeVirtualDiskSeam{c}, diskRef)
 		_ = r.op(cyc, "compute.openiaas.virtual_disk.create", func() error {
 			activityID, err := oi.VirtualDisk().Create(ctx, &client.OpenIaaSVirtualDiskCreateRequest{
@@ -334,8 +354,9 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	// and this lean cycle keeps the VM halted — the network attachment at provision
 	// time is what we exercise (mirrors the VMware cycle).
 	var adapterID string
+	var adapterRef *adapterTeardownRef // function-scoped so PHASE 4 can record the explicit-delete proof
 	if networkID != "" {
-		adapterRef := &adapterTeardownRef{VMID: vmID}
+		adapterRef = &adapterTeardownRef{VMID: vmID}
 		registerNetworkAdapterTeardown(r.Cleanup, computeNetworkAdapterSeam{c}, adapterRef)
 		_ = r.op(cyc, "compute.openiaas.network_adapter.create", func() error {
 			activityID, err := oi.NetworkAdapter().Create(ctx, &client.CreateOpenIaasNetworkAdapterRequest{
@@ -365,7 +386,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	// not a false failure. Every op is breaker-gated, so once tripped these become
 	// recorded skips and the deferred TeardownAll still sweeps everything. ---
 	if adapterID != "" {
-		_ = r.op(cyc, "compute.openiaas.network_adapter.delete", func() error {
+		cyc.explicitDelete(r, &adapterRef.ExplicitlyDeleted, "compute.openiaas.network_adapter.delete", func() error {
 			activityID, err := oi.NetworkAdapter().Delete(ctx, adapterID)
 			if err != nil {
 				return idempotentDeleteErr(err)
@@ -387,7 +408,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 			_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
 			return werr
 		})
-		_ = r.op(cyc, "compute.openiaas.virtual_disk.delete", func() error {
+		cyc.explicitDelete(r, &diskRef.ExplicitlyDeleted, "compute.openiaas.virtual_disk.delete", func() error {
 			activityID, err := oi.VirtualDisk().Delete(ctx, diskID)
 			if err != nil {
 				return idempotentDeleteErr(err)
@@ -400,7 +421,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		r.skip(cyc, "compute.openiaas.virtual_disk.delete")
 	}
 
-	_ = r.op(cyc, "compute.openiaas.virtual_machine.delete", func() error {
+	cyc.explicitDelete(r, &vmRef.ExplicitlyDeleted, "compute.openiaas.virtual_machine.delete", func() error {
 		activityID, err := oi.VirtualMachine().Delete(ctx, vmID)
 		if err != nil {
 			return idempotentDeleteErr(err)

--- a/cmd/ct-validate/cycle_compute_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle_test.go
@@ -17,11 +17,12 @@ type fakeVMSeam struct {
 	log     *[]string
 	findID  string
 	findErr error
+	delErr  error // when non-nil, DeleteAndWait fails (e.g. an OpenIaaS 403-on-absent)
 }
 
 func (f fakeVMSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "vm.delete:"+id)
-	return nil
+	return f.delErr
 }
 func (f fakeVMSeam) PowerOffAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "vm.poweroff:"+id)
@@ -36,6 +37,7 @@ type fakeDiskSeam struct {
 	log         *[]string
 	connections []string
 	findID      string
+	delErr      error // when non-nil, DeleteAndWait fails (e.g. an OpenIaaS 403-on-absent)
 }
 
 func (f fakeDiskSeam) ReadConnections(_ context.Context, id string) ([]string, error) {
@@ -47,7 +49,7 @@ func (f fakeDiskSeam) DisconnectAndWait(_ context.Context, id, vmID string) erro
 }
 func (f fakeDiskSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "disk.delete:"+id)
-	return nil
+	return f.delErr
 }
 func (f fakeDiskSeam) FindIDByName(_ context.Context, name, vmID string) (string, error) {
 	*f.log = append(*f.log, "disk.find:"+name)
@@ -55,8 +57,9 @@ func (f fakeDiskSeam) FindIDByName(_ context.Context, name, vmID string) (string
 }
 
 type fakeAdapterSeam struct {
-	log *[]string
-	ids []string // FindIDsByVM returns these
+	log    *[]string
+	ids    []string // FindIDsByVM returns these
+	delErr error    // when non-nil, DeleteAndWait fails (e.g. an OpenIaaS 403-on-absent)
 }
 
 func (f fakeAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, error) {
@@ -65,7 +68,7 @@ func (f fakeAdapterSeam) FindIDsByVM(_ context.Context, vmID string) ([]string, 
 }
 func (f fakeAdapterSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "adapter.delete:"+id)
-	return nil
+	return f.delErr
 }
 
 func indexOf(log []string, prefix string) int {
@@ -447,5 +450,194 @@ func TestFlagsValidateRejectsRunawayLoad(t *testing.T) {
 	}
 	if _, err := parseFlags([]string{"-runs", "100000000"}, out); err == nil {
 		t.Fatal("-runs 100000000 must be rejected (runaway load)")
+	}
+}
+
+// --- Bug B: OpenIaaS deferred teardown 403-on-absent (#303) via same-cycle proof ---
+
+// TestConfirmComputeDeleteByPriorDelete pins the pure decision: nil/404 are
+// idempotent success; a 403 is accepted ONLY with same-cycle explicit-delete proof,
+// else it FAILS CLOSED; any other error surfaces. Mutations: accept a 403 without
+// proof → the "no proof" case wrongly passes → RED; reject a proven 403 → the
+// proven case wrongly fails → RED.
+func TestConfirmComputeDeleteByPriorDelete(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+	notFound := client.StatusError{Code: http.StatusNotFound}
+	serverErr := client.StatusError{Code: http.StatusInternalServerError}
+
+	if confirmComputeDeleteByPriorDelete(nil, false, "id-x") != nil {
+		t.Fatal("a nil delete error must be success")
+	}
+	if confirmComputeDeleteByPriorDelete(notFound, false, "id-x") != nil {
+		t.Fatal("a definitive 404 must be idempotent success even without prior-delete proof")
+	}
+	if err := confirmComputeDeleteByPriorDelete(forbidden, true, "id-x"); err != nil {
+		t.Fatalf("a 403 WITH same-cycle explicit-delete proof must be success (no false orphan), got %v", err)
+	}
+	if confirmComputeDeleteByPriorDelete(forbidden, false, "id-x") == nil {
+		t.Fatal("a 403 WITHOUT proof must FAIL CLOSED (a possible orphan, never masked)")
+	}
+	if confirmComputeDeleteByPriorDelete(serverErr, true, "id-x") == nil {
+		t.Fatal("a non-403/404 error must surface even with prior-delete proof")
+	}
+}
+
+// TestOpenIaaSVMTeardownConfirms403ByPriorDelete pins the wiring: the deferred VM
+// teardown re-deletes an already-gone VM (OpenIaaS answers 403, not 404). With the
+// same-cycle explicit-delete proof it is a clean success (no false orphan); without
+// it, it fails closed. Mutation: revert the wrap to idempotentDeleteErr (404-only)
+// → the proven 403 surfaces as a failure → RED.
+func TestOpenIaaSVMTeardownConfirms403ByPriorDelete(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+
+	// VM explicitly deleted this cycle: deferred delete 403s, proof present → success.
+	var log []string
+	cl := NewCleanup()
+	registerVMTeardown(cl, fakeVMSeam{log: &log, delErr: forbidden},
+		&vmTeardownRef{Name: "vm", ID: "vm-1", Resolved: true, ExplicitlyDeleted: true})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a 403 on a VM proven deleted this cycle must be confirmed absent (no false orphan), got failures %v", f)
+	}
+
+	// No proof (e.g. explicit delete skipped by the breaker): 403 fails closed.
+	var log2 []string
+	cl2 := NewCleanup()
+	registerVMTeardown(cl2, fakeVMSeam{log: &log2, delErr: forbidden},
+		&vmTeardownRef{Name: "vm", ID: "vm-1", Resolved: true, ExplicitlyDeleted: false})
+	if f := cl2.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("a 403 with NO same-cycle delete proof must fail closed (possible orphan), got failures %v", f)
+	}
+
+	// A definitive 404 is idempotent success regardless of proof.
+	var log3 []string
+	cl3 := NewCleanup()
+	registerVMTeardown(cl3, fakeVMSeam{log: &log3, delErr: client.StatusError{Code: http.StatusNotFound}},
+		&vmTeardownRef{Name: "vm", ID: "vm-1", Resolved: true, ExplicitlyDeleted: false})
+	if f := cl3.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a definitive 404 must be idempotent success, got failures %v", f)
+	}
+
+	// UNRESOLVED (create id never came back): the teardown finds the VM by name and
+	// re-deletes it; a 403 there carries NO same-cycle proof → must fail closed (a
+	// created-but-unresolved, still-present VM must never be masked). Mutation: force
+	// priorDeleteOK=true on this path → the 403 is masked → RED.
+	var log4 []string
+	cl4 := NewCleanup()
+	registerVMTeardown(cl4, fakeVMSeam{log: &log4, findID: "found-vm-9", delErr: forbidden},
+		&vmTeardownRef{Name: "vm", MachineManagerID: "mm-1"}) // Resolved=false
+	if f := cl4.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("an unresolved find-by-name VM 403 carries no proof and must fail closed, got failures %v", f)
+	}
+}
+
+// TestOpenIaaSDiskTeardownConfirms403ByPriorDelete: same doctrine for the disk leaf.
+func TestOpenIaaSDiskTeardownConfirms403ByPriorDelete(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+
+	var log []string
+	cl := NewCleanup()
+	registerVirtualDiskTeardown(cl, fakeDiskSeam{log: &log, delErr: forbidden},
+		&diskTeardownRef{Name: "d-data", VMID: "vm-1", ID: "disk-1", Resolved: true, ExplicitlyDeleted: true})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a 403 on a disk proven deleted this cycle must be confirmed absent, got failures %v", f)
+	}
+
+	var log2 []string
+	cl2 := NewCleanup()
+	registerVirtualDiskTeardown(cl2, fakeDiskSeam{log: &log2, delErr: forbidden},
+		&diskTeardownRef{Name: "d-data", VMID: "vm-1", ID: "disk-1", Resolved: true, ExplicitlyDeleted: false})
+	if f := cl2.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("a disk 403 with NO same-cycle delete proof must fail closed, got failures %v", f)
+	}
+
+	// UNRESOLVED: the disk is found by name (created-but-unresolved), then re-deleted;
+	// a 403 there carries no proof → must fail closed. Mutation: force priorDeleteOK=true
+	// on the find-by-name path → the 403 is masked → RED.
+	var log3 []string
+	cl3 := NewCleanup()
+	registerVirtualDiskTeardown(cl3, fakeDiskSeam{log: &log3, findID: "disk-9", delErr: forbidden},
+		&diskTeardownRef{Name: "d-data", VMID: "vm-1"}) // Resolved=false
+	if f := cl3.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("an unresolved find-by-name disk 403 carries no proof and must fail closed, got failures %v", f)
+	}
+}
+
+// TestOpenIaaSAdapterTeardownConfirms403ByPriorDelete: the adapter leaf, both the
+// resolved (proof-bearing) path and the unresolved delete-all-on-VM path (which
+// carries NO per-id proof → a 403 there must fail closed).
+func TestOpenIaaSAdapterTeardownConfirms403ByPriorDelete(t *testing.T) {
+	forbidden := client.StatusError{Code: http.StatusForbidden, Body: "Forbidden."}
+
+	// Resolved + proof → 403 confirmed absent.
+	var log []string
+	cl := NewCleanup()
+	registerNetworkAdapterTeardown(cl, fakeAdapterSeam{log: &log, delErr: forbidden},
+		&adapterTeardownRef{VMID: "vm-1", ID: "ad-1", Resolved: true, ExplicitlyDeleted: true})
+	if f := cl.TeardownAll(context.Background()); len(f) != 0 {
+		t.Fatalf("a 403 on an adapter proven deleted this cycle must be confirmed absent, got failures %v", f)
+	}
+
+	// Resolved + no proof → fail closed.
+	var log2 []string
+	cl2 := NewCleanup()
+	registerNetworkAdapterTeardown(cl2, fakeAdapterSeam{log: &log2, delErr: forbidden},
+		&adapterTeardownRef{VMID: "vm-1", ID: "ad-1", Resolved: true, ExplicitlyDeleted: false})
+	if f := cl2.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("an adapter 403 with NO same-cycle delete proof must fail closed, got failures %v", f)
+	}
+
+	// Unresolved delete-all-on-VM: no per-id proof → a 403 must fail closed even if
+	// the ref were (wrongly) marked. Mutation: pass ref.ExplicitlyDeleted instead of
+	// false in the delete-all branch → this 403 would be masked → RED.
+	var log3 []string
+	cl3 := NewCleanup()
+	registerNetworkAdapterTeardown(cl3, fakeAdapterSeam{log: &log3, ids: []string{"ad-9"}, delErr: forbidden},
+		&adapterTeardownRef{VMID: "vm-1", ExplicitlyDeleted: true}) // unresolved (Resolved=false)
+	if f := cl3.TeardownAll(context.Background()); len(f) != 1 {
+		t.Fatalf("an unresolved delete-all 403 must fail closed (no per-id proof), got failures %v", f)
+	}
+}
+
+// TestExplicitDeleteMarksProofOnlyWhenClosureRuns is the blocker-#2 guard: the
+// same-cycle proof must be set from INSIDE the breaker-gated closure, never from
+// r.op's return value (which is nil on a breaker SKIP too). A skipped explicit
+// delete must leave the proof false, so a later 403-on-absent fails closed instead
+// of masking a still-present forbidden orphan. Mutation: set the flag with
+// `r.op(...) == nil` → case (a) would mark it true on a skip → RED.
+func TestExplicitDeleteMarksProofOnlyWhenClosureRuns(t *testing.T) {
+	cyc := computeLifecycleCycle{}
+
+	// (a) breaker tripped → op skipped → closure NOT run → proof stays false.
+	b := NewBreaker(1000, 0.99, 1000)
+	b.Trip("force-skip")
+	r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+	deleted, ran := false, false
+	cyc.explicitDelete(r, &deleted, "compute.openiaas.virtual_machine.delete", func() error {
+		ran = true
+		return nil
+	})
+	if ran {
+		t.Fatal("a tripped breaker must skip the op — the closure must not run")
+	}
+	if deleted {
+		t.Fatal("a skipped (never-run) explicit delete must NOT set the same-cycle proof (else a later 403 masks an orphan)")
+	}
+
+	// (b) breaker allows + delete succeeds → proof set.
+	r2 := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	deleted2 := false
+	cyc.explicitDelete(r2, &deleted2, "compute.openiaas.virtual_machine.delete", func() error { return nil })
+	if !deleted2 {
+		t.Fatal("a ran-and-succeeded explicit delete must set the same-cycle proof")
+	}
+
+	// (c) breaker allows + delete fails → proof NOT set.
+	r3 := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	deleted3 := false
+	cyc.explicitDelete(r3, &deleted3, "compute.openiaas.virtual_machine.delete", func() error {
+		return errors.New("delete boom")
+	})
+	if deleted3 {
+		t.Fatal("a failed explicit delete must NOT set the same-cycle proof")
 	}
 }


### PR DESCRIPTION
Refs #316

## Problem (observed live)

A full live OpenIaaS `compute_lifecycle` write cycle ran cleanly end-to-end — the explicit deprovision deleted the network adapter, the data disk and the VM (all OK) — yet the report ended with three false `TEARDOWN FAILURES (possible orphans)`:

```
compute.openiaas.network_adapter <id> (after 1 attempt(s)): Unexpected response code: 403 (Forbidden.)
compute.openiaas.virtual_disk    <name>-data ...: 403 (Forbidden.)
compute.openiaas.virtual_machine <name> ...: 403 (Forbidden.)
```

There were **no real orphans**. The deferred teardown safety net re-deletes what the explicit phase already removed, and the OpenIaaS compute API answers **403 for an already-absent resource** (the absent/forbidden conflation, #303), which the 404-only `idempotentDeleteErr` surfaced — producing a non-zero exit on a healthy run.

## Fix

A deferred compute delete `403` is resolved by `confirmComputeDeleteByPriorDelete(err, priorDeleteOK, id)`:

- a definitive `404` → idempotent success;
- a `403` accepted as already-gone **only** on strict positive same-cycle evidence — this cycle's explicit delete of **this exact id** already succeeded (`ExplicitlyDeleted` on the teardown ref);
- a `403` **without** that proof **fails closed** (surfaced as a teardown failure) — never masking a possible orphan;
- any other error (incl. an activity-completion failure, which is not a `StatusError`) is surfaced unchanged.

A by-id `Read` re-check (the VMware #330 pattern) is **deliberately not used**: the OpenIaaS `Read` maps both `403` and `404` to absent (`requireNotFoundOrOK(resp, 403)`), so it cannot prove absence — it would mask a present-but-forbidden orphan, exactly the access-denied→absent inference the never-orphan doctrine forbids.

The proof is recorded from **inside the breaker-gated closure** (`explicitDelete`), never from `r.op`'s return value (which is `nil` on a breaker skip too, where the delete never ran).

## Scope

- Touches only the OpenIaaS deferred teardown decision. The explicit deprovision keeps its 404-only behaviour (a `403` there is a genuine signal).
- The disk **disconnect** step is intentionally left unchanged — its live failure is a separate bug handled in a follow-up PR.

## Tests (mutation-proven)

`go build`, `gofmt -l` (clean), `go vet`, `go test -race ./cmd/ct-validate/...` all green. New/extended tests cover the resolved / unresolved-find-by-name / no-proof / `404` paths for VM, disk and adapter, plus the breaker-skip marking guard. Mutations verified RED:

- revert a teardown wrap to 404-only → the proven-`403` test fails;
- mark the proof via `r.op(...) == nil` → the breaker-skip test fails;
- force `priorDeleteOK := true` → the unresolved-`403` tests fail.

## Review

Plan reviewed adversarially (two rounds, both blockers resolved); a multi-lens pre-commit review found no blockers; the committed diff passed an independent adversarial diff review (GO).