### PR TITLE
fix(#316): OpenIaaS lifecycle — drop the disk disconnect (delete works attached)

### DIFF
--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -438,11 +438,13 @@ func (s iamPATSeam) FindIDByName(ctx context.Context, name string) (string, erro
 //
 // Teardown ordering is leaves-first (LIFO over registration order): the network
 // adapter and the user data disk are removed BEFORE the VM anchor, because a VM
-// delete does NOT cascade a user-created disk (it would orphan storage) and a
-// still-connected disk can refuse deletion. Each teardown is registered BEFORE
-// the create it undoes (F3), keyed by a deterministic identity, and finds its
-// resource via a STRICT listing when the create's activity did not resolve the
-// id.
+// delete does NOT cascade a user-created disk (it would orphan storage). The disk
+// is deleted DIRECTLY while still attached — live evidence shows the attached data
+// disk delete succeeds, and an explicit disconnect requires a RUNNING VM (this lean
+// cycle leaves the VM halted), so a pre-delete disconnect would only fail and BLOCK
+// the delete that otherwise works. Each teardown is registered BEFORE the create it
+// undoes (F3), keyed by a deterministic identity, and finds its resource via a
+// STRICT listing when the create's activity did not resolve the id.
 //
 // 403-on-absent (#303): the OpenIaaS compute DELETE answers 403 (not 404) for an
 // ALREADY-ABSENT resource — observed live when the deferred net re-deletes what
@@ -545,10 +547,11 @@ func (s computeVMSeam) FindIDByName(ctx context.Context, name, machineManagerID 
 	return found, nil
 }
 
-// diskSeam is the subset of the virtual-disk client a disk teardown needs.
+// diskSeam is the subset of the virtual-disk client a disk teardown needs. There
+// is intentionally no Disconnect: the data disk is deleted directly while attached
+// (see registerVirtualDiskTeardown). Keeping the method off the interface makes
+// re-introducing a pre-delete disconnect a compile error.
 type diskSeam interface {
-	ReadConnections(ctx context.Context, id string) ([]string, error) // connected VM ids
-	DisconnectAndWait(ctx context.Context, id, vmID string) error
 	DeleteAndWait(ctx context.Context, id string) error
 	FindIDByName(ctx context.Context, name, vmID string) (string, error)
 }
@@ -562,9 +565,13 @@ type diskTeardownRef struct {
 	ExplicitlyDeleted bool
 }
 
-// registerVirtualDiskTeardown registers the user data-disk teardown: disconnect
-// from EVERY connected VM (a VM delete never cascades a user disk) THEN delete.
-// Registered before the disk create; runs before the VM teardown (LIFO).
+// registerVirtualDiskTeardown registers the user data-disk teardown: delete the
+// disk (a VM delete never cascades a user disk, so it must be removed explicitly).
+// The disk is deleted DIRECTLY while attached — no pre-delete disconnect: the
+// attached-disk delete succeeds (live evidence), and a disconnect requires a
+// running VM, so a pre-delete disconnect on this lean halted-VM cycle would only
+// fail and block the delete that otherwise works. Registered before the disk
+// create; runs before the VM teardown (LIFO).
 func registerVirtualDiskTeardown(cl *Cleanup, seam diskSeam, ref *diskTeardownRef) {
 	cl.Register(fmt.Sprintf("compute.openiaas.virtual_disk %s", ref.Name), func(tctx context.Context) error {
 		id := ref.ID
@@ -578,15 +585,6 @@ func registerVirtualDiskTeardown(cl *Cleanup, seam diskSeam, ref *diskTeardownRe
 			}
 			id = found
 		}
-		vmIDs, err := seam.ReadConnections(tctx, id)
-		if err != nil {
-			return err
-		}
-		for _, vmID := range vmIDs {
-			if derr := seam.DisconnectAndWait(tctx, id, vmID); derr != nil {
-				return derr
-			}
-		}
 		// 403-on-absent (#303): accept only on the same-cycle explicit-delete proof
 		// for the RESOLVED id (a find-by-name fallback carries no proof → fail closed).
 		priorDeleteOK := ref.Resolved && ref.ExplicitlyDeleted && id == ref.ID
@@ -595,33 +593,6 @@ func registerVirtualDiskTeardown(cl *Cleanup, seam diskSeam, ref *diskTeardownRe
 }
 
 type computeVirtualDiskSeam struct{ c *client.Client }
-
-func (s computeVirtualDiskSeam) ReadConnections(ctx context.Context, id string) ([]string, error) {
-	disk, err := s.c.Compute().OpenIaaS().VirtualDisk().Read(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if disk == nil { // 403/absent mapped to nil → nothing connected to disconnect
-		return nil, nil
-	}
-	var vmIDs []string
-	for _, vm := range disk.VirtualMachines {
-		if vm.Connected && vm.ID != "" {
-			vmIDs = append(vmIDs, vm.ID)
-		}
-	}
-	return vmIDs, nil
-}
-
-func (s computeVirtualDiskSeam) DisconnectAndWait(ctx context.Context, id, vmID string) error {
-	activityID, err := s.c.Compute().OpenIaaS().VirtualDisk().Disconnect(ctx, id,
-		&client.OpenIaaSVirtualDiskConnectionRequest{VirtualMachineID: vmID})
-	if err != nil {
-		return idempotentDeleteErr(err) // already disconnected/gone → ok
-	}
-	_, werr := s.c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
-	return werr
-}
 
 func (s computeVirtualDiskSeam) DeleteAndWait(ctx context.Context, id string) error {
 	activityID, err := s.c.Compute().OpenIaaS().VirtualDisk().Delete(ctx, id)

--- a/cmd/ct-validate/cycle_compute_lifecycle.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle.go
@@ -194,7 +194,6 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		"compute.openiaas.network_adapter.create",
 		"compute.openiaas.virtual_machine.read",
 		"compute.openiaas.network_adapter.delete",
-		"compute.openiaas.virtual_disk.disconnect",
 		"compute.openiaas.virtual_disk.delete",
 		"compute.openiaas.virtual_machine.delete",
 	}
@@ -281,7 +280,7 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 		for _, ep := range []string{
 			"compute.openiaas.virtual_disk.create", "compute.openiaas.network_adapter.create",
 			"compute.openiaas.virtual_machine.read",
-			"compute.openiaas.network_adapter.delete", "compute.openiaas.virtual_disk.disconnect",
+			"compute.openiaas.network_adapter.delete",
 			"compute.openiaas.virtual_disk.delete", "compute.openiaas.virtual_machine.delete",
 		} {
 			r.skip(cyc, ep)
@@ -399,15 +398,10 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 	}
 
 	if diskID != "" {
-		_ = r.op(cyc, "compute.openiaas.virtual_disk.disconnect", func() error {
-			activityID, err := oi.VirtualDisk().Disconnect(ctx, diskID,
-				&client.OpenIaaSVirtualDiskConnectionRequest{VirtualMachineID: vmID})
-			if err != nil {
-				return idempotentDeleteErr(err)
-			}
-			_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
-			return werr
-		})
+		// No explicit disconnect: deleting the attached data disk works directly
+		// (live evidence), and a disconnect requires a RUNNING VM ("VM state is
+		// halted but should be running") which this lean halted-VM cycle never
+		// satisfies — mirrors the dropped Connect (#333).
 		cyc.explicitDelete(r, &diskRef.ExplicitlyDeleted, "compute.openiaas.virtual_disk.delete", func() error {
 			activityID, err := oi.VirtualDisk().Delete(ctx, diskID)
 			if err != nil {
@@ -417,7 +411,6 @@ func (cyc computeLifecycleCycle) Run(ctx context.Context, c *client.Client, r *R
 			return werr
 		})
 	} else {
-		r.skip(cyc, "compute.openiaas.virtual_disk.disconnect")
 		r.skip(cyc, "compute.openiaas.virtual_disk.delete")
 	}
 

--- a/cmd/ct-validate/cycle_compute_lifecycle_test.go
+++ b/cmd/ct-validate/cycle_compute_lifecycle_test.go
@@ -34,19 +34,11 @@ func (f fakeVMSeam) FindIDByName(_ context.Context, name, mmID string) (string, 
 }
 
 type fakeDiskSeam struct {
-	log         *[]string
-	connections []string
-	findID      string
-	delErr      error // when non-nil, DeleteAndWait fails (e.g. an OpenIaaS 403-on-absent)
+	log    *[]string
+	findID string
+	delErr error // when non-nil, DeleteAndWait fails (e.g. an OpenIaaS 403-on-absent)
 }
 
-func (f fakeDiskSeam) ReadConnections(_ context.Context, id string) ([]string, error) {
-	return f.connections, nil
-}
-func (f fakeDiskSeam) DisconnectAndWait(_ context.Context, id, vmID string) error {
-	*f.log = append(*f.log, "disk.disconnect:"+id+"/"+vmID)
-	return nil
-}
 func (f fakeDiskSeam) DeleteAndWait(_ context.Context, id string) error {
 	*f.log = append(*f.log, "disk.delete:"+id)
 	return f.delErr
@@ -128,21 +120,22 @@ func TestRegisterVMTeardownNotFoundIsNoop(t *testing.T) {
 	}
 }
 
-// TestRegisterVirtualDiskTeardownDisconnectsEveryConnectionThenDeletes pins the
-// disk doctrine: a user disk is disconnected from EVERY connected VM BEFORE
-// delete (a VM delete never cascades it). Mutation: drop the disconnect loop →
-// the "disconnect before delete" assertion goes RED.
-func TestRegisterVirtualDiskTeardownDisconnectsEveryConnectionThenDeletes(t *testing.T) {
+// TestRegisterVirtualDiskTeardownDeletesDirectlyNoDisconnect pins the Bug A
+// doctrine: the data-disk teardown deletes the disk DIRECTLY while attached, with
+// NO pre-delete disconnect (a disconnect needs a running VM; the lean cycle leaves
+// it halted, and a disconnect there would only block the delete that works). The
+// fakeDiskSeam no longer implements ReadConnections/DisconnectAndWait, so
+// re-introducing a disconnect step would not compile — a structural guard. The
+// runtime assertion pins that only a delete is performed.
+func TestRegisterVirtualDiskTeardownDeletesDirectlyNoDisconnect(t *testing.T) {
 	var log []string
 	cl := NewCleanup()
-	registerVirtualDiskTeardown(cl, fakeDiskSeam{log: &log, connections: []string{"vm-1", "vm-2"}},
+	registerVirtualDiskTeardown(cl, fakeDiskSeam{log: &log},
 		&diskTeardownRef{Name: "d-data", VMID: "vm-1", ID: "disk-7", Resolved: true})
 	cl.TeardownAll(context.Background())
-	d1 := indexOf(log, "disk.disconnect:disk-7/vm-1")
-	d2 := indexOf(log, "disk.disconnect:disk-7/vm-2")
-	del := indexOf(log, "disk.delete:disk-7")
-	if d1 == -1 || d2 == -1 || del == -1 || d1 > del || d2 > del {
-		t.Fatalf("disk must disconnect EVERY connection before delete; log=%v", log)
+	// Exactly one op — a direct delete by id, nothing else (no disconnect, no read).
+	if len(log) != 1 || log[0] != "disk.delete:disk-7" {
+		t.Fatalf("the disk teardown must perform exactly one op (a direct delete, no disconnect); log=%v", log)
 	}
 }
 


### PR DESCRIPTION
Refs #316

> **Stacked on #334** (base `s9/ct-validate-openiaas-teardown-403`). GitHub will retarget this PR to `rc/v1.8.0` once #334 merges. Review the per-commit diff (this PR adds one commit on top of Bug B).

## Problem (observed live)

In the live OpenIaaS `compute_lifecycle` run, `compute.openiaas.virtual_disk.disconnect` **failed** (the XOA "Disconnect a virtual disk" activity errored) while the very next `compute.openiaas.virtual_disk.delete` **succeeded** on the still-attached disk.

Root cause (mirror of merged #333, which dropped `Connect`): a disconnect requires a **running** VM (`VM state is halted but should be running`), and this lean lifecycle deliberately leaves the VM **halted**. So the disconnect is superfluous — and worse, it can **block** a delete that otherwise works.

## Fix

Remove the disk disconnect from the harness entirely:

- **Cycle**: drop the explicit `virtual_disk.disconnect` op, its `writeSteps` entry, and its two `r.skip(...)` emissions. The disk block now just deletes.
- **Deferred teardown**: `registerVirtualDiskTeardown` deletes the attached disk **directly** (no `ReadConnections` + `DisconnectAndWait` loop), keeping Bug B's same-cycle `403`-on-absent proof guard (`confirmComputeDeleteByPriorDelete`). `ReadConnections`/`DisconnectAndWait` are removed from the `diskSeam` interface and the seam impl.

For the never-orphan safety net this is also **safer**: a pre-delete disconnect on a halted VM would fail and **block** the delete that works — removing it removes a failure point on the cleanup path. A delete refusal still **surfaces** (never masked): the explicit path is 404-only idempotent, the deferred path accepts a `403` only on same-cycle proof and otherwise fails closed.

## Scope

- The client `VirtualDisk().Disconnect`/`Connect` are **untouched** (used by the provider).
- Mirrors #333 (dropped `Connect`) for the symmetric reason.

## Tests

`go build`, `gofmt -l` (clean), `go vet`, `go test -race ./cmd/ct-validate/...` all green. The disconnect-ordering test is replaced by `TestRegisterVirtualDiskTeardownDeletesDirectlyNoDisconnect` (asserts exactly one op — a direct delete). The `fakeDiskSeam` no longer implements the disconnect methods, so re-introducing a pre-delete disconnect **fails to compile** — a structural guard (compile-time mutation verified).

## Review

PLAN-reviewed adversarially (GO); a multi-lens pre-commit review found no blockers; the committed diff passed an independent adversarial diff review (GO).