### PR TITLE
tooling(#315): scripts README, ct-soak probe, and machine_managers read-only cycle

### DIFF
--- a/cmd/ct-validate/cycle_machine_managers.go
+++ b/cmd/ct-validate/cycle_machine_managers.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// machineManagersCycle is a READ-ONLY probe of exactly the first two steps of the
+// compute_lifecycle cycle: the local run-identity token, then the OpenIaaS
+// machine_managers list. The list call is the SAME c.Compute().OpenIaaS().
+// MachineManager().List(ctx) the vm/readonly cycles make — byte-identical through
+// the real provider client (not curl). It exists to characterize, in isolation and
+// under -runs/-concurrency, the intermittent 5xx on machine_managers.list (#315):
+//
+//	1  ok    compute.openiaas.run_identity            0 ms
+//	2  FAIL  compute.openiaas.machine_managers.list   http_5xx
+//
+// No writes, no substrate discovery beyond this one list, no teardown.
+type machineManagersCycle struct{}
+
+func (machineManagersCycle) Name() string { return "machine_managers" }
+func (machineManagersCycle) Kind() Kind   { return KindRead }
+
+func (machineManagersCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	// Step 1: run identity — a local 128-bit token, never an API call (mirrors the
+	// compute_lifecycle cycle's first step so the output reads identically).
+	_ = r.op(machineManagersCycle{}, "compute.openiaas.run_identity", func() error {
+		_, err := newRunToken()
+		return err
+	})
+	// Step 2: the exact machine_managers list call. Its error (incl. an http_5xx) is
+	// recorded and categorized by r.op exactly as in the vm cycle.
+	_ = r.op(machineManagersCycle{}, "compute.openiaas.machine_managers.list", func() error {
+		_, err := c.Compute().OpenIaaS().MachineManager().List(ctx)
+		return err
+	})
+	return nil
+}

--- a/cmd/ct-validate/cycle_machine_managers_test.go
+++ b/cmd/ct-validate/cycle_machine_managers_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestMachineManagersCycleProbesIdentityThenList pins that the cycle performs
+// EXACTLY two recorded ops, in order — the local run-identity then the OpenIaaS
+// machine_managers list — and nothing else. Mutation: drop either op → the count
+// or order assertion goes RED.
+func TestMachineManagersCycleProbesIdentityThenList(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// machine_managers list = GET /api/compute/v1/open_iaas
+		if r.Method != http.MethodGet {
+			t.Errorf("machine_managers probe must be read-only, got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"mm-1"}]`))
+	})
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	if err := (machineManagersCycle{}).Run(context.Background(), c, r); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	ops := r.Recorder.Ops()
+	if len(ops) != 2 ||
+		ops[0].Endpoint != "compute.openiaas.run_identity" ||
+		ops[1].Endpoint != "compute.openiaas.machine_managers.list" {
+		t.Fatalf("expected exactly [run_identity, machine_managers.list], got %+v", ops)
+	}
+	for _, o := range ops {
+		if !o.OK || o.Skipped {
+			t.Fatalf("op %s must be OK on a 200, got %+v", o.Endpoint, o)
+		}
+	}
+	if r.Cleanup.Pending() != 0 {
+		t.Fatalf("a read-only probe must register no teardown, got %d", r.Cleanup.Pending())
+	}
+}
+
+// TestMachineManagersCycleSurfaces5xx pins that an http 5xx on the list is recorded
+// as a FAILURE (the #315 signal the probe exists to catch), not swallowed. Mutation:
+// ignore the List error → the op would read OK → RED.
+func TestMachineManagersCycleSurfaces5xx(t *testing.T) {
+	c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // the transient ComputeManager flake
+	})
+	r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+	_ = (machineManagersCycle{}).Run(context.Background(), c, r)
+
+	var found bool
+	for _, o := range r.Recorder.Ops() {
+		if o.Endpoint == "compute.openiaas.machine_managers.list" {
+			found = true
+			if o.OK || o.Skipped {
+				t.Fatalf("machine_managers.list must FAIL on a 5xx, got %+v", o)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("machine_managers.list op must be recorded")
+	}
+}
+
+// TestRegistryHasMachineManagersReadOnly pins that the cycle is registered and is a
+// read-only cycle selectable WITHOUT -write (unlike the gated write lifecycle).
+func TestRegistryHasMachineManagersReadOnly(t *testing.T) {
+	reg := buildRegistry()
+	sel, _, err := reg.Select("machine_managers", false)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if len(sel) != 1 || sel[0].Name() != "machine_managers" || sel[0].Kind() != KindRead {
+		t.Fatalf("machine_managers must be a read-only selectable cycle, got %v", sel)
+	}
+}

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -36,6 +36,7 @@ func buildRegistry() *Registry {
 		readonlyCycle{},
 		backupCycle{},
 		computeOpenIaaSCycle{},
+		machineManagersCycle{},
 		computeLifecycleCycle{},
 		computeVMwareLifecycleCycle{},
 		vpcCycle{},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,9 +39,31 @@ scripts/ct-test.sh tf   <scenario>                   # play the same scenario vi
   scripts/ct-test.sh --tenant vmware api vm-vmware -runs 20 -concurrency 4
   ```
 
-Scenarios today: `readonly` (safe, read-only), `vpc`, `storage`, `vm` (OpenIaaS
-lifecycle), `vm-vmware` (VMware lifecycle). Write scenarios create then destroy
-their resources, with a deferred never-orphan teardown net.
+Scenarios today: `readonly` (safe, read-only), `machine-managers` (read-only: just
+`run_identity` + `machine_managers.list`, repeatable — see below), `vpc`, `storage`,
+`vm` (OpenIaaS lifecycle), `vm-vmware` (VMware lifecycle). Write scenarios create then
+destroy their resources, with a deferred never-orphan teardown net.
+
+### `machine-managers` — isolated, client-identical probe of one flaky call (#315)
+
+A read-only scenario that performs EXACTLY the first two steps of the `vm` cycle — the
+local `run_identity` token, then `compute.openiaas.machine_managers.list` (the same
+`MachineManager().List(ctx)` call) — and nothing else. It is the faithful way to
+reproduce the intermittent `machine_managers` 5xx (#315) in isolation, through the real
+provider client (unlike a `curl` probe, it is byte-identical to what the `vm` cycle
+sends). Drive it with load knobs:
+
+```bash
+# repeat the exact call 100× in series (default breaker stops on distress)
+scripts/ct-test.sh api machine-managers -runs 100 -concurrency 1
+
+# characterize the full 5xx rate over all 100 calls (relax the breaker), or chase the burst correlation
+scripts/ct-test.sh api machine-managers -runs 100 -concurrency 1 \
+  -abort-failure-rate 1.0 -abort-consecutive 1000 -abort-window 1000
+scripts/ct-test.sh api machine-managers -runs 100 -concurrency 8
+```
+
+The per-endpoint report then gives the OK% / 5xx rate of `machine_managers.list`.
 
 ## `ct-soak.sh` — characterize intermittent endpoint flakiness
 
@@ -80,16 +102,16 @@ flakiness (e.g. ComputeManager 5xx bursts) and to size a client retry/backoff po
 **Fidelity to the real client:** the probe sends the **same bytes** as the
 `ct-validate` Go client — an empty `User-Agent` and no `Accept` header (curl would
 otherwise inject `curl/x.y` + `Accept: */*`, which a gateway can route differently).
-For a 100% client-identical soak that exercises `machine_managers.list` through the
-real Go client, drive the read-only cycle with load knobs instead:
+Even so, curl can never be 100% identical (HTTP version, TLS, header order, keep-alive).
+**For a byte-identical soak, prefer the `machine-managers` scenario** (above), which
+drives `machine_managers.list` through the real Go client:
 
 ```bash
-CT_ENV_OPENIAAS=/path/.env.recette-openiaas scripts/ct-test.sh api readonly -runs 100 -concurrency 8
+CT_ENV_OPENIAAS=/path/.env.recette-openiaas scripts/ct-test.sh api machine-managers -runs 100 -concurrency 8
 ```
 
-The per-endpoint table then reports the 5xx rate of `compute.openiaas.machine_managers.list`
-specifically. Use `ct-soak.sh` for a targeted single-endpoint probe; `ct-test.sh api readonly`
-for a multi-endpoint soak through the exact provider client.
+Use `ct-soak.sh` as a quick standalone curl probe; use `ct-test.sh api machine-managers`
+(or `api readonly` for a multi-endpoint sweep) when you need the exact provider client.
 
 ## `coverage_ratchet.sh` — CI coverage gate
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,9 +72,24 @@ API_PATH=/api/compute/v1/open_iaas/storage_repositories scripts/ct-soak.sh
 | `PER_STEP` | `25` | calls per step (total = `PER_STEP` × #steps) |
 | `MAX_TIME` | `30` | per-call timeout (s) |
 | `ABORT_5XX_RATE` | `0.5` | stop the ladder if a step's 5xx rate exceeds this |
+| `USER_AGENT` | *(empty)* | `User-Agent` header (empty = byte-for-byte like the Go client) |
 
 Exit code is non-zero if the breaker tripped. Useful to characterize platform
 flakiness (e.g. ComputeManager 5xx bursts) and to size a client retry/backoff policy.
+
+**Fidelity to the real client:** the probe sends the **same bytes** as the
+`ct-validate` Go client — an empty `User-Agent` and no `Accept` header (curl would
+otherwise inject `curl/x.y` + `Accept: */*`, which a gateway can route differently).
+For a 100% client-identical soak that exercises `machine_managers.list` through the
+real Go client, drive the read-only cycle with load knobs instead:
+
+```bash
+CT_ENV_OPENIAAS=/path/.env.recette-openiaas scripts/ct-test.sh api readonly -runs 100 -concurrency 8
+```
+
+The per-endpoint table then reports the 5xx rate of `compute.openiaas.machine_managers.list`
+specifically. Use `ct-soak.sh` for a targeted single-endpoint probe; `ct-test.sh api readonly`
+for a multi-endpoint soak through the exact provider client.
 
 ## `coverage_ratchet.sh` — CI coverage gate
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,93 @@
+# `scripts/`
+
+Helper scripts for developing, testing and validating the Cloud Temple Terraform
+provider. None of them are required to *use* the published provider — they support
+contributors and CI.
+
+| Script | Purpose | Needs live API? |
+| ------ | ------- | --------------- |
+| [`ct-test.sh`](ct-test.sh) | Run a business scenario against the live API (via the `ct-validate` runner) **or** via Terraform. | Yes |
+| [`ct-soak.sh`](ct-soak.sh) | Bounded, breaker-guarded soak probe of one read-only endpoint, to characterize intermittent platform flakiness. | Yes (read-only) |
+| [`coverage_ratchet.sh`](coverage_ratchet.sh) | CI coverage gate for the pure (platform-independent) packages. | No |
+| [`coverage_floor.txt`](coverage_floor.txt) | Data file: the per-package coverage floors enforced by the ratchet. | — |
+
+---
+
+## `ct-test.sh` — run a scenario against the API or via Terraform
+
+Loads a tenant's credentials, targets the API host (`shiva.cloud-temple.com`), plays
+a business scenario, prints PASS/FAIL, and cleans up after itself.
+
+```bash
+scripts/ct-test.sh list                              # list scenarios and which modes are ready
+scripts/ct-test.sh api  <scenario> [flags...]        # play the scenario directly against the API
+scripts/ct-test.sh tf   <scenario>                   # play the same scenario via Terraform (apply + destroy)
+```
+
+- **Tenant selection** (which credentials, hence which platform you exercise):
+  `--tenant openiaas` (default, uses `$CT_ENV_OPENIAAS`) or `--tenant vmware`
+  (uses `$CT_ENV_VMWARE`); or set `CT_TENANT`, or `CT_TEST_ENV=<file>` to point at a
+  creds file directly. The API host is the same for every tenant — the tenant is
+  determined by the credentials, not the URL.
+- **Credentials file** is `KEY=value` with `CLOUDTEMPLE_CLIENT_ID` /
+  `CLOUDTEMPLE_SECRET_ID`.
+- **Load knobs** (api mode) are forwarded verbatim to the `ct-validate` runner, so
+  you can drive bounded repetition and parallelism — the circuit breaker still guards
+  the API:
+
+  ```bash
+  scripts/ct-test.sh --tenant vmware api vm-vmware -runs 20 -concurrency 4
+  ```
+
+Scenarios today: `readonly` (safe, read-only), `vpc`, `storage`, `vm` (OpenIaaS
+lifecycle), `vm-vmware` (VMware lifecycle). Write scenarios create then destroy
+their resources, with a deferred never-orphan teardown net.
+
+## `ct-soak.sh` — characterize intermittent endpoint flakiness
+
+Authenticates with a PAT, then fires a fixed quota of GET calls per **concurrency
+step** (1 → 2 → 4 → 8 …), measuring HTTP code and latency for each call. After every
+step it reports OK% / 5xx / 4xx / errors and latency percentiles, and **stops the
+ladder early** if a step's 5xx rate crosses a threshold — the bounded-probe /
+stop-at-first-distress doctrine (never stress a shared API to breakage).
+
+Read-only (GETs only — no writes, no orphans). Credentials and the bearer token are
+never printed.
+
+```bash
+# default: OpenIaaS machine_managers list, steps "1 2 4 8", 25 calls/step (= 100 total)
+CT_ENV=/path/to/.env.recette-openiaas scripts/ct-soak.sh
+
+# more aggressive ladder, or probe a different read-only GET:
+STEPS="1 2 4 8 16" PER_STEP=20 scripts/ct-soak.sh
+API_PATH=/api/compute/v1/open_iaas/storage_repositories scripts/ct-soak.sh
+```
+
+| Env knob | Default | Meaning |
+| -------- | ------- | ------- |
+| `CT_ENV` | `$CT_ENV_OPENIAAS`, else `./.env.recette-openiaas` | creds file (`CLOUDTEMPLE_CLIENT_ID` / `CLOUDTEMPLE_SECRET_ID`) |
+| `HOST` | `shiva.cloud-temple.com` | API host |
+| `API_PATH` | `/api/compute/v1/open_iaas` | the GET path to probe (machine_managers list) |
+| `STEPS` | `1 2 4 8` | concurrency ladder |
+| `PER_STEP` | `25` | calls per step (total = `PER_STEP` × #steps) |
+| `MAX_TIME` | `30` | per-call timeout (s) |
+| `ABORT_5XX_RATE` | `0.5` | stop the ladder if a step's 5xx rate exceeds this |
+
+Exit code is non-zero if the breaker tripped. Useful to characterize platform
+flakiness (e.g. ComputeManager 5xx bursts) and to size a client retry/backoff policy.
+
+## `coverage_ratchet.sh` — CI coverage gate
+
+Runs the pure-package unit tests under the race detector with coverage and **fails if
+any package's statement coverage drops below its recorded floor** in
+[`coverage_floor.txt`](coverage_floor.txt). The floor is raised as the suite grows and
+must never be lowered by hand — making "add tests where they are missing" a systemic CI
+guard rather than a discretionary habit.
+
+```bash
+scripts/coverage_ratchet.sh            # run + gate (used by CI)
+scripts/coverage_ratchet.sh --update   # run + rewrite the floor to current, then commit it
+```
+
+Portable bash 3.2+ (macOS and CI behave the same). No live platform required — only the
+pure packages (`internal/client`, `internal/provider`, `internal/provider/helpers`) run.

--- a/scripts/ct-soak.sh
+++ b/scripts/ct-soak.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# ct-soak — bounded, breaker-guarded soak probe of ONE read-only Cloud Temple API
+# endpoint, to characterize intermittent platform flakiness (e.g. #315: OpenIaaS
+# machine_managers 5xx bursts) WITHOUT hammering a shared recette/dev API.
+#
+# It authenticates with a PAT (client/secret), then fires a fixed quota of GET
+# calls per concurrency STEP (1, 2, 4, 8, ...), measuring HTTP code + latency for
+# each call. After every step it reports OK% / 5xx / 4xx / errors and latency
+# percentiles, and STOPS EARLY if a step's 5xx rate crosses a threshold (the
+# bounded-probe / stop-at-first-distress doctrine — never stress to breakage).
+#
+# READ-ONLY: it only issues GETs (default: the machine_managers list). No writes,
+# no orphans. Credentials and the bearer token are NEVER printed.
+#
+# Usage:
+#   scripts/ct-soak.sh                         # default: openiaas machine_managers, steps "1 2 4 8", 25/step (=100)
+#   CT_ENV=/path/.env.recette-openiaas scripts/ct-soak.sh
+#   STEPS="1 2 4 8 16" PER_STEP=20 scripts/ct-soak.sh
+#   API_PATH=/api/compute/v1/open_iaas/storage_repositories scripts/ct-soak.sh   # probe another GET
+#
+# Env knobs (all optional):
+#   CT_ENV          creds file, KEY=value with CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID
+#                   (default: $CT_ENV_OPENIAAS, else ./.env.recette-openiaas)
+#   HOST            API host                (default: shiva.cloud-temple.com)
+#   API_PATH        the GET path to probe   (default: /api/compute/v1/open_iaas  → machine_managers.list)
+#   STEPS           concurrency ladder      (default: "1 2 4 8")
+#   PER_STEP        calls per step          (default: 25  → total = PER_STEP * #steps)
+#   MAX_TIME        per-call curl timeout s (default: 30)
+#   ABORT_5XX_RATE  stop if a step's 5xx rate exceeds this (default: 0.5)
+#
+# It does NOT mutate anything and is safe to re-run.
+
+set -uo pipefail
+
+HOST="${HOST:-shiva.cloud-temple.com}"
+API_PATH="${API_PATH:-/api/compute/v1/open_iaas}"   # OpenIaaS machine_managers list
+STEPS="${STEPS:-1 2 4 8}"
+PER_STEP="${PER_STEP:-25}"
+MAX_TIME="${MAX_TIME:-30}"
+ABORT_5XX_RATE="${ABORT_5XX_RATE:-0.5}"
+
+# --- resolve & load credentials (never printed) ------------------------------
+CT_ENV="${CT_ENV:-${CT_ENV_OPENIAAS:-./.env.recette-openiaas}}"
+if [ ! -f "$CT_ENV" ]; then
+  echo "ct-soak: credentials file not found: $CT_ENV" >&2
+  echo "         set CT_ENV=/path/to/.env (KEY=value: CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID)" >&2
+  exit 2
+fi
+set -a; . "$CT_ENV" 2>/dev/null; set +a
+if [ -z "${CLOUDTEMPLE_CLIENT_ID:-}" ] || [ -z "${CLOUDTEMPLE_SECRET_ID:-}" ]; then
+  echo "ct-soak: CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID not set in $CT_ENV" >&2
+  exit 2
+fi
+
+# --- authenticate (PAT → bearer JWT; the response body IS the raw JWT) --------
+# The token is captured into a variable and never echoed.
+TOKEN="$(curl -ksS --max-time "$MAX_TIME" -X POST \
+  "https://${HOST}/api/iam/v2/auth/personal_access_token" \
+  -H 'Content-Type: application/json' \
+  -d "{\"id\":\"${CLOUDTEMPLE_CLIENT_ID}\",\"secret\":\"${CLOUDTEMPLE_SECRET_ID}\"}" 2>/dev/null)"
+case "$TOKEN" in
+  eyJ*) : ;;  # looks like a JWT
+  *) echo "ct-soak: authentication failed (no JWT returned). Check creds/host." >&2; exit 2 ;;
+esac
+
+URL="https://${HOST}${API_PATH}"
+echo "ct-soak: target  GET ${URL}"
+echo "ct-soak: ladder  STEPS='${STEPS}'  PER_STEP=${PER_STEP}  (total $(( $(wc -w <<<"$STEPS") * PER_STEP )) calls)  abort-5xx-rate=${ABORT_5XX_RATE}"
+echo "ct-soak: NOTE read-only probe; stops early if a step's 5xx rate exceeds the threshold."
+echo
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# one_call <outfile>: GET the endpoint, write "<http_code> <time_total_s>" to outfile.
+# A transport error / timeout (curl non-zero) is recorded as code 000.
+one_call() {
+  local out="$1" line
+  line="$(curl -ksS --max-time "$MAX_TIME" -o /dev/null \
+            -w '%{http_code} %{time_total}' \
+            -H "Authorization: Bearer ${TOKEN}" "$URL" 2>/dev/null)" || line="000 0"
+  printf '%s\n' "$line" > "$out"
+}
+
+# percentile <p> < sorted_numbers : nearest-rank percentile of stdin (ms, integers)
+percentile() {
+  local p="$1"
+  awk -v p="$p" '{a[NR]=$1} END{ if(NR==0){print "-";exit} n=int((p/100)*NR+0.999); if(n<1)n=1; if(n>NR)n=NR; print a[n] }'
+}
+
+TOTAL_CALLS=0; TOTAL_OK=0; TOTAL_5XX=0; TOTAL_4XX=0; TOTAL_ERR=0
+aborted=0
+
+printf '%-6s %-6s %-5s %-5s %-5s %-6s %8s %8s %8s %8s\n' \
+  STEP CALLS OK 5xx 4xx other "p50(ms)" "p95(ms)" "max(ms)" "OK%"
+printf '%.0s-' {1..78}; echo
+
+for C in $STEPS; do
+  rm -f "$WORK"/r_*
+  done_n=0
+  # fire PER_STEP calls in waves of C concurrent requests
+  while [ "$done_n" -lt "$PER_STEP" ]; do
+    pids=()
+    for ((k=0; k<C && done_n<PER_STEP; k++)); do
+      one_call "$WORK/r_$done_n" &
+      pids+=($!)
+      done_n=$((done_n+1))
+    done
+    wait "${pids[@]}" 2>/dev/null
+  done
+
+  # aggregate this step
+  step_ok=0; step_5xx=0; step_4xx=0; step_err=0; step_n=0
+  : > "$WORK/lat_ms"
+  for f in "$WORK"/r_*; do
+    [ -f "$f" ] || continue
+    read -r code t < "$f"
+    step_n=$((step_n+1))
+    # latency seconds -> ms (integer)
+    ms="$(awk -v t="$t" 'BEGIN{printf "%d", t*1000}')"
+    echo "$ms" >> "$WORK/lat_ms"
+    case "$code" in
+      2??) step_ok=$((step_ok+1)) ;;
+      5??) step_5xx=$((step_5xx+1)) ;;
+      4??) step_4xx=$((step_4xx+1)) ;;
+      *)   step_err=$((step_err+1)) ;;
+    esac
+  done
+
+  sort -n "$WORK/lat_ms" > "$WORK/lat_sorted"
+  p50="$(percentile 50 < "$WORK/lat_sorted")"
+  p95="$(percentile 95 < "$WORK/lat_sorted")"
+  pmax="$(tail -1 "$WORK/lat_sorted" 2>/dev/null || echo -)"
+  okpct="$(awk -v ok="$step_ok" -v n="$step_n" 'BEGIN{ if(n==0){print "-"} else printf "%.0f", 100*ok/n }')"
+
+  printf '%-6s %-6s %-5s %-5s %-5s %-6s %8s %8s %8s %7s%%\n' \
+    "$C" "$step_n" "$step_ok" "$step_5xx" "$step_4xx" "$step_err" "$p50" "$p95" "$pmax" "$okpct"
+
+  TOTAL_CALLS=$((TOTAL_CALLS+step_n)); TOTAL_OK=$((TOTAL_OK+step_ok))
+  TOTAL_5XX=$((TOTAL_5XX+step_5xx)); TOTAL_4XX=$((TOTAL_4XX+step_4xx)); TOTAL_ERR=$((TOTAL_ERR+step_err))
+
+  # breaker: stop the ladder if this step's 5xx rate crosses the threshold
+  trip="$(awk -v x="$step_5xx" -v n="$step_n" -v thr="$ABORT_5XX_RATE" \
+    'BEGIN{ if(n>0 && (x/n)>thr) print 1; else print 0 }')"
+  if [ "$trip" = "1" ]; then
+    echo
+    echo "ct-soak: ABORT — step concurrency=$C had 5xx rate > ${ABORT_5XX_RATE} ($step_5xx/$step_n). Stopping the ladder (API distress)."
+    aborted=1
+    break
+  fi
+done
+
+echo
+printf '%.0s=' {1..78}; echo
+echo "TOTAL: calls=$TOTAL_CALLS  ok=$TOTAL_OK  5xx=$TOTAL_5XX  4xx=$TOTAL_4XX  other=$TOTAL_ERR"
+awk -v ok="$TOTAL_OK" -v x="$TOTAL_5XX" -v n="$TOTAL_CALLS" 'BEGIN{
+  if(n==0){print "TOTAL: no calls"; exit}
+  printf "TOTAL: OK rate=%.1f%%  5xx rate=%.1f%%\n", 100*ok/n, 100*x/n
+}'
+if [ "$TOTAL_5XX" -gt 0 ]; then
+  echo "VERDICT: intermittent 5xx observed — consistent with the #315 ComputeManager flakiness. A bounded client retry/backoff on the read path would absorb it."
+else
+  echo "VERDICT: no 5xx in this run."
+fi
+[ "$aborted" -eq 1 ] && exit 1 || exit 0

--- a/scripts/ct-soak.sh
+++ b/scripts/ct-soak.sh
@@ -39,6 +39,11 @@ STEPS="${STEPS:-1 2 4 8}"
 PER_STEP="${PER_STEP:-25}"
 MAX_TIME="${MAX_TIME:-30}"
 ABORT_5XX_RATE="${ABORT_5XX_RATE:-0.5}"
+# USER_AGENT mirrors the ct-validate Go client, which sends an EMPTY User-Agent and
+# NO Accept header. curl otherwise injects "curl/x.y" + "Accept: */*", which a
+# gateway/WAF can route differently — so by default we send the same bytes as the
+# real client. Override USER_AGENT to test a specific UA.
+USER_AGENT="${USER_AGENT:-}"
 
 # --- resolve & load credentials (never printed) ------------------------------
 CT_ENV="${CT_ENV:-${CT_ENV_OPENIAAS:-./.env.recette-openiaas}}"
@@ -57,7 +62,7 @@ fi
 # The token is captured into a variable and never echoed.
 TOKEN="$(curl -ksS --max-time "$MAX_TIME" -X POST \
   "https://${HOST}/api/iam/v2/auth/personal_access_token" \
-  -H 'Content-Type: application/json' \
+  -A "$USER_AGENT" -H 'Accept:' -H 'Content-Type: application/json' \
   -d "{\"id\":\"${CLOUDTEMPLE_CLIENT_ID}\",\"secret\":\"${CLOUDTEMPLE_SECRET_ID}\"}" 2>/dev/null)"
 case "$TOKEN" in
   eyJ*) : ;;  # looks like a JWT
@@ -79,6 +84,7 @@ one_call() {
   local out="$1" line
   line="$(curl -ksS --max-time "$MAX_TIME" -o /dev/null \
             -w '%{http_code} %{time_total}' \
+            -A "$USER_AGENT" -H 'Accept:' \
             -H "Authorization: Bearer ${TOKEN}" "$URL" 2>/dev/null)" || line="000 0"
   printf '%s\n' "$line" > "$out"
 }

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -42,6 +42,7 @@ CTV_BIN="${CTV_BIN:-/tmp/ct-validate-bin}"
 scenarios() {
   cat <<'EOF'
 readonly|readonly|0|1|Read every service (no create/destroy). The safest scenario, validates the tool.
+machine-managers|machine_managers|0|1|OpenIaaS: just run_identity + machine_managers.list, repeatable, to characterize the #315 5xx flakiness. Read-only.
 vpc|vpc|1|1|Create a VPC static IP + floating-IP binding, verify, then destroy.
 storage|object_storage|1|1|Create an object-storage bucket + account + ACL, verify, then destroy.
 vm|compute_lifecycle|1|1|OpenIaaS: create a VM from a template, add a disk, connect the network, then destroy.


### PR DESCRIPTION
Refs #316
Refs #315

Tooling to characterize the intermittent OpenIaaS `machine_managers.list` 5xx (#315), plus docs for `scripts/`.

## Contents

1. **`scripts/README.md`** — documents the `scripts/` directory (`ct-test.sh`, `ct-soak.sh`, `coverage_ratchet.sh`).
2. **`scripts/ct-soak.sh`** — bounded, breaker-guarded read-only soak of a single endpoint. Sends the **same bytes** as the Go client (empty `User-Agent`, no `Accept`) so a gateway can't route it differently from `ct-validate`.
3. **`cmd/ct-validate` `machine_managers` cycle** — a read-only cycle that does EXACTLY `run_identity` + `machine_managers.list` (the same `MachineManager().List(ctx)` call as the `vm`/`readonly` cycles), nothing else. The faithful, client-identical way to reproduce the 5xx in isolation:

   ```bash
   scripts/ct-test.sh api machine-managers -runs 100 -concurrency 1
   ```

## Why curl wasn't enough

A `curl` soak isn't byte-identical to the Go client (HTTP version, TLS, header order, keep-alive). Item 2 narrows the gap (UA/Accept), item 3 removes it entirely by driving the real client.

## Safety / scope

Pure tooling + docs — no provider/client code path, no Terraform state touched. The cycle is read-only (no writes, no teardown). `go build`, `gofmt -l`, `go vet`, `go test -race` all green; the cycle's two-op order, 5xx surfacing, and read-only classification are unit-tested.