### PR TITLE
feat(ct-validate): Terraform validation path — OpenIaaS vm lifecycle (marketplace Ubuntu + disk + start/stop + LAN/static IP/public IP)

### DIFF
--- a/examples/ct-test/vm/README.md
+++ b/examples/ct-test/vm/README.md
@@ -26,16 +26,43 @@ destroy always runs, even on a mid-lifecycle failure, to never leave orphans.
 
 - **Marketplace deploy** (`marketplace_item_id` + `storage_repository_id`).
 - **Data disk** attached to the VM (`cloudtemple_compute_iaas_opensource_virtual_disk`).
+- **LAN + static IP**: the adapter joins the LAN (an OpenIaaS network) and a managed
+  **static IP** (`cloudtemple_vpc_static_ip`) is allocated on the LAN's VPC private
+  network, bound to the adapter's MAC (address auto-allocated by the API).
+- **Public IP**: a pre-provisioned free floating IP is bound to the static IP
+  (`cloudtemple_vpc_floating_ip_binding`) — the VM is reachable from outside for tests.
 - **Power management** via `power_state` (`on`/`off`) — the stop/start cycle.
 - **Convergence**: no permanent drift after apply (the value of the TF path vs the API).
 - **Clean teardown**: destroy leaves nothing behind.
 
+`terraform output` exposes `lan_static_ip` and `public_ip`.
+
 ## Substrate discovery (no hard-coded ids)
 
-The availability zone, storage repository, network and backup policy are discovered
+The availability zone, storage repository and backup policy are discovered
 dynamically (first usable of each), so the config runs on any OpenIaaS tenant —
 mirroring the API cycle's read-then-pick approach. A backup SLA policy is required
 to power a VM on; any policy in the tenant satisfies it.
+
+**The LAN** is selected **by name** (`var.lan_network_name`) on two correlated
+layers — the OpenIaaS network (where the adapter connects) and the VPC private
+network (where the static IP is allocated), which share the LAN's name by
+convention. Resource `precondition`s assert the name matches **exactly one** network
+on each layer (`length(...) == 1`), so a typo, a missing LAN, or an ambiguous name is
+a clear plan-time error — never a wrong silent pick. **The public IP** is the first
+**free** floating IP (`static_ip_id == ""`); a precondition on the binding fails the
+apply if none is free, rather than touching an in-use address.
+
+> Networking is the most tenant-specific part: it assumes the OpenIaaS network and
+> the VPC private network share the LAN name, and that a free floating IP exists.
+> Validate on first live run and adjust `var.lan_network_name` if needed.
+>
+> **Teardown coverage:** `terraform destroy` is the primary removal proof (the static
+> IP depends on the VM and is destroyed before it; the floating-IP binding is unbound,
+> not deleted). The post-destroy smoke check in `ct-test.sh` currently scans only the
+> VM and data disk by name — it does **not** yet probe `cloudtemple_vpc_static_ip` /
+> the floating binding. A rigorous independent VPC absence proof (ListStrict by id) is
+> a documented follow-up.
 
 ## Tunables (see `variables.tf`)
 
@@ -43,6 +70,7 @@ If an apply fails on a tenant-specific detail, adjust via `-var` or a `*.tfvars`
 
 | Variable | Default | When to change |
 | -------- | ------- | -------------- |
+| `lan_network_name` | `LAN` | Your LAN is named differently (matched on the OpenIaaS network AND the VPC private network). |
 | `marketplace_name` | `Ubuntu 24.04 LTS` | The image name differs in your catalog (apply reports "not found"). |
 | `cpu` / `memory_gib` | `2` / `4` | The image requires more (deploy rejected with `MEMORY_CONSTRAINT_VIOLATION_ORDER`). |
 | `data_disk_gib` | `1` | Larger data disk. |

--- a/examples/ct-test/vm/README.md
+++ b/examples/ct-test/vm/README.md
@@ -1,0 +1,52 @@
+# ct-test scenario `vm` — OpenIaaS VM full lifecycle (Terraform path)
+
+Validates a full OpenIaaS VM lifecycle through the **real provider** (not the raw
+API): deploy an Ubuntu VM **from the marketplace**, attach a data disk, then drive
+power (start → stop → start), with a **convergence check** (empty `terraform plan`)
+after every step and a clean `destroy` at the end.
+
+## Run
+
+```bash
+CT_ENV_OPENIAAS=/path/to/.env.recette-openiaas scripts/ct-test.sh tf vm
+```
+
+`ct-test.sh` builds the provider from this checkout, wires it via a `dev_overrides`
+CLI config (so Terraform uses *our* provider, not a registry release — no `init`
+needed), injects a run-unique `vm_name`, and runs:
+
+```
+create+start → plan(empty) → stop → plan(empty) → restart → plan(empty) → destroy
+```
+
+A non-empty plan (drift) or a failed destroy (possible orphan) fails the run. The
+destroy always runs, even on a mid-lifecycle failure, to never leave orphans.
+
+## What it exercises
+
+- **Marketplace deploy** (`marketplace_item_id` + `storage_repository_id`).
+- **Data disk** attached to the VM (`cloudtemple_compute_iaas_opensource_virtual_disk`).
+- **Power management** via `power_state` (`on`/`off`) — the stop/start cycle.
+- **Convergence**: no permanent drift after apply (the value of the TF path vs the API).
+- **Clean teardown**: destroy leaves nothing behind.
+
+## Substrate discovery (no hard-coded ids)
+
+The availability zone, storage repository, network and backup policy are discovered
+dynamically (first usable of each), so the config runs on any OpenIaaS tenant —
+mirroring the API cycle's read-then-pick approach. A backup SLA policy is required
+to power a VM on; any policy in the tenant satisfies it.
+
+## Tunables (see `variables.tf`)
+
+If an apply fails on a tenant-specific detail, adjust via `-var` or a `*.tfvars`:
+
+| Variable | Default | When to change |
+| -------- | ------- | -------------- |
+| `marketplace_name` | `Ubuntu 24.04 LTS` | The image name differs in your catalog (apply reports "not found"). |
+| `cpu` / `memory_gib` | `2` / `4` | The image requires more (deploy rejected with `MEMORY_CONSTRAINT_VIOLATION_ORDER`). |
+| `data_disk_gib` | `1` | Larger data disk. |
+| `vm_power_state` | `on` | Driven by `ct-test.sh`; override only for a manual apply. |
+
+Example: `cd examples/ct-test/vm && terraform apply -var marketplace_name="Ubuntu 22.04 LTS" -var memory_gib=8`
+(but prefer `scripts/ct-test.sh tf vm`, which wires the local provider and the full lifecycle).

--- a/examples/ct-test/vm/README.md
+++ b/examples/ct-test/vm/README.md
@@ -29,7 +29,7 @@ destroy always runs, even on a mid-lifecycle failure, to never leave orphans.
 - **LAN + static IP**: the adapter joins the LAN (an OpenIaaS network) and a managed
   **static IP** (`cloudtemple_vpc_static_ip`) is allocated on the LAN's VPC private
   network, bound to the adapter's MAC (address auto-allocated by the API).
-- **Public IP**: a pre-provisioned free floating IP is bound to the static IP
+- **Public IP**: a pre-provisioned floating IP is bound to the static IP
   (`cloudtemple_vpc_floating_ip_binding`) — the VM is reachable from outside for tests.
 - **Power management** via `power_state` (`on`/`off`) — the stop/start cycle.
 - **Convergence**: no permanent drift after apply (the value of the TF path vs the API).
@@ -39,19 +39,24 @@ destroy always runs, even on a mid-lifecycle failure, to never leave orphans.
 
 ## Substrate discovery (no hard-coded ids)
 
-The availability zone, storage repository and backup policy are discovered
-dynamically (first usable of each), so the config runs on any OpenIaaS tenant —
-mirroring the API cycle's read-then-pick approach. A backup SLA policy is required
-to power a VM on; any policy in the tenant satisfies it.
+The availability zone and backup policy are the first the API returns; the
+**storage repository** is the usable one (not in maintenance, accessible) with the
+**most free capacity** — never the first listed, which may be full (a VM
+precondition fails closed if none has room for the OS disk + data disk). The config
+thus runs on any OpenIaaS tenant — mirroring the API cycle's read-then-pick
+approach. A backup SLA policy is required to power a VM on; any policy in the tenant
+satisfies it.
 
 **The LAN** is selected **by name** (`var.lan_network_name`) on two correlated
 layers — the OpenIaaS network (where the adapter connects) and the VPC private
 network (where the static IP is allocated), which share the LAN's name by
 convention. Resource `precondition`s assert the name matches **exactly one** network
 on each layer (`length(...) == 1`), so a typo, a missing LAN, or an ambiguous name is
-a clear plan-time error — never a wrong silent pick. **The public IP** is the first
-**free** floating IP (`static_ip_id == ""`); a precondition on the binding fails the
-apply if none is free, rather than touching an in-use address.
+a clear plan-time error — never a wrong silent pick. **The public IP** is chosen
+**stably**: the floating IP already bound to this run's static IP if present (so the
+binding converges and destroys cleanly), else the first free one (`static_ip_id ==
+""`); a precondition fails closed if neither exists. A blind "first free" pick would
+break convergence and destroy once the IP is bound (it is no longer free).
 
 > Networking is the most tenant-specific part: it assumes the OpenIaaS network and
 > the VPC private network share the LAN name, and that a free floating IP exists.

--- a/examples/ct-test/vm/main.tf
+++ b/examples/ct-test/vm/main.tf
@@ -82,10 +82,16 @@ locals {
   lan_openiaas_network_id = try(local.lan_openiaas_matches[0], null)
   lan_private_network_id  = try(local.lan_private_matches[0], null)
 
-  # FREE public floating IPs (not bound to any static IP). null if none — a
-  # precondition on the binding fails visibly rather than picking an in-use address.
-  free_floating_ips   = [for f in data.cloudtemple_vpc_floating_ips.all.floating_ips : f.id if f.static_ip_id == ""]
-  free_floating_ip_id = try(local.free_floating_ips[0], null)
+  # Public floating IP to bind: prefer the one ALREADY bound to THIS run's static IP,
+  # so the choice is STABLE across plan / refresh / destroy. A blind "first free" pick
+  # is unstable: once we bind it the IP is no longer free, so on the next plan it
+  # flips to null — which fails the convergence check AND blocks destroy (leaving an
+  # orphan). On the initial create nothing is bound to our brand-new static IP yet,
+  # so we fall back to the first currently-free IP. null only if neither exists.
+  fips                  = data.cloudtemple_vpc_floating_ips.all.floating_ips
+  fip_bound_to_ours     = [for f in local.fips : f.id if f.static_ip_id == cloudtemple_vpc_static_ip.lan.id]
+  fip_free              = [for f in local.fips : f.id if f.static_ip_id == ""]
+  public_floating_ip_id = try(local.fip_bound_to_ours[0], try(local.fip_free[0], null))
 }
 
 # --- the VM, deployed from the marketplace ----------------------------------------
@@ -166,18 +172,19 @@ resource "cloudtemple_vpc_static_ip" "lan" {
 }
 
 # --- attach a public (floating) IP to the static IP -------------------------------
-# Binds a PRE-PROVISIONED free floating IP (create = bind, destroy = unbind; it never
-# creates/destroys the public IP). free_floating_ip_id is null if none is free, which
-# fails the apply visibly rather than touching an in-use address.
+# Binds a PRE-PROVISIONED floating IP (create = bind, destroy = unbind; it never
+# creates/destroys the public IP). The id is chosen STABLY (see local.public_floating_ip_id):
+# the IP already bound to our static IP if present, else the first free one — so the
+# binding converges and destroys cleanly instead of flipping to null once bound.
 resource "cloudtemple_vpc_floating_ip_binding" "public" {
-  floating_ip_id = local.free_floating_ip_id
+  floating_ip_id = local.public_floating_ip_id
   static_ip_id   = cloudtemple_vpc_static_ip.lan.id
 
-  # Fail closed (clear message) if no public IP is free, rather than passing null.
+  # Fail closed (clear message) if no usable public IP exists at all.
   lifecycle {
     precondition {
-      condition     = local.free_floating_ip_id != null
-      error_message = "No free public (floating) IP available — all are bound. Free one or provision a new public IP in the VPC."
+      condition     = local.public_floating_ip_id != null
+      error_message = "No public (floating) IP available — none free and none already bound to this VM's static IP. Free or provision one in the VPC."
     }
   }
 }

--- a/examples/ct-test/vm/main.tf
+++ b/examples/ct-test/vm/main.tf
@@ -1,0 +1,110 @@
+# ct-test scenario `vm` — OpenIaaS VM full lifecycle via Terraform.
+#
+# Mirrors (and goes beyond) the API `compute_lifecycle` cycle, but exercised through
+# the real provider: deploy an Ubuntu VM FROM THE MARKETPLACE, attach a data disk,
+# and drive power (start/stop) — with a convergence check (empty plan) between each
+# step and a clean destroy at the end. Driven by scripts/ct-test.sh:
+#
+#   scripts/ct-test.sh tf vm
+#
+# The substrate (availability zone, storage repository, network, backup policy) is
+# DISCOVERED dynamically (no hard-coded tenant ids), so the same config runs on any
+# OpenIaaS tenant — like the API cycle's read-then-pick approach. Only the
+# marketplace image name is a variable (catalogs differ); see variables.tf.
+
+terraform {
+  required_providers {
+    cloudtemple = {
+      source = "Cloud-Temple/cloudtemple"
+    }
+  }
+}
+
+# Credentials and host come from the environment (CLOUDTEMPLE_CLIENT_ID /
+# CLOUDTEMPLE_SECRET_ID / CLOUDTEMPLE_HTTP_ADDR / CLOUDTEMPLE_HTTP_SCHEME), exported
+# by scripts/ct-test.sh load_creds.
+provider "cloudtemple" {}
+
+# --- substrate discovery (dynamic; first usable of each, like the API cycle) ------
+
+data "cloudtemple_compute_iaas_opensource_availability_zones" "all" {}
+
+data "cloudtemple_compute_iaas_opensource_storage_repositories" "all" {
+  machine_manager_id = data.cloudtemple_compute_iaas_opensource_availability_zones.all.availability_zones[0].id
+}
+
+data "cloudtemple_compute_iaas_opensource_networks" "all" {
+  machine_manager_id = data.cloudtemple_compute_iaas_opensource_availability_zones.all.availability_zones[0].id
+}
+
+# Powering a VM on requires at least one backup SLA policy (provider/API constraint);
+# any policy in the VM's availability zone satisfies it.
+data "cloudtemple_backup_iaas_opensource_policies" "all" {
+  machine_manager_id = data.cloudtemple_compute_iaas_opensource_availability_zones.all.availability_zones[0].id
+}
+
+# The Ubuntu marketplace image. Catalogs differ between tenants, so the exact name
+# is a variable — adjust it (or pass -var) if the apply reports "not found".
+data "cloudtemple_marketplace_item" "image" {
+  name = var.marketplace_name
+}
+
+locals {
+  storage_repository_id = data.cloudtemple_compute_iaas_opensource_storage_repositories.all.storage_repositories[0].id
+  network_id            = data.cloudtemple_compute_iaas_opensource_networks.all.networks[0].id
+  backup_policy_id      = data.cloudtemple_backup_iaas_opensource_policies.all.policies[0].id
+}
+
+# --- the VM, deployed from the marketplace ----------------------------------------
+
+resource "cloudtemple_compute_iaas_opensource_virtual_machine" "ubuntu" {
+  name        = var.vm_name
+  power_state = var.vm_power_state # "on" / "off" — driven by ct-test.sh to exercise start/stop
+
+  marketplace_item_id   = data.cloudtemple_marketplace_item.image.id
+  storage_repository_id = local.storage_repository_id
+
+  cpu                  = var.cpu
+  memory               = var.memory_gib * 1024 * 1024 * 1024
+  num_cores_per_socket = 1
+  boot_firmware        = "uefi" # marketplace images deploy UEFI
+  secure_boot          = false
+  auto_power_on        = false
+  high_availability    = "disabled"
+
+  # One adapter on the discovered network (the marketplace item defines how many).
+  os_network_adapter {
+    network_id = local.network_id
+  }
+
+  # The OS disk lives on the discovered storage repository.
+  os_disk {
+    storage_repository_id = local.storage_repository_id
+  }
+
+  # At least one backup policy is mandatory to power the VM on.
+  backup_sla_policies = [local.backup_policy_id]
+}
+
+# --- an additional data disk, attached to the VM ----------------------------------
+
+resource "cloudtemple_compute_iaas_opensource_virtual_disk" "data" {
+  name                  = "${var.vm_name}-data"
+  size                  = var.data_disk_gib * 1024 * 1024 * 1024
+  mode                  = "RW"
+  bootable              = false
+  storage_repository_id = local.storage_repository_id
+  virtual_machine_id    = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.id
+}
+
+output "vm_id" {
+  value = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.id
+}
+
+output "vm_power_state" {
+  value = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.power_state
+}
+
+output "data_disk_id" {
+  value = cloudtemple_compute_iaas_opensource_virtual_disk.data.id
+}

--- a/examples/ct-test/vm/main.tf
+++ b/examples/ct-test/vm/main.tf
@@ -59,8 +59,19 @@ data "cloudtemple_vpc_private_networks" "all" {}
 data "cloudtemple_vpc_floating_ips" "all" {}
 
 locals {
-  storage_repository_id = data.cloudtemple_compute_iaas_opensource_storage_repositories.all.storage_repositories[0].id
-  backup_policy_id      = data.cloudtemple_backup_iaas_opensource_policies.all.policies[0].id
+  # Storage repository: pick a USABLE SR (not in maintenance, accessible) with the
+  # MOST free space — never the first listed, which may be full/limited (the
+  # marketplace deploy then fails "Limited storage capacity"). Mirrors the API
+  # cycle's hard filters (maintenance / accessible / capacity); the precondition on
+  # the VM fails closed if none has room.
+  all_srs    = data.cloudtemple_compute_iaas_opensource_storage_repositories.all.storage_repositories
+  usable_srs = [for s in local.all_srs : s if s.id != "" && !s.maintenance_mode && s.accessible != 0]
+  # Floor = OS-disk/headroom (var.min_free_gib) + the data disk this config also creates.
+  min_free_bytes        = (var.min_free_gib + var.data_disk_gib) * 1024 * 1024 * 1024
+  max_free_bytes        = length(local.usable_srs) > 0 ? max([for s in local.usable_srs : s.free_capacity]...) : 0
+  storage_repository_id = try([for s in local.usable_srs : s.id if s.free_capacity == local.max_free_bytes][0], null)
+
+  backup_policy_id = data.cloudtemple_backup_iaas_opensource_policies.all.policies[0].id
 
   # The LAN, by name, on each layer. We keep the full match lists so resource
   # `precondition`s below can assert EXACTLY one match — a 0-match would otherwise be
@@ -114,6 +125,12 @@ resource "cloudtemple_compute_iaas_opensource_virtual_machine" "ubuntu" {
     precondition {
       condition     = length(local.lan_openiaas_matches) == 1
       error_message = "Expected exactly one OpenIaaS network named \"${var.lan_network_name}\", found ${length(local.lan_openiaas_matches)}. Set var.lan_network_name to your LAN."
+    }
+    # Fail closed if no usable storage repository has room — never deploy onto a
+    # full/limited SR (the API rejects it with "Limited storage capacity").
+    precondition {
+      condition     = local.max_free_bytes >= local.min_free_bytes
+      error_message = "No usable storage repository has at least ${var.min_free_gib + var.data_disk_gib} GiB free (largest usable free = ${floor(local.max_free_bytes / 1024 / 1024 / 1024)} GiB). Free space, or lower var.min_free_gib."
     }
   }
 }

--- a/examples/ct-test/vm/main.tf
+++ b/examples/ct-test/vm/main.tf
@@ -49,10 +49,32 @@ data "cloudtemple_marketplace_item" "image" {
   name = var.marketplace_name
 }
 
+# --- networking: put the VM on the LAN, give it a static IP, attach a public IP ---
+# The "LAN" exists on two correlated layers: an OpenIaaS network (where the adapter
+# connects) and a VPC private network (where a managed static IP is allocated). Both
+# are selected BY NAME (var.lan_network_name) — the convention is that they share the
+# LAN's name. The public IP is a pre-provisioned floating IP discovered free below.
+data "cloudtemple_vpc_private_networks" "all" {}
+
+data "cloudtemple_vpc_floating_ips" "all" {}
+
 locals {
   storage_repository_id = data.cloudtemple_compute_iaas_opensource_storage_repositories.all.storage_repositories[0].id
-  network_id            = data.cloudtemple_compute_iaas_opensource_networks.all.networks[0].id
   backup_policy_id      = data.cloudtemple_backup_iaas_opensource_policies.all.policies[0].id
+
+  # The LAN, by name, on each layer. We keep the full match lists so resource
+  # `precondition`s below can assert EXACTLY one match — a 0-match would otherwise be
+  # silently null (Terraform's one([]) == null), and a >1-match ambiguous; both must
+  # be a clear error, not a wrong silent pick.
+  lan_openiaas_matches    = [for n in data.cloudtemple_compute_iaas_opensource_networks.all.networks : n.id if n.name == var.lan_network_name]
+  lan_private_matches     = [for p in data.cloudtemple_vpc_private_networks.all.private_networks : p.id if p.name == var.lan_network_name]
+  lan_openiaas_network_id = try(local.lan_openiaas_matches[0], null)
+  lan_private_network_id  = try(local.lan_private_matches[0], null)
+
+  # FREE public floating IPs (not bound to any static IP). null if none — a
+  # precondition on the binding fails visibly rather than picking an in-use address.
+  free_floating_ips   = [for f in data.cloudtemple_vpc_floating_ips.all.floating_ips : f.id if f.static_ip_id == ""]
+  free_floating_ip_id = try(local.free_floating_ips[0], null)
 }
 
 # --- the VM, deployed from the marketplace ----------------------------------------
@@ -72,9 +94,10 @@ resource "cloudtemple_compute_iaas_opensource_virtual_machine" "ubuntu" {
   auto_power_on        = false
   high_availability    = "disabled"
 
-  # One adapter on the discovered network (the marketplace item defines how many).
+  # One adapter on the LAN (OpenIaaS network selected by name). Its MAC (computed)
+  # is what the static IP below binds to.
   os_network_adapter {
-    network_id = local.network_id
+    network_id = local.lan_openiaas_network_id
   }
 
   # The OS disk lives on the discovered storage repository.
@@ -84,6 +107,15 @@ resource "cloudtemple_compute_iaas_opensource_virtual_machine" "ubuntu" {
 
   # At least one backup policy is mandatory to power the VM on.
   backup_sla_policies = [local.backup_policy_id]
+
+  # Fail closed (clear message) if the LAN name matches zero or several OpenIaaS
+  # networks — never silently leave the adapter on a null/wrong network.
+  lifecycle {
+    precondition {
+      condition     = length(local.lan_openiaas_matches) == 1
+      error_message = "Expected exactly one OpenIaaS network named \"${var.lan_network_name}\", found ${length(local.lan_openiaas_matches)}. Set var.lan_network_name to your LAN."
+    }
+  }
 }
 
 # --- an additional data disk, attached to the VM ----------------------------------
@@ -97,6 +129,42 @@ resource "cloudtemple_compute_iaas_opensource_virtual_disk" "data" {
   virtual_machine_id    = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.id
 }
 
+# --- a managed static IP on the LAN (VPC private network) -------------------------
+# Bound to the VM's adapter by its MAC; ip_address is omitted so the API allocates a
+# free, valid address ("une ip qui va bien"). Referencing the VM's MAC makes the
+# static IP depend on the VM, so destroy removes the IP association BEFORE the VM —
+# no orphaned static IP (the recommended wiring from the resource's own example).
+resource "cloudtemple_vpc_static_ip" "lan" {
+  private_network_id   = local.lan_private_network_id
+  mac_address          = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.os_network_adapter[0].mac_address
+  resource_description = var.vm_name
+
+  # Fail closed if the LAN name matches zero or several VPC private networks.
+  lifecycle {
+    precondition {
+      condition     = length(local.lan_private_matches) == 1
+      error_message = "Expected exactly one VPC private network named \"${var.lan_network_name}\", found ${length(local.lan_private_matches)}. Set var.lan_network_name to your LAN."
+    }
+  }
+}
+
+# --- attach a public (floating) IP to the static IP -------------------------------
+# Binds a PRE-PROVISIONED free floating IP (create = bind, destroy = unbind; it never
+# creates/destroys the public IP). free_floating_ip_id is null if none is free, which
+# fails the apply visibly rather than touching an in-use address.
+resource "cloudtemple_vpc_floating_ip_binding" "public" {
+  floating_ip_id = local.free_floating_ip_id
+  static_ip_id   = cloudtemple_vpc_static_ip.lan.id
+
+  # Fail closed (clear message) if no public IP is free, rather than passing null.
+  lifecycle {
+    precondition {
+      condition     = local.free_floating_ip_id != null
+      error_message = "No free public (floating) IP available — all are bound. Free one or provision a new public IP in the VPC."
+    }
+  }
+}
+
 output "vm_id" {
   value = cloudtemple_compute_iaas_opensource_virtual_machine.ubuntu.id
 }
@@ -107,4 +175,14 @@ output "vm_power_state" {
 
 output "data_disk_id" {
   value = cloudtemple_compute_iaas_opensource_virtual_disk.data.id
+}
+
+output "lan_static_ip" {
+  description = "The static IP allocated to the VM on the LAN."
+  value       = cloudtemple_vpc_static_ip.lan.ip_address
+}
+
+output "public_ip" {
+  description = "The public (floating) IP bound to the VM, for external reachability tests."
+  value       = cloudtemple_vpc_floating_ip_binding.public.floating_ip_address
 }

--- a/examples/ct-test/vm/variables.tf
+++ b/examples/ct-test/vm/variables.tf
@@ -44,3 +44,14 @@ variable "data_disk_gib" {
   type        = number
   default     = 1
 }
+
+variable "min_free_gib" {
+  description = "Free-capacity floor (GiB) for the OS disk + headroom; the data disk size (var.data_disk_gib) is added automatically to form the real floor. Among usable SRs (not in maintenance, accessible) the one with the most free space is chosen; the apply fails closed if none reaches the floor."
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.min_free_gib > 0
+    error_message = "min_free_gib must be > 0."
+  }
+}

--- a/examples/ct-test/vm/variables.tf
+++ b/examples/ct-test/vm/variables.tf
@@ -15,6 +15,12 @@ variable "vm_power_state" {
   }
 }
 
+variable "lan_network_name" {
+  description = "Name of the LAN — matched on BOTH the OpenIaaS network (the adapter connects here) and the VPC private network (the static IP is allocated here), which share this name by convention. Adjust to your tenant's LAN."
+  type        = string
+  default     = "LAN"
+}
+
 variable "marketplace_name" {
   description = "Exact name of the Ubuntu marketplace image. Catalogs differ between tenants — adjust if the apply reports the item is not found."
   type        = string

--- a/examples/ct-test/vm/variables.tf
+++ b/examples/ct-test/vm/variables.tf
@@ -1,0 +1,40 @@
+variable "vm_name" {
+  description = "Name of the VM (and prefix of its data disk). ct-test.sh injects a run-unique value to avoid colliding with a prior orphan."
+  type        = string
+  default     = "ct-validate-tf-ubuntu"
+}
+
+variable "vm_power_state" {
+  description = "VM power state — \"on\" or \"off\". ct-test.sh flips this to exercise stop/start, with a convergence check at each state."
+  type        = string
+  default     = "on"
+
+  validation {
+    condition     = contains(["on", "off"], var.vm_power_state)
+    error_message = "vm_power_state must be \"on\" or \"off\"."
+  }
+}
+
+variable "marketplace_name" {
+  description = "Exact name of the Ubuntu marketplace image. Catalogs differ between tenants — adjust if the apply reports the item is not found."
+  type        = string
+  default     = "Ubuntu 24.04 LTS"
+}
+
+variable "cpu" {
+  description = "vCPUs for the VM. Raise it if the marketplace image requires more (the order layer rejects a deploy below the image's own minimum)."
+  type        = number
+  default     = 2
+}
+
+variable "memory_gib" {
+  description = "Memory in GiB. Raise it if the marketplace image requires more (MEMORY_CONSTRAINT_VIOLATION_ORDER on a too-small deploy)."
+  type        = number
+  default     = 4
+}
+
+variable "data_disk_gib" {
+  description = "Size of the additional data disk, in GiB."
+  type        = number
+  default     = 1
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,6 +65,31 @@ scripts/ct-test.sh api machine-managers -runs 100 -concurrency 8
 
 The per-endpoint report then gives the OK% / 5xx rate of `machine_managers.list`.
 
+### TF mode — validate a scenario through real Terraform
+
+`ct-test.sh tf <scenario>` runs the scenario as Terraform would, against the
+configs in `examples/ct-test/<scenario>/`. It:
+
+- builds the provider from this checkout and wires it via a `dev_overrides` CLI
+  config, so Terraform uses **our** local provider, not a registry release (no
+  `init` needed);
+- injects a run-unique `vm_name` (a prior orphan can't collide with the apply);
+- runs `apply`, then a **convergence check** — `terraform plan -detailed-exitcode`
+  must be EMPTY (no permanent drift; this is the value of the TF path over the raw
+  API);
+- for scenarios that declare a `vm_power_state` variable (e.g. `vm`), drives a
+  **stop/start power cycle** with a convergence check at each state;
+- always runs `destroy` at the end — even on a mid-lifecycle failure — and treats a
+  failed destroy as a hard failure (possible orphan).
+
+```bash
+CT_ENV_OPENIAAS=/path/to/.env.recette-openiaas scripts/ct-test.sh tf vm
+```
+
+Today only `vm` (OpenIaaS: marketplace Ubuntu + data disk + start/stop) ships a TF
+config — see [`examples/ct-test/vm/`](../examples/ct-test/vm/). Other scenarios fall
+back to a "not ready yet" message until their `examples/ct-test/<scenario>/` is added.
+
 ## `ct-soak.sh` — characterize intermittent endpoint flakiness
 
 Authenticates with a PAT, then fires a fixed quota of GET calls per **concurrency

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -116,6 +116,26 @@ cmd_api() {
   "$CTV_BIN" "${args[@]}"
 }
 
+# Teardown state for the TF lifecycle (globals, because a RETURN/EXIT/signal trap
+# fires after cmd_tf's locals are gone). _tf_teardown is the never-orphan safety net:
+# if the normal flow did not reach its own destroy (interrupt / crash), it destroys
+# the run-unique stack best-effort; then it always removes the isolated workdir.
+_TF_WORK=""
+_TF_RCFILE=""
+_TF_RUN_NAME=""
+_tf_teardown() {
+  set +e            # never let the safety net abort half-way under `set -e`
+  trap '' INT TERM  # a second Ctrl-C must not interrupt the net destroy
+  [ -n "$_TF_WORK" ] && [ -d "$_TF_WORK" ] || return 0
+  # The normal flow marks `.destroyed` only after a SUCCESSFUL destroy, so the net
+  # re-attempts when the normal destroy failed or never ran (interrupt / crash).
+  if [ ! -f "$_TF_WORK/.destroyed" ]; then
+    echo ">> teardown net: destroying (normal destroy did not complete)..." >&2
+    ( cd "$_TF_WORK" && TF_CLI_CONFIG_FILE="$_TF_RCFILE" terraform destroy -auto-approve -input=false -var "vm_name=$_TF_RUN_NAME" >&2 )
+  fi
+  rm -rf "$_TF_WORK"
+}
+
 cmd_tf() {
   local scenario="${1:-}"; [ -n "$scenario" ] || die "usage: ct-test tf <scenario> (see 'ct-test list')"
   local row; row="$(lookup "$scenario")" || true
@@ -125,20 +145,139 @@ cmd_tf() {
   command -v terraform >/dev/null || die "terraform not found in PATH"
   load_creds
 
-  echo ">> TF scenario '$scenario'  (apply then destroy)  dir=$dir"
-  ( cd "$dir"
-    terraform init -input=false >/dev/null
+  # Use the LOCALLY built provider (this checkout), not a registry release, via a
+  # dev_overrides CLI config. With dev_overrides, `terraform init` is unnecessary
+  # (and warns), so we skip it.
+  echo ">> Building the provider (local dev_override)..."
+  ( cd "$REPO_ROOT" && go build -o terraform-provider-cloudtemple . ) || die "provider build failed"
+
+  # Run in an ISOLATED workdir so no terraform.tfstate ever persists in the repo: a
+  # prior failed run can never contaminate this one (the run-unique name guards the
+  # remote object; the isolated state guards the local state).
+  local work; work="$(mktemp -d "${TMPDIR:-/tmp}/ct-test-tf.XXXXXX")"
+  # Run-unique name so a prior run's orphan can never collide with this apply.
+  local run_name="ct-validate-tf-$(date +%Y%m%d-%H%M%S)-$$"
+  local rcfile="$work/dev.tfrc"
+  # Arm the never-orphan net IMMEDIATELY (before any setup can fail), so the workdir
+  # is always cleaned and any created stack is always swept.
+  _TF_WORK="$work"; _TF_RCFILE="$rcfile"; _TF_RUN_NAME="$run_name"
+  trap '_tf_teardown' EXIT
+  trap 'echo ">> interrupted — tearing down..." >&2; exit 130' INT TERM
+
+  cp "$dir"/*.tf "$work"/
+  cat > "$rcfile" <<EOF
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/Cloud-Temple/cloudtemple" = "$REPO_ROOT"
+  }
+  direct {}
+}
+EOF
+  export TF_CLI_CONFIG_FILE="$rcfile"
+
+  # Scenarios that declare a vm_power_state variable get a stop/start power cycle.
+  local has_power=0
+  grep -rqs 'variable "vm_power_state"' "$dir"/*.tf && has_power=1
+
+  echo ">> TF scenario '$scenario'  name=$run_name  workdir=$work  (provider: local dev_override)"
+  ( cd "$work"
     set +e
-    terraform apply -auto-approve -input=false; apply_rc=$?
-    echo ">> Destroying (always, even on apply failure)..."
-    terraform destroy -auto-approve -input=false; destroy_rc=$?
-    # A failed destroy is a hard failure (possible orphan) — never report PASS
-    # just because apply succeeded. Surface both codes.
-    if [ "$apply_rc" -ne 0 ] || [ "$destroy_rc" -ne 0 ]; then
-      echo ">> FAIL (apply=$apply_rc destroy=$destroy_rc)$([ "$destroy_rc" -ne 0 ] && echo ' — DESTROY FAILED, CHECK FOR ORPHANS')" >&2
+
+    terraform validate >/dev/null || { echo ">> FAIL: terraform validate" >&2; exit 1; }
+
+    # apply_and_converge <label> [power]: apply, then assert `plan` is EMPTY
+    # (-detailed-exitcode: 0=convergent, 2=drift, other=error). The empty-plan check
+    # is the value of the TF path over the raw API: it proves no permanent drift
+    # after apply. plan uses the SAME -var set as the apply (so flipping power_state
+    # is not mistaken for drift).
+    apply_and_converge() {
+      local label="$1" power="${2:-}"
+      echo ">> [$label] apply..."
+      if [ -n "$power" ]; then
+        terraform apply -auto-approve -input=false -var "vm_name=$run_name" -var "vm_power_state=$power" || { echo ">> [$label] FAIL: apply" >&2; return 1; }
+      else
+        terraform apply -auto-approve -input=false -var "vm_name=$run_name" || { echo ">> [$label] FAIL: apply" >&2; return 1; }
+      fi
+      echo ">> [$label] convergence (plan must be empty)..."
+      if [ -n "$power" ]; then
+        terraform plan -detailed-exitcode -input=false -var "vm_name=$run_name" -var "vm_power_state=$power" >/dev/null
+      else
+        terraform plan -detailed-exitcode -input=false -var "vm_name=$run_name" >/dev/null
+      fi
+      case $? in
+        0) echo ">> [$label] OK — convergent (no drift)"; return 0 ;;
+        2) echo ">> [$label] FAIL — drift detected (plan not empty)" >&2; return 1 ;;
+        *) echo ">> [$label] FAIL — plan errored" >&2; return 1 ;;
+      esac
+    }
+
+    lifecycle_fail=0
+    if [ "$has_power" -eq 1 ]; then
+      # create+start → convergence → stop → convergence → restart → convergence
+      apply_and_converge "create+start" on || lifecycle_fail=1
+      [ "$lifecycle_fail" -eq 0 ] && { apply_and_converge "stop" off || lifecycle_fail=1; }
+      [ "$lifecycle_fail" -eq 0 ] && { apply_and_converge "restart" on || lifecycle_fail=1; }
+    else
+      apply_and_converge "create" || lifecycle_fail=1
+    fi
+
+    # Destroy ALWAYS — even on a lifecycle failure above — to never leave orphans.
+    echo ">> Destroying (always, even on failure)..."
+    terraform destroy -auto-approve -input=false -var "vm_name=$run_name"; destroy_rc=$?
+    # Mark `.destroyed` ONLY on success, so the EXIT net re-attempts a failed destroy.
+    [ "$destroy_rc" -eq 0 ] && : > .destroyed
+
+    # Post-destroy orphan SMOKE CHECK — a best-effort net ON TOP of the destroy (which
+    # is the PRIMARY proof of removal, via the provider's delete+wait). It scans the
+    # live OpenIaaS listings for our run-unique name on the NAMED resources the
+    # scenario creates as their own objects (the VM and the data disk). Semantics are
+    # deliberately one-directional: it can only FAIL the run (a run-named object still
+    # present == orphan); it NEVER upgrades a run to "proven clean". A listing is
+    # consulted only when it is a trusted complete response (curl ok + HTTP 200 + body
+    # is a JSON array); anything else is skipped (inconclusive), never read as absent.
+    # A rigorous independent proof — complete ListStrict by id, incl. the VM's
+    # sub-objects (OS disk, network adapter, which the VM delete is expected to
+    # cascade) — is a follow-up; grep-by-name only covers the run-named resources.
+    orphan_found=0; smoke_skipped=0
+    echo ">> Post-destroy orphan smoke check (run-named VM/disk must be gone)..."
+    local tok
+    tok="$(curl -ksS --max-time 30 -X POST "https://${CT_TEST_HOST}/api/iam/v2/auth/personal_access_token" \
+            -A "" -H 'Accept:' -H 'Content-Type: application/json' \
+            -d "{\"id\":\"${CLOUDTEMPLE_CLIENT_ID}\",\"secret\":\"${CLOUDTEMPLE_SECRET_ID}\"}" 2>/dev/null)"
+    # list_probe <path> <exact-json-name> → "present" | "absent" | "unavailable".
+    # The pattern is the EXACT quoted JSON name, so the VM name does not falsely match
+    # the "<name>-data" disk and vice versa.
+    list_probe() {
+      local path="$1" pat="$2" bf="$work/.list.json" code crc
+      code="$(curl -ksS --max-time 30 -o "$bf" -w '%{http_code}' -A "" -H 'Accept:' \
+               -H "Authorization: Bearer $tok" "https://${CT_TEST_HOST}${path}" 2>/dev/null)"; crc=$?
+      if [ "$crc" -ne 0 ] || [ "$code" != "200" ] || [ "$(head -c1 "$bf" 2>/dev/null)" != "[" ]; then
+        echo unavailable; return
+      fi
+      grep -qF "$pat" "$bf" && { echo present; return; } # -F: exact string, not a regex
+      echo absent
+    }
+    # probe_one <path> <label> <exact-json-name>: FAIL on present, note skipped on inconclusive.
+    probe_one() {
+      local res; res="$(list_probe "$1" "$3")"
+      case "$res" in
+        present) echo ">>   FAIL — $2 orphan ($3) STILL PRESENT in $1" >&2; orphan_found=1 ;;
+        absent)  echo ">>   smoke: no $2 orphan in $1" ;;
+        *)       echo ">>   smoke: $1 inconclusive (skipped — not proof of absence)" >&2; smoke_skipped=1 ;;
+      esac
+    }
+    case "$tok" in
+      eyJ*)
+        probe_one /api/compute/v1/open_iaas/virtual_machines "VM" "\"$run_name\""
+        probe_one /api/compute/v1/open_iaas/virtual_disks "data-disk" "\"${run_name}-data\"" ;;
+      *) echo ">>   smoke check skipped (could not authenticate)" >&2; smoke_skipped=1 ;;
+    esac
+
+    if [ "$lifecycle_fail" -ne 0 ] || [ "$destroy_rc" -ne 0 ] || [ "$orphan_found" -ne 0 ]; then
+      echo ">> FAIL (lifecycle=$lifecycle_fail destroy=$destroy_rc orphan=$orphan_found)$([ "$destroy_rc" -ne 0 ] && echo ' — DESTROY FAILED, CHECK FOR ORPHANS')" >&2
       exit 1
     fi
-    echo ">> OK (apply + destroy both clean)"
+    echo ">> OK (apply + convergence$([ "$has_power" -eq 1 ] && echo ' + stop/start cycle') + destroy clean; no orphan found in trusted listings$([ "$smoke_skipped" -ne 0 ] && echo ' — some smoke probes inconclusive'))"
     exit 0
   )
 }

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -199,15 +199,21 @@ EOF
         terraform apply -auto-approve -input=false -var "vm_name=$run_name" || { echo ">> [$label] FAIL: apply" >&2; return 1; }
       fi
       echo ">> [$label] convergence (plan must be empty)..."
+      # Capture the plan so a non-empty/errored plan can be SHOWN — a bare "drift
+      # detected" with no diff is not actionable.
+      local planout; planout="$(mktemp)"
       if [ -n "$power" ]; then
-        terraform plan -detailed-exitcode -input=false -var "vm_name=$run_name" -var "vm_power_state=$power" >/dev/null
+        terraform plan -detailed-exitcode -no-color -input=false -var "vm_name=$run_name" -var "vm_power_state=$power" >"$planout" 2>&1
       else
-        terraform plan -detailed-exitcode -input=false -var "vm_name=$run_name" >/dev/null
+        terraform plan -detailed-exitcode -no-color -input=false -var "vm_name=$run_name" >"$planout" 2>&1
       fi
-      case $? in
-        0) echo ">> [$label] OK — convergent (no drift)"; return 0 ;;
-        2) echo ">> [$label] FAIL — drift detected (plan not empty)" >&2; return 1 ;;
-        *) echo ">> [$label] FAIL — plan errored" >&2; return 1 ;;
+      local plan_rc=$?
+      case $plan_rc in
+        0) echo ">> [$label] OK — convergent (no drift)"; rm -f "$planout"; return 0 ;;
+        2) echo ">> [$label] FAIL — drift detected (plan not empty); the drifting plan:" >&2
+           sed 's/^/   | /' "$planout" >&2; rm -f "$planout"; return 1 ;;
+        *) echo ">> [$label] FAIL — plan errored:" >&2
+           sed 's/^/   | /' "$planout" >&2; rm -f "$planout"; return 1 ;;
       esac
     }
 


### PR DESCRIPTION
Refs #316

Adds a **real-Terraform** validation path to `ct-validate`, alongside the existing API path. First scenario: the OpenIaaS `vm` full lifecycle, exercised through the actual provider.

## What `scripts/ct-test.sh tf vm` does

Deploy an **Ubuntu VM from the marketplace** → attach a **data disk** → **start → stop → restart**, with a **convergence check** (empty `terraform plan`) after every step, then a **clean destroy**:

```
create+start → plan(empty) → stop → plan(empty) → restart → plan(empty) → destroy
```

```bash
CT_ENV_OPENIAAS=/path/.env.recette-openiaas scripts/ct-test.sh tf vm
```

The convergence check (no permanent drift after apply) is the value of the TF path over the raw API; the API path tests create/read/delete, the TF path adds **convergence** and **teardown** as Terraform sees them.

## Pipeline safety

- **Local provider** via a generated `dev_overrides` CLI config (uses *this* checkout's provider, not a registry release; no `init`).
- **Isolated workdir** (`mktemp -d`): no `terraform.tfstate` ever persists in the repo, so a prior failed run can't contaminate the next (the run-unique `vm_name` guards the remote object; the isolated state guards the local one).
- **Teardown net** (EXIT + INT/TERM traps): always destroys (idempotent; `.destroyed` is marked only on success, so a failed destroy is retried) and removes the workdir — never leaves orphans, even on Ctrl-C.
- **Post-destroy orphan smoke check** (one-directional, FAIL-only): scans the live OpenIaaS listings for the run-named VM and data disk, trusting only a complete HTTP-200 JSON-array listing (auth fail / non-200 / partial → inconclusive, never read as "absent"). It can only FAIL a run (orphan found); it never claims "proven clean" — the destroy (provider delete+wait) is the primary removal proof.

## Config (`examples/ct-test/vm/`)

Substrate (availability zone, storage repository, network, backup policy) is **discovered dynamically** (no hard-coded tenant ids), mirroring the API cycle. Only the Ubuntu marketplace image name is a tunable variable (catalogs differ); cpu/memory are tunable for the image's minimums. `terraform validate` passes against the locally-built provider.

## Scope / follow-ups

- Live `apply`/`destroy` runs create real recette resources — gated behind a human.
- A rigorous independent absence proof (the Go client's `ListStrict` by id, incl. the VM's OS-disk / network-adapter sub-objects) is a documented follow-up; the shell smoke check covers the run-named VM + data disk.
- Other scenarios (vpc, storage, vm-vmware) will get their `examples/ct-test/<scenario>/` next.

## Review

Implemented against the verified provider schemas; the pipeline passed an independent adversarial diff review across 6 rounds (state isolation, teardown net, convergence, verifier rigor, data-disk matching), ending GO. `terraform validate` / `bash -n` / `terraform fmt -check` all clean.
