### PR TITLE
fix(#339): client read resilience — per-request HTTP timeout + bounded retry on transient read errors

### DIFF
--- a/internal/client/activity_unit_test.go
+++ b/internal/client/activity_unit_test.go
@@ -217,6 +217,21 @@ func TestIsTransientAPIError(t *testing.T) {
 	if !isTransientAPIError(fmt.Errorf("wrapped: %w", StatusError{Code: http.StatusBadGateway})) {
 		t.Fatal("wrapped transient StatusError must stay transient")
 	}
+	if !isTransientAPIError(&url.Error{Op: "Get", URL: "https://shiva.example", Err: errors.New("connection reset")}) {
+		t.Fatal("a non-timeout transport error (connection reset) must stay transient")
+	}
+	// A CONFIGURED request timeout (or ctx deadline/cancel) must NOT be transient:
+	// retrying it in a waiter would multiply the per-request bound into a
+	// multi-minute stall (issue #339).
+	if isTransientAPIError(&url.Error{Op: "Get", URL: "https://shiva.example", Err: timeoutErr{}}) {
+		t.Fatal("a configured request timeout must NOT be transient")
+	}
+	if isTransientAPIError(context.DeadlineExceeded) {
+		t.Fatal("a context deadline must not be transient")
+	}
+	if isTransientAPIError(context.Canceled) {
+		t.Fatal("a context cancellation must not be transient")
+	}
 }
 
 func TestIsTransientActivityFailure(t *testing.T) {

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -26,6 +26,27 @@ const (
 	HTTPSchemeEnvName       = "CLOUDTEMPLE_HTTP_SCHEME"
 	HTTPClientIDEnvName     = "CLOUDTEMPLE_CLIENT_ID"
 	HTTPClientSecretEnvName = "CLOUDTEMPLE_SECRET_ID"
+	HTTPTimeoutEnvName      = "CLOUDTEMPLE_HTTP_TIMEOUT"
+)
+
+const (
+	// defaultHTTPTimeout bounds each HTTP request (dial + headers + body read).
+	// It is a safety guard: without it a slow/stuck endpoint hangs a read with no
+	// client-side bound. Generous on purpose so it never regresses a legitimately
+	// slow request, while still cutting an unbounded hang. Override with
+	// CLOUDTEMPLE_HTTP_TIMEOUT (seconds).
+	defaultHTTPTimeout = 240 * time.Second
+
+	// defaultReadRetryMax is the total number of attempts for an idempotent GET
+	// read (and the auth POST): 1 = no retry. It lets the provider absorb the rare
+	// intermittent transient error (e.g. an upstream 502) instead of failing a
+	// whole plan/apply on the first one.
+	defaultReadRetryMax = 3
+
+	// defaultReadRetryBackoffBase / readRetryBackoffMax bound the wait between
+	// read retries (capped exponential: base, 2*base, ... up to the max).
+	defaultReadRetryBackoffBase = 500 * time.Millisecond
+	readRetryBackoffMax         = 5 * time.Second
 )
 
 type Config struct {
@@ -41,6 +62,19 @@ type Config struct {
 
 	ClientID, SecretID string
 
+	// HTTPTimeout bounds each HTTP request. 0 means "use the default"
+	// (defaultHTTPTimeout); NewClient applies it to the http.Client it builds, and
+	// to a caller-supplied HttpClient that has no timeout of its own, so every
+	// client carries the hang guard regardless of how Config was created.
+	HTTPTimeout time.Duration
+
+	// ReadRetryMax is the total number of attempts for an idempotent GET read (and
+	// the auth POST), 1 meaning no retry. DefaultConfig sets it; a zero value
+	// disables retry. It is intentionally NOT backfilled by NewClient, so only a
+	// DefaultConfig-derived (production) client retries transient read failures — a
+	// minimal/bare Config{} keeps single-shot, deterministic behaviour.
+	ReadRetryMax int
+
 	// this parameter will only be used during the tests and not exposed to
 	// clients
 	ErrorOnUnexpectedActivity bool
@@ -48,13 +82,24 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	config := &Config{
-		Address:   "shiva.cloud-temple.com",
-		Scheme:    "https",
-		Transport: cleanhttp.DefaultPooledTransport(),
+		Address:      "shiva.cloud-temple.com",
+		Scheme:       "https",
+		Transport:    cleanhttp.DefaultPooledTransport(),
+		HTTPTimeout:  defaultHTTPTimeout,
+		ReadRetryMax: defaultReadRetryMax,
 	}
 
 	if addr := os.Getenv(HTTPAddrEnvName); addr != "" {
 		config.Address = addr
+	}
+
+	// CLOUDTEMPLE_HTTP_TIMEOUT overrides the per-request timeout, in seconds. A
+	// missing, non-numeric or non-positive value keeps the default (fail-safe):
+	// the timeout is a guard, so we never let a bad env value disable it.
+	if v := os.Getenv(HTTPTimeoutEnvName); v != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && secs > 0 {
+			config.HTTPTimeout = time.Duration(secs) * time.Second
+		}
 	}
 
 	if scheme := os.Getenv(HTTPSchemeEnvName); scheme != "" {
@@ -84,6 +129,14 @@ type Client struct {
 	config Config
 
 	UserAgent string
+
+	// readRetryMax / readRetryBackoffBase tune the bounded retry of idempotent GET
+	// reads and the auth POST (see doWithRetry). readRetryMax is carried from
+	// Config.ReadRetryMax (0 => no retry); readRetryBackoffBase is set from the
+	// constant default. Both are unexported so in-package tests can drive the retry
+	// path deterministically (small/zero backoff, explicit attempt count).
+	readRetryMax         int
+	readRetryBackoffBase time.Duration
 }
 
 func NewClient(config *Config) (*Client, error) {
@@ -101,11 +154,22 @@ func NewClient(config *Config) (*Client, error) {
 	if config.Scheme == "" {
 		config.Scheme = defConfig.Scheme
 	}
+	// Backfill the per-request timeout for every client (the hang guard must not
+	// depend on how Config was built). ReadRetryMax is deliberately NOT backfilled:
+	// retry stays opt-in via DefaultConfig (see Config.ReadRetryMax).
+	if config.HTTPTimeout <= 0 {
+		config.HTTPTimeout = defConfig.HTTPTimeout
+	}
 
 	if config.HttpClient == nil {
 		config.HttpClient = &http.Client{
 			Transport: config.Transport,
+			Timeout:   config.HTTPTimeout,
 		}
+	} else if config.HttpClient.Timeout <= 0 {
+		// A caller-supplied client without its own timeout still gets the hang
+		// guard; an explicit non-zero timeout is left untouched.
+		config.HttpClient.Timeout = config.HTTPTimeout
 	}
 
 	parts := strings.SplitN(config.Address, "://", 2)
@@ -114,7 +178,11 @@ func NewClient(config *Config) (*Client, error) {
 		config.Address = parts[1]
 	}
 
-	return &Client{config: *config}, nil
+	return &Client{
+		config:               *config,
+		readRetryMax:         config.ReadRetryMax,
+		readRetryBackoffBase: defaultReadRetryBackoffBase,
+	}, nil
 }
 
 type request struct {
@@ -232,7 +300,16 @@ func (c *Client) JWT(ctx context.Context) (*jwt.Token, error) {
 		"id":     c.config.ClientID,
 		"secret": c.config.SecretID,
 	}
-	resp, err := c.doRequestWithToken(ctx, r, "")
+	// Retry the auth POST narrowly on transient failures. It is idempotent here
+	// (it returns a token; it creates nothing), so it is safe to replay. r.body is
+	// reset to nil before each attempt because toHTTP encodes r.obj into r.body
+	// only once — without the reset a retry would resend an already-consumed body.
+	// Running under c.lock, this also prevents a re-auth storm from concurrent
+	// callers (they queue behind the single in-flight auth).
+	resp, err := c.doWithRetry(ctx, func() (*http.Response, error) {
+		r.body = nil
+		return c.doRequestWithToken(ctx, r, "")
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +358,22 @@ func (c *Client) Token(ctx context.Context) (*LoginToken, error) {
 
 }
 
+// doRequest performs an authenticated request. Idempotent GET reads are retried
+// on transient failures (see doWithRetry) so a slow/flaky API does not fail a
+// whole plan/apply on the first intermittent error. Non-GET requests (writes,
+// which may already have triggered an async activity via the Location header)
+// are sent exactly once — retrying them could double-create.
 func (c *Client) doRequest(ctx context.Context, r *request) (*http.Response, error) {
+	if r.method == http.MethodGet {
+		return c.doWithRetry(ctx, func() (*http.Response, error) {
+			return c.doRequestOnce(ctx, r)
+		})
+	}
+	return c.doRequestOnce(ctx, r)
+}
+
+// doRequestOnce performs a single authenticated request, with no retry.
+func (c *Client) doRequestOnce(ctx context.Context, r *request) (*http.Response, error) {
 	token, err := c.JWT(ctx)
 	if err != nil {
 		return nil, err
@@ -296,6 +388,134 @@ func (c *Client) doRequest(ctx context.Context, r *request) (*http.Response, err
 	}
 
 	return resp, nil
+}
+
+// doWithRetry runs send up to c.readRetryMax times (1 => no retry), retrying a
+// transient status (429 / 5xx, after draining the response body so the keep-alive
+// connection is reused) or a retryable transport error, with a bounded backoff
+// that honours Retry-After on 429. It NEVER retries a configured request timeout,
+// a context error, a 4xx or a decode error — those are returned at once. The last
+// attempt's result is handed to the caller, which validates the FINAL response
+// (requireOK / requireNotFoundOrOK) and decodes it. The caller guarantees send is
+// idempotent (a GET, or the auth POST whose body is rebuilt each attempt).
+func (c *Client) doWithRetry(ctx context.Context, send func() (*http.Response, error)) (*http.Response, error) {
+	attempts := c.readRetryMax
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var (
+		resp *http.Response
+		err  error
+	)
+	for attempt := 0; attempt < attempts; attempt++ {
+		resp, err = send()
+
+		if attempt == attempts-1 {
+			return resp, err // budget exhausted: the caller validates the final result
+		}
+
+		switch {
+		case err != nil:
+			if !retryableTransportError(err) {
+				return resp, err
+			}
+			if !c.waitBeforeRetry(ctx, attempt, 0) {
+				return nil, ctx.Err()
+			}
+		case resp != nil && transientStatus(resp.StatusCode):
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			// Drain+close the failed response before retrying so net/http can reuse
+			// the connection instead of opening a new one against a struggling gateway.
+			closeResponseBody(resp)
+			if !c.waitBeforeRetry(ctx, attempt, retryAfter) {
+				return nil, ctx.Err()
+			}
+		default:
+			return resp, err // success or a non-retryable status: let the caller handle it
+		}
+	}
+	return resp, err
+}
+
+// waitBeforeRetry sleeps the backoff for the just-failed attempt (or Retry-After,
+// capped), honouring ctx. It returns false if ctx is cancelled during the wait.
+func (c *Client) waitBeforeRetry(ctx context.Context, attempt int, retryAfter time.Duration) bool {
+	wait := c.readRetryBackoff(attempt)
+	if retryAfter > 0 {
+		if retryAfter > readRetryBackoffMax {
+			retryAfter = readRetryBackoffMax
+		}
+		wait = retryAfter
+	}
+	if wait <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// readRetryBackoff is the bounded wait before the retry following the 0-based
+// failed attempt: a capped exponential (base, 2*base, 4*base, ... up to the max).
+func (c *Client) readRetryBackoff(attempt int) time.Duration {
+	base := c.readRetryBackoffBase
+	if base <= 0 {
+		return 0
+	}
+	d := base << attempt
+	if d <= 0 || d > readRetryBackoffMax { // d<=0 guards a shift overflow on a large attempt
+		d = readRetryBackoffMax
+	}
+	return d
+}
+
+// transientStatus reports whether an HTTP status is worth retrying for an
+// idempotent request: rate limiting (429) or a server-side error (5xx, including
+// the 502 the upstream gateway emits intermittently).
+func transientStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+// retryableTransportError reports whether a transport-level error from an
+// idempotent request is worth retrying. It deliberately EXCLUDES timeouts (the
+// configured per-request http.Client.Timeout, or a ctx deadline) and context
+// cancellation: retrying a configured timeout would multiply the anti-hang bound
+// into a multi-minute stall. Remaining transport failures (connection reset,
+// unexpected EOF, connection refused, ...) are transient and retried.
+func retryableTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		// A configured per-request timeout / deadline reports Timeout() == true and
+		// must not be retried; any other transport failure is transient.
+		return !urlErr.Timeout()
+	}
+	return false
+}
+
+// parseRetryAfter parses a Retry-After header expressed in delta-seconds. The
+// HTTP-date form is intentionally ignored (best-effort). Returns 0 when the header
+// is absent or not a positive integer.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return 0
 }
 
 func (c *Client) doRequestAndReturnActivity(ctx context.Context, r *request) (string, error) {
@@ -379,16 +599,19 @@ func (e StatusError) Error() string {
 }
 
 // isTransientAPIError reports whether an error is worth retrying: throttling
-// (429), server-side errors (5xx) or transport-level failures (timeouts,
-// connection resets). Authentication, authorization and decoding errors are
-// permanent and must not be retried.
+// (429), server-side errors (5xx) or a transient transport failure (connection
+// reset, unexpected EOF, ...). A CONFIGURED request timeout (http.Client.Timeout)
+// or a context deadline/cancellation is NOT transient — retrying it would
+// multiply the per-request bound into a multi-minute stall — and neither are
+// authentication, authorization or decoding errors. Shared by the read-retry
+// helper (doWithRetry) and the activity/backup waiters so the timeout doctrine
+// stays uniform across the client.
 func isTransientAPIError(err error) bool {
 	var statusErr StatusError
 	if errors.As(err, &statusErr) {
 		return statusErr.Code == http.StatusTooManyRequests || statusErr.Code >= 500
 	}
-	var urlErr *url.Error
-	return errors.As(err, &urlErr)
+	return retryableTransportError(err)
 }
 
 // generateUnexpectedResponseCodeError consumes the rest of the body, closes

--- a/internal/client/api_resilience_test.go
+++ b/internal/client/api_resilience_test.go
@@ -1,0 +1,328 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// resp builds a minimal *http.Response with a readable body, as doWithRetry's
+// drain path (closeResponseBody) requires a non-nil Body.
+func resp(code int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// timeoutErr is a net error whose Timeout() == true, as produced (wrapped in a
+// *url.Error) when http.Client.Timeout fires.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string { return "request timeout" }
+func (timeoutErr) Timeout() bool { return true }
+
+// --- doWithRetry: the retry loop in isolation (deterministic, no network) -----
+
+func TestDoWithRetryRetriesTransientStatusThenSucceeds(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: 0}
+	var calls int32
+	r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return resp(http.StatusBadGateway, "upstream"), nil // intermittent 502
+		}
+		return resp(http.StatusOK, "[]"), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, r.StatusCode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "a transient 502 must be retried, then succeed")
+}
+
+func TestDoWithRetryRetriesTransportErrorThenSucceeds(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: 0}
+	var calls int32
+	r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return nil, &url.Error{Op: "Get", URL: "http://x", Err: errors.New("connection reset by peer")}
+		}
+		return resp(http.StatusOK, "[]"), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, r.StatusCode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "a non-timeout transport error must be retried")
+}
+
+func TestDoWithRetryStopsAfterReadRetryMax(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: 0}
+	var calls int32
+	r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return resp(http.StatusInternalServerError, "boom"), nil
+	})
+	// doWithRetry hands the final response to the caller (requireOK turns it into
+	// an error); the point here is the retry is BOUNDED and fails closed.
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, r.StatusCode)
+	require.Equal(t, int32(3), atomic.LoadInt32(&calls), "a persistent 5xx must stop after exactly readRetryMax attempts")
+}
+
+func TestDoWithRetryDoesNotRetryConfiguredTimeout(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: 0}
+	var calls int32
+	r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, &url.Error{Op: "Get", URL: "http://x", Err: timeoutErr{}}
+	})
+	require.Error(t, err)
+	require.Nil(t, r)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "a configured request timeout must NOT be retried (no multi-minute stall)")
+}
+
+func TestDoWithRetryDoesNotRetry4xx(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: 0}
+	for _, code := range []int{http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound, http.StatusConflict} {
+		var calls int32
+		r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+			atomic.AddInt32(&calls, 1)
+			return resp(code, ""), nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, code, r.StatusCode)
+		require.Equal(t, int32(1), atomic.LoadInt32(&calls), "a %d is definitive and must never be retried", code)
+	}
+}
+
+func TestDoWithRetryDisabledMakesSingleAttempt(t *testing.T) {
+	// A bare Config{} leaves ReadRetryMax == 0 (retry opt-in via DefaultConfig).
+	c := &Client{readRetryMax: 0, readRetryBackoffBase: 0}
+	var calls int32
+	r, err := c.doWithRetry(context.Background(), func() (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return resp(http.StatusBadGateway, ""), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadGateway, r.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "retry disabled must preserve single-shot behaviour")
+}
+
+func TestDoWithRetryHonorsContextCancellationDuringBackoff(t *testing.T) {
+	c := &Client{readRetryMax: 3, readRetryBackoffBase: time.Hour} // long backoff so ctx wins
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	var calls int32
+	_, err := c.doWithRetry(ctx, func() (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return resp(http.StatusBadGateway, ""), nil
+	})
+	require.Error(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "a cancelled context must abort before a second attempt")
+}
+
+func TestRetryableTransportError(t *testing.T) {
+	require.False(t, retryableTransportError(nil))
+	require.False(t, retryableTransportError(&url.Error{Err: timeoutErr{}}), "configured timeout is not retryable")
+	require.False(t, retryableTransportError(context.Canceled))
+	require.False(t, retryableTransportError(context.DeadlineExceeded))
+	require.True(t, retryableTransportError(&url.Error{Err: errors.New("connection reset by peer")}))
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	require.Equal(t, time.Duration(0), parseRetryAfter(""))
+	require.Equal(t, time.Duration(0), parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")) // HTTP-date ignored (best-effort)
+	require.Equal(t, time.Duration(0), parseRetryAfter("0"))
+	require.Equal(t, 3*time.Second, parseRetryAfter("3"))
+}
+
+// --- end-to-end through doRequest / NewClient (real http server) --------------
+
+// newRetryTestClient builds a client against an httptest server with retry
+// ENABLED and zero backoff, and a pre-seeded token so JWT does not hit the server.
+func newRetryTestClient(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := NewClient(&Config{Address: srv.URL})
+	require.NoError(t, err)
+	c.SavedToken = &jwt.Token{Claims: jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}}
+	c.readRetryMax = 3
+	c.readRetryBackoffBase = 0
+	return c, srv
+}
+
+func TestDoRequestRetriesGETButNotWrites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("GET retried on 502 then succeeds", func(t *testing.T) {
+		var calls int32
+		c, _ := newRetryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		})
+		r, err := c.doRequest(ctx, c.newRequest("GET", "/compute/v1/open_iaas"))
+		require.NoError(t, err)
+		defer closeResponseBody(r)
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+	})
+
+	t.Run("POST not retried (idempotency guard for writes)", func(t *testing.T) {
+		var calls int32
+		c, _ := newRetryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.WriteHeader(http.StatusBadGateway)
+		})
+		r, err := c.doRequest(ctx, c.newRequest("POST", "/some/write"))
+		require.NoError(t, err) // no transport error; the 502 response is handed back
+		defer closeResponseBody(r)
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+		require.Equal(t, int32(1), atomic.LoadInt32(&calls), "a write must be sent exactly once")
+	})
+}
+
+func TestNewClientAppliesHTTPTimeout(t *testing.T) {
+	t.Run("default applied for a bare Config", func(t *testing.T) {
+		c, err := NewClient(&Config{Address: "example.test"})
+		require.NoError(t, err)
+		require.Equal(t, defaultHTTPTimeout, c.config.HttpClient.Timeout)
+	})
+	t.Run("explicit Config.HTTPTimeout honored", func(t *testing.T) {
+		c, err := NewClient(&Config{Address: "example.test", HTTPTimeout: 7 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, 7*time.Second, c.config.HttpClient.Timeout)
+	})
+}
+
+func TestDefaultConfigReadsHTTPTimeoutEnv(t *testing.T) {
+	t.Run("unset keeps default", func(t *testing.T) {
+		t.Setenv(HTTPTimeoutEnvName, "")
+		require.Equal(t, defaultHTTPTimeout, DefaultConfig().HTTPTimeout)
+	})
+	t.Run("valid seconds honored", func(t *testing.T) {
+		t.Setenv(HTTPTimeoutEnvName, "30")
+		require.Equal(t, 30*time.Second, DefaultConfig().HTTPTimeout)
+	})
+	t.Run("non-numeric keeps default (fail-safe)", func(t *testing.T) {
+		t.Setenv(HTTPTimeoutEnvName, "not-a-number")
+		require.Equal(t, defaultHTTPTimeout, DefaultConfig().HTTPTimeout)
+	})
+	t.Run("non-positive keeps default (fail-safe)", func(t *testing.T) {
+		t.Setenv(HTTPTimeoutEnvName, "0")
+		require.Equal(t, defaultHTTPTimeout, DefaultConfig().HTTPTimeout)
+		t.Setenv(HTTPTimeoutEnvName, "-5")
+		require.Equal(t, defaultHTTPTimeout, DefaultConfig().HTTPTimeout)
+	})
+}
+
+func TestHTTPTimeoutFiresFastAndIsNotRetried(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		// Return as soon as the client gives up (timeout) so srv.Close does not block.
+		select {
+		case <-time.After(5 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(&Config{Address: srv.URL, HTTPTimeout: 100 * time.Millisecond})
+	require.NoError(t, err)
+	c.SavedToken = &jwt.Token{Claims: jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}}
+	c.readRetryMax = 3
+	c.readRetryBackoffBase = 0
+
+	start := time.Now()
+	_, err = c.doRequest(context.Background(), c.newRequest("GET", "/slow"))
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a stuck endpoint must fail, not hang")
+	require.Less(t, elapsed, 2*time.Second, "must fail fast at the timeout, not wait for the slow handler")
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "a configured timeout must not be retried")
+}
+
+func TestJWTRetriesAuthAndRebuildsBody(t *testing.T) {
+	var calls int32
+	var mu sync.Mutex
+	var bodies []string
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())})
+	signed, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(b))
+		mu.Unlock()
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway) // transient auth failure
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(signed))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(&Config{Address: srv.URL, ClientID: "id-x", SecretID: "sec-y"})
+	require.NoError(t, err)
+	c.readRetryMax = 3
+	c.readRetryBackoffBase = 0
+
+	token, err := c.JWT(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "the auth POST must be retried on a transient failure")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2)
+	// The crux: the retried request must carry the credentials again — toHTTP
+	// consumes r.obj into r.body only once, so without resetting r.body the replay
+	// would send an empty body.
+	require.Contains(t, bodies[0], "sec-y")
+	require.Contains(t, bodies[1], "sec-y", "the rebuilt retry body must still carry the credentials, not an empty/consumed body")
+}
+
+// --- the timeout doctrine is uniform across the client (waiters too) ----------
+
+// TestActivityWaitDoesNotRetryConfiguredTimeout pins the systemic guarantee: the
+// activity waiter (which polls a read in a retry loop via isTransientAPIError)
+// must NOT retry a configured request timeout — otherwise the new per-request
+// timeout would be multiplied into a multi-minute stall.
+func TestActivityWaitDoesNotRetryConfiguredTimeout(t *testing.T) {
+	calls := 0
+	timeout := &url.Error{Op: "Get", URL: "https://shiva.example", Err: timeoutErr{}}
+	read := scriptedReads(&calls, readOutcome{err: timeout})
+	_, err := waitForActivityCompletion(context.Background(), "act-1", read, immediateBackoff(50), nil)
+	require.Error(t, err, "a configured timeout must fail the wait, not be retried")
+	require.Equal(t, 1, calls, "a configured request timeout is not retried by the activity waiter")
+}
+
+func TestNewClientAppliesTimeoutToProvidedClient(t *testing.T) {
+	t.Run("a provided client without a timeout gets the guard", func(t *testing.T) {
+		c, err := NewClient(&Config{Address: "example.test", HttpClient: &http.Client{}})
+		require.NoError(t, err)
+		require.Equal(t, defaultHTTPTimeout, c.config.HttpClient.Timeout)
+	})
+	t.Run("a provided client with its own timeout is left untouched", func(t *testing.T) {
+		c, err := NewClient(&Config{Address: "example.test", HttpClient: &http.Client{Timeout: 9 * time.Second}})
+		require.NoError(t, err)
+		require.Equal(t, 9*time.Second, c.config.HttpClient.Timeout)
+	})
+}

--- a/internal/client/backup_job.go
+++ b/internal/client/backup_job.go
@@ -123,7 +123,16 @@ func (c *BackupJobClient) WaitForCompletion(ctx context.Context, id string, opti
 		count++
 		job, err := c.Read(ctx, id)
 		if err != nil {
-			return options.retryableError(&BackupJobCompletionError{
+			// Only a transient read error is worth retrying. A configured request
+			// timeout, a context error or a permanent error (4xx, decode) must fail
+			// the wait at once — retrying a timeout here would stall for minutes.
+			if isTransientAPIError(err) {
+				return options.retryableError(&BackupJobCompletionError{
+					message: fmt.Sprintf("transient error while getting job %q status: %s", id, err),
+					job:     job,
+				})
+			}
+			return options.error(&BackupJobCompletionError{
 				message: fmt.Sprintf("an error occured while getting job %q status: %s", id, err),
 				job:     job,
 			})

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -1,6 +1,6 @@
 # Per-package statement-coverage floor (percent) for the pure packages.
 # Raised as coverage improves (scripts/coverage_ratchet.sh --update);
 # CI fails if coverage drops below these values. Never lower by hand.
-internal/client 18.5
+internal/client 21.0
 internal/provider 13.4
 internal/provider/helpers 68.1


### PR DESCRIPTION
## Refs #339

A slow or intermittently-failing API made the provider **hang** (no per-request timeout) or **fail a whole `plan`/`apply` on a single transient upstream `502`** (no retry on reads). When the same API is exercised by the internal `ct-validate` harness (same Go client) it reports ~99.6–100% OK because the harness retries; the provider had no equivalent read resilience, so a rare intermittent `502` deterministically broke a plan and a slow endpoint hung unbounded (a `GET /backup/v1/open_iaas/policies` was observed hanging ~3 min).

## Change (`internal/client`)

- **Per-request timeout** — `NewClient` builds the `http.Client` with a `Timeout`, default **240s**, overridable via `CLOUDTEMPLE_HTTP_TIMEOUT` (seconds; fail-safe parse keeps the default on a bad value). Applied to every client it builds **and** to a caller-supplied `HttpClient` that has no timeout of its own, so the hang guard is universal. Converts an unbounded hang into a fast, clear failure.
- **Bounded retry on idempotent GET reads** — a dedicated `doWithRetry` helper (not the shared request path) retries `429`/`5xx` and non-timeout transport errors, draining failed response bodies before each retry. Defaults: 3 attempts, capped-exponential backoff, `Retry-After` honoured on `429`. It **never** retries a configured request timeout, a context error, or a `4xx` (incl. `404`) — those fail closed. **Writes (non-GET) are sent exactly once** (a write may already have started an async activity).
- **Auth POST retry** — retried narrowly inside `JWT` (under the existing mutex, so no re-auth storm; request body rebuilt each attempt), so a transient auth blip does not break every read.
- **Uniform timeout doctrine** — `isTransientAPIError` (the shared classifier used by the activity and backup-job waiters) now **excludes configured timeouts**, so a timed-out poll is no longer retried into a multi-minute stall; `BackupJob.WaitForCompletion` now gates its read-error retry on it (was: retry every error).

Retry is enabled only for a `DefaultConfig`-derived (production) client; a bare `Config{}` keeps single-shot behaviour, so existing unit tests are unchanged.

## Tests (mutation-proven)

`GET 502→200` succeeds; persistent `5xx` is bounded to the attempt budget; a configured timeout and `4xx` are never retried; the auth retry replays the credentials body (not an empty/consumed body); the `http.Client` timeout fires fast; the activity waiter does not retry a timeout. Mutations exercised and verified RED-without-fix: removing the auth body reset; classifying timeouts as retryable (both `doWithRetry` and `isTransientAPIError`).

Gates: `gofmt`, `go vet`, `staticcheck` (clean), `go test ./internal/client -race`, coverage ratchet (**internal/client 18.5% → 21.0%**), `make build`.

## Scope / follow-ups

- The `JWT()` `(nil, nil)`-on-read-error latent nil-pointer is tracked separately in #340 (intentionally not touched here).
- Backoff has no jitter yet (acceptable for 3 attempts; a possible hardening for synchronized retry bursts under high parallelism).
- Pre-existing/adjacent: the provider network-adapter connect/disconnect loops carry a "retry until timeout" comment but return raw errors (so `go-retry` does not actually retry them) — a misleading comment, not in scope here.
