### PR TITLE
fix(#340): JWT — fail closed on auth read/parse error, never cache a bad token

### DIFF
--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -318,15 +318,22 @@ func (c *Client) JWT(ctx context.Context) (*jwt.Token, error) {
 		return nil, err
 	}
 
-	bytes, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil
+		// Surface the read failure (fail closed) instead of returning a nil token
+		// with no error — the caller would dereference token.Raw and panic.
+		return nil, fmt.Errorf("failed to read authentication response: %w", err)
 	}
 
-	token, _, err := new(jwt.Parser).ParseUnverified(string(bytes), jwt.MapClaims{})
+	token, _, err := new(jwt.Parser).ParseUnverified(string(body), jwt.MapClaims{})
+	if err != nil {
+		// Do NOT cache a partially-parsed token on error: a later cache hit reads
+		// its claims (the "exp" expiry) and would panic on a malformed token.
+		return nil, fmt.Errorf("failed to parse authentication token: %w", err)
+	}
 	c.SavedToken = token
 
-	return token, err
+	return token, nil
 }
 
 type LoginToken struct {

--- a/internal/client/jwt_auth_test.go
+++ b/internal/client/jwt_auth_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubRoundTripper lets a test return a crafted *http.Response for any request,
+// so the JWT auth path can be exercised without a real server.
+type stubRoundTripper struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (s stubRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return s.fn(r) }
+
+// errReadCloser is a response body whose Read always fails — it simulates a
+// connection dropping while the auth response body is being read.
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("simulated body read failure") }
+func (errReadCloser) Close() error             { return nil }
+
+// TestJWTReturnsErrorWhenAuthBodyReadFails pins #340: a failed read of the auth
+// response body must surface as an error (fail closed), never (nil, nil) — which
+// the caller would turn into a nil-pointer panic on token.Raw.
+func TestJWTReturnsErrorWhenAuthBodyReadFails(t *testing.T) {
+	c, err := NewClient(&Config{
+		Address: "https://shiva.example",
+		Transport: stubRoundTripper{fn: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: errReadCloser{}}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		token, err := c.JWT(context.Background())
+		require.Error(t, err, "a failed auth-body read must surface as an error, not (nil, nil)")
+		require.Nil(t, token)
+	})
+	require.Nil(t, c.SavedToken, "a failed read must not cache a token")
+}
+
+// TestJWTReturnsErrorOnUnparseableTokenAndDoesNotCache pins the adjacent defect:
+// on a parse error the partially-parsed token must NOT be cached, otherwise the
+// next cache hit reads its (malformed) claims and panics. "aaa.bbb.ccc" is a
+// 3-segment string whose header fails to decode, so ParseUnverified returns a
+// non-nil token AND an error — the exact shape that the old code cached.
+func TestJWTReturnsErrorOnUnparseableTokenAndDoesNotCache(t *testing.T) {
+	c, err := NewClient(&Config{
+		Address: "https://shiva.example",
+		Transport: stubRoundTripper{fn: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("aaa.bbb.ccc")),
+			}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	token, err := c.JWT(context.Background())
+	require.Error(t, err, "an unparseable auth token must surface as an error")
+	require.Nil(t, token)
+	require.Nil(t, c.SavedToken, "a parse failure must not cache a bad token")
+
+	// With the bad token cached (old behaviour), this second call panics in the
+	// cache-hit branch while reading the malformed claims.
+	require.NotPanics(t, func() { _, _ = c.JWT(context.Background()) })
+}


### PR DESCRIPTION
## Refs #340

`JWT()` mishandled two auth-response error paths, each leading to a panic:

1. **Read error swallowed** — `io.ReadAll` of the auth response body returning an error caused `JWT` to `return nil, nil` (a nil token **with no error**). The caller `doRequestOnce` then dereferenced `token.Raw` → nil-pointer panic.
2. **Bad token cached on parse error** — `c.SavedToken = token` ran unconditionally after `ParseUnverified`, so a malformed 3-segment token (non-nil token + parse error) was cached; the next cache hit read its claims (`["exp"].(float64)`) and panicked.

## Change (`internal/client/api.go`)

- The read error and the parse error are now **returned** (fail closed, with context).
- **No token is cached on error** — only a successfully-parsed token reaches `c.SavedToken`.
- A transient/garbled auth response now surfaces a clear error and lets the next call re-authenticate, instead of crashing.
- Minor: the local `bytes` was renamed `body` (it shadowed the `bytes` package).

## Tests (mutation-proven)

- A body that errors on read → `JWT` returns an error (not `nil, nil`), no panic, no cached token. (RED if `return nil, nil` is restored.)
- A malformed 3-segment token `aaa.bbb.ccc` → `JWT` returns an error, caches nothing, and a second call does not panic. (RED if the unconditional cache is restored.)

Gates: `gofmt`, `go vet`, `staticcheck` (clean), `go test ./internal/client -race`, coverage ratchet, `make build`.

## Follow-up

The cache-hit branch still reads `exp` with unguarded type assertions, so a syntactically valid token lacking a numeric `exp` would panic on the next call. Out of scope here (distinct from the error paths fixed above); tracked in #342.
