### PR TITLE
fix(#342): guard the exp claim in the JWT cache-hit (no panic on a malformed cached token)

### DIFF
--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -287,11 +287,16 @@ func (c *Client) JWT(ctx context.Context) (*jwt.Token, error) {
 	defer c.lock.Unlock()
 
 	if c.SavedToken != nil {
-		expireAt := c.SavedToken.Claims.(jwt.MapClaims)["exp"].(float64)
-		tm := time.Unix(int64(expireAt), 0)
-
-		if time.Until(tm) > 5*time.Minute {
-			return c.SavedToken, nil
+		// Serve the cached token only while it stays valid for at least 5 more
+		// minutes. Read its expiry defensively: a token whose claims are nil, or
+		// whose "exp" is absent or non-numeric, is treated as unusable and falls
+		// through to re-authentication — never panicking on the type assertions.
+		if claims, ok := c.SavedToken.Claims.(jwt.MapClaims); ok {
+			if exp, ok := claims["exp"].(float64); ok {
+				if time.Until(time.Unix(int64(exp), 0)) > 5*time.Minute {
+					return c.SavedToken, nil
+				}
+			}
 		}
 	}
 

--- a/internal/client/jwt_auth_test.go
+++ b/internal/client/jwt_auth_test.go
@@ -6,8 +6,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +75,66 @@ func TestJWTReturnsErrorOnUnparseableTokenAndDoesNotCache(t *testing.T) {
 	// With the bad token cached (old behaviour), this second call panics in the
 	// cache-hit branch while reading the malformed claims.
 	require.NotPanics(t, func() { _, _ = c.JWT(context.Background()) })
+}
+
+// signedJWT builds a parseable JWT carrying the given claims.
+func signedJWT(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	s, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return s
+}
+
+// authStub returns a transport that answers every request with a 200 carrying a
+// fresh valid token, counting the calls (so a test can assert re-auth happened).
+func authStub(token string, calls *int32) stubRoundTripper {
+	return stubRoundTripper{fn: func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(calls, 1)
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(token))}, nil
+	}}
+}
+
+// TestJWTCacheHitGuardsExpClaim pins #342: the cache-hit branch must read "exp"
+// defensively. A valid far-future token is served from cache; a cached token
+// with nil/empty/non-numeric claims must NOT panic — it falls through to a
+// single re-authentication.
+func TestJWTCacheHitGuardsExpClaim(t *testing.T) {
+	fresh := signedJWT(t, jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())})
+
+	t.Run("far-future exp is served from cache without re-auth", func(t *testing.T) {
+		var calls int32
+		c, err := NewClient(&Config{Address: "https://shiva.example", Transport: authStub(fresh, &calls)})
+		require.NoError(t, err)
+		c.SavedToken = &jwt.Token{Claims: jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())}}
+
+		tok, err := c.JWT(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, tok)
+		require.Equal(t, int32(0), atomic.LoadInt32(&calls), "a valid far-future cached token must be served without re-auth")
+	})
+
+	for _, bc := range []struct {
+		name string
+		tok  *jwt.Token
+	}{
+		{"nil claims", &jwt.Token{}},
+		{"non-MapClaims type", &jwt.Token{Claims: jwt.RegisteredClaims{}}},
+		{"empty claims (no exp)", &jwt.Token{Claims: jwt.MapClaims{}}},
+		{"non-numeric exp", &jwt.Token{Claims: jwt.MapClaims{"exp": "soon"}}},
+	} {
+		bc := bc
+		t.Run("falls through to re-auth without panic on "+bc.name, func(t *testing.T) {
+			var calls int32
+			c, err := NewClient(&Config{Address: "https://shiva.example", Transport: authStub(fresh, &calls)})
+			require.NoError(t, err)
+			c.SavedToken = bc.tok
+
+			require.NotPanics(t, func() {
+				tok, err := c.JWT(context.Background())
+				require.NoError(t, err)
+				require.NotNil(t, tok)
+			})
+			require.Equal(t, int32(1), atomic.LoadInt32(&calls), "an unusable cached token must trigger exactly one re-auth")
+		})
+	}
 }


### PR DESCRIPTION
## Refs #342

The `JWT()` cache-hit branch read the cached token's expiry with **unguarded** type assertions:

```go
expireAt := c.SavedToken.Claims.(jwt.MapClaims)["exp"].(float64)
```

A syntactically valid token whose claims are `nil`, not a `jwt.MapClaims`, or whose `exp` is absent or non-numeric would **panic** there on the next call. (#340 stopped caching a token on a read/parse *error*; this closes the remaining case — a successfully-parsed token without a usable `exp`.)

## Change (`internal/client/api.go`)

Read the expiry with comma-ok assertions: an unusable cached token now **falls through to re-authentication** instead of panicking. A valid far-future token is still served from cache, unchanged.

## Tests (mutation-proven)

`TestJWTCacheHitGuardsExpClaim`: a far-future token is served from cache without re-auth (transport calls = 0); `nil` claims, a non-`MapClaims` type, missing `exp`, and a non-numeric `exp` each fall through to exactly one re-auth without panicking. Restoring the unguarded assertions turns the malformed-claims subtests RED.

Gates: `gofmt`, `go vet`, `staticcheck` (clean), `go test ./internal/client -race`, coverage ratchet (21.1%), `make build`.

With #340 + this change, `JWT()` can no longer panic on a malformed or expired-claim auth token — it fails closed or re-authenticates.
