### PR TITLE
fix(#345): omit empty cloudInit in OpenIaaS create (marketplace/template deploy 400)

### DIFF
--- a/internal/client/cloudinit_test.go
+++ b/internal/client/cloudinit_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenIaasCreateRequestsOmitEmptyCloudInit pins the fix for the empty
+// cloudInit bug: an unset CloudInit must be OMITTED from the request body. The
+// API rejects "cloudInit":{} with "When cloudInit is provided, cloudConfig is
+// required", so a value-typed field (which omitempty cannot drop) breaks every
+// deploy without cloud-init. This test goes RED if the field reverts to a value
+// struct.
+func TestOpenIaasCreateRequestsOmitEmptyCloudInit(t *testing.T) {
+	m, err := json.Marshal(&MarketplaceOpenIaasDeployementRequest{ID: "id", Name: "n", StorageRepositoryID: "sr"})
+	require.NoError(t, err)
+	require.NotContains(t, string(m), "cloudInit", "marketplace deploy must omit an unset cloudInit (not send {})")
+
+	c, err := json.Marshal(&CreateOpenIaasVirtualMachineRequest{Name: "n", TemplateID: "t"})
+	require.NoError(t, err)
+	require.NotContains(t, string(c), "cloudInit", "template create must omit an unset cloudInit (not send {})")
+}
+
+// TestOpenIaasCreateRequestsIncludeCloudInitWhenSet documents the positive path:
+// a configured cloud-init is serialized with its cloudConfig.
+func TestOpenIaasCreateRequestsIncludeCloudInitWhenSet(t *testing.T) {
+	m, err := json.Marshal(&MarketplaceOpenIaasDeployementRequest{
+		ID:        "id",
+		CloudInit: &CloudInit{CloudConfig: "#cloud-config\npackages: [htop]"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(m), `"cloudInit"`)
+	require.Contains(t, string(m), `"cloudConfig"`)
+
+	c, err := json.Marshal(&CreateOpenIaasVirtualMachineRequest{
+		Name:      "n",
+		CloudInit: &CloudInit{CloudConfig: "#cloud-config", NetworkConfig: "version: 2"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(c), `"cloudInit"`)
+	require.Contains(t, string(c), `"networkConfig"`)
+}

--- a/internal/client/compute_iaas_opensource_virtual_machine.go
+++ b/internal/client/compute_iaas_opensource_virtual_machine.go
@@ -78,7 +78,7 @@ type CreateOpenIaasVirtualMachineRequest struct {
 	TemplateID      string             `json:"templateId"`
 	CPU             int                `json:"cpu"`
 	Memory          int                `json:"memory"`
-	CloudInit       CloudInit          `json:"cloudInit,omitempty"`
+	CloudInit       *CloudInit         `json:"cloudInit,omitempty"`
 	NetworkAdapters []OSNetworkAdapter `json:"networkAdapters,omitempty"`
 }
 

--- a/internal/client/marketplace_item.go
+++ b/internal/client/marketplace_item.go
@@ -199,7 +199,7 @@ type MarketplaceOpenIaasDeployementRequest struct {
 	Name                string               `json:"name"`
 	StorageRepositoryID string               `json:"storageRepositoryId"`
 	NetworkData         []NetworkDataMapping `json:"networkData,omitempty"`
-	CloudInit           CloudInit            `json:"cloudInit,omitempty"`
+	CloudInit           *CloudInit           `json:"cloudInit,omitempty"`
 }
 
 func (c *MarketplaceItemClient) DeployOpenIaasItem(ctx context.Context, req *MarketplaceOpenIaasDeployementRequest) (string, error) {

--- a/internal/provider/openiaas_cloudinit_test.go
+++ b/internal/provider/openiaas_cloudinit_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOpenIaasCloudInit pins the cloud-init build logic that feeds the
+// OpenIaaS create payload (#345): omit when unconfigured (so "cloudInit" is not
+// sent as an empty object the API rejects), fail closed when network_config is
+// set without cloud_config, and populate when cloud_config is set.
+func TestBuildOpenIaasCloudInit(t *testing.T) {
+	t.Run("absent (nil map) → nil, no error", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(nil)
+		require.NoError(t, err)
+		require.Nil(t, ci)
+	})
+
+	t.Run("empty map → nil", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(map[string]interface{}{})
+		require.NoError(t, err)
+		require.Nil(t, ci)
+	})
+
+	t.Run("all-empty values → nil", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(map[string]interface{}{"cloud_config": "", "network_config": ""})
+		require.NoError(t, err)
+		require.Nil(t, ci, "an all-empty cloud_init must be omitted, not sent as {}")
+	})
+
+	t.Run("network_config without cloud_config → error, fail closed", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(map[string]interface{}{"network_config": "version: 2"})
+		require.Error(t, err, "cloud_config is required when cloud_init is set; must fail before the API 400")
+		require.Nil(t, ci)
+	})
+
+	t.Run("cloud_config only → populated, no network_config", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(map[string]interface{}{"cloud_config": "#cloud-config"})
+		require.NoError(t, err)
+		require.NotNil(t, ci)
+		require.Equal(t, "#cloud-config", ci.CloudConfig)
+		require.Empty(t, ci.NetworkConfig)
+	})
+
+	t.Run("cloud_config + network_config → populated both", func(t *testing.T) {
+		ci, err := buildOpenIaasCloudInit(map[string]interface{}{"cloud_config": "#cloud-config", "network_config": "version: 2"})
+		require.NoError(t, err)
+		require.NotNil(t, ci)
+		require.Equal(t, "#cloud-config", ci.CloudConfig)
+		require.Equal(t, "version: 2", ci.NetworkConfig)
+	})
+}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -442,21 +442,40 @@ Order of the elements in the list is the boot order.`,
 	}
 }
 
+// buildOpenIaasCloudInit maps the optional cloud_init schema attribute to the
+// client payload. It returns:
+//   - nil when cloud_init is absent, empty, or only carries empty values, so the
+//     "cloudInit" field is OMITTED from the request (the API rejects an empty
+//     cloudInit object with "cloudConfig is required");
+//   - an error when cloud_init is set with a network_config but no cloud_config —
+//     the API requires cloud_config whenever cloudInit is present, so we fail
+//     closed with a clear message instead of forwarding a doomed request;
+//   - a populated *client.CloudInit when cloud_config is set (network_config
+//     optional).
+func buildOpenIaasCloudInit(raw map[string]interface{}) (*client.CloudInit, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	cloudConfig, _ := raw["cloud_config"].(string)
+	networkConfig, _ := raw["network_config"].(string)
+	if cloudConfig == "" {
+		if networkConfig != "" {
+			return nil, fmt.Errorf("cloud_init requires cloud_config: set cloud_config (the API rejects a cloud-init without it)")
+		}
+		return nil, nil
+	}
+	return &client.CloudInit{CloudConfig: cloudConfig, NetworkConfig: networkConfig}, nil
+}
+
 func openIaasVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
 
-	// Cloud-Init to configure the virtual machine
-	var cloudInit client.CloudInit
-	cloudInitRaw, ok := d.Get("cloud_init").(map[string]interface{})
-	if ok && cloudInitRaw != nil && len(cloudInitRaw) > 0 {
-		cloudConfig, ok := cloudInitRaw["cloud_config"].(string)
-		if cloudConfig != "" && ok {
-			cloudInit.CloudConfig = cloudConfig
-		}
-		networkConfig, ok := cloudInitRaw["network_config"].(string)
-		if networkConfig != "" && ok {
-			cloudInit.NetworkConfig = networkConfig
-		}
+	// Cloud-Init to configure the virtual machine. A nil result omits the
+	// "cloudInit" field entirely — the API rejects an empty cloudInit object.
+	cloudInitRaw, _ := d.Get("cloud_init").(map[string]interface{})
+	cloudInit, err := buildOpenIaasCloudInit(cloudInitRaw)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	osNetworkAdapters := d.Get("os_network_adapter").([]interface{})


### PR DESCRIPTION
## Refs #345

A VM deploy **without `cloud_init`** failed:

```
400 — When cloudInit is provided, cloudConfig is required
```

`CloudInit` was a **value struct** with `omitempty` in both create payloads (`CreateOpenIaasVirtualMachineRequest`, `MarketplaceOpenIaasDeployementRequest`). `encoding/json`'s `omitempty` does **not** drop a zero struct, so an unset cloud-init serialized as `"cloudInit":{}`, which the API rejects. Every marketplace deploy without cloud-init (and the latent template path) was broken — TF prod breaker.

## Change

- **Client**: `CloudInit` → `*CloudInit` in both request structs; a `nil` pointer is omitted.
- **Provider**: a pure helper `buildOpenIaasCloudInit(raw) (*client.CloudInit, error)`:
  - absent / empty / all-empty → `nil` (the field is omitted);
  - `network_config` set **without** `cloud_config` → **clear error, fail closed** before the API call (the API requires `cloud_config` whenever cloud-init is present);
  - `cloud_config` set → populated `*CloudInit`.

No read/state/tfstate impact: `CloudInit` lives only in request structs; the `cloud_init` schema attribute is unchanged.

## Tests (mutation-proven)

- Client serialization: an unset `CloudInit` is omitted (no `"cloudInit"` key); a set one includes `cloudConfig`/`networkConfig`.
- Helper: absent / empty / all-empty → nil; network-only → error; cloud_config (± network_config) → populated.
- Mutation A: helper returns an empty `&CloudInit{}` for the empty case → helper tests RED.

Gates: `gofmt`, `go vet`, `staticcheck` (clean), `go test ./internal/client ./internal/provider -race`, coverage ratchet (client 21.1%, provider 13.4%→13.6%), `make build`.

Found via the `ct-validate` Terraform path (Refs #316 / #338); unblocks the `tf vm` end-to-end validation.
