### PR TITLE
chore(#339): raise default HTTP request timeout 240s -> 600s

### DIFF
--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -35,7 +35,7 @@ const (
 	// client-side bound. Generous on purpose so it never regresses a legitimately
 	// slow request, while still cutting an unbounded hang. Override with
 	// CLOUDTEMPLE_HTTP_TIMEOUT (seconds).
-	defaultHTTPTimeout = 240 * time.Second
+	defaultHTTPTimeout = 600 * time.Second
 
 	// defaultReadRetryMax is the total number of attempts for an idempotent GET
 	// read (and the auth POST): 1 = no retry. It lets the provider absorb the rare


### PR DESCRIPTION
## Refs #339

Raises the default per-request HTTP timeout (the anti-hang guard from #339) from **240s to 600s**, for more headroom on slow OpenIaaS operations — observed live: a marketplace VM deploy polled ~2 min, and some paths are slower under load — while still bounding a truly stuck request. Still overridable via `CLOUDTEMPLE_HTTP_TIMEOUT`.

Safe by construction: the read-retry path explicitly excludes a configured timeout (`retryableTransportError`), so a longer timeout never multiplies into a longer stall. The change only makes the guard **more lenient**, so it cannot regress an existing client (TF prod breaker = NO).

Value chosen by the maintainer. Tests assert against the `defaultHTTPTimeout` constant and adapt automatically.

Gates: `gofmt`, `go test ./internal/client -race`, `make build`. (Review depth scaled to a one-line, reversible, user-directed constant bump.)
