### PR TITLE
feat(#319): retry VPC async writes on the transient platform 502

### DIFF
--- a/internal/client/activity.go
+++ b/internal/client/activity.go
@@ -18,6 +18,27 @@ var transientActivityReasons = []string{
 	"None of the workers were able to respond",
 }
 
+// transientActivityReasonPairs lists COMPOSITE (AND) markers: a failure reason
+// is transient only when it contains the lead phrase AND at least one of the
+// corroborating signals. The VPC platform's transient gateway hiccup
+// (#315/#319) surfaces as "Failed to load configuration via API: <html>…502
+// Bad Gateway…nginx…". The lead phrase ALONE is too broad: IsTransientActivity
+// Failure is GLOBAL — it also gates VIF/compute retries — and a genuine
+// PERMANENT config-load failure could carry the same phrase. Requiring a
+// 502 / Bad Gateway corroboration keeps it fail-closed: a false negative
+// (missing a transient 502) is preferred to a false positive (retrying a
+// non-idempotent permanent failure). A bare "502" without the lead phrase is
+// likewise NOT matched, so an unrelated upstream 502 stays fatal.
+var transientActivityReasonPairs = []struct {
+	lead  string
+	anyOf []string
+}{
+	{
+		lead:  "Failed to load configuration via API",
+		anyOf: []string{"502", "Bad Gateway"},
+	},
+}
+
 // IsTransientActivityFailure reports whether err is an activity that reached
 // the "failed" state for a reason known to be transient platform-side.
 func IsTransientActivityFailure(err error) bool {
@@ -30,6 +51,21 @@ func IsTransientActivityFailure(err error) bool {
 			if strings.Contains(state.Reason, marker) {
 				return true
 			}
+		}
+		for _, pair := range transientActivityReasonPairs {
+			if strings.Contains(state.Reason, pair.lead) && containsAny(state.Reason, pair.anyOf) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containsAny reports whether s contains at least one of the given substrings.
+func containsAny(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
 		}
 	}
 	return false

--- a/internal/client/activity_unit_test.go
+++ b/internal/client/activity_unit_test.go
@@ -261,6 +261,34 @@ func TestIsTransientActivityFailure(t *testing.T) {
 	if IsTransientActivityFailure(errors.New("plain error")) {
 		t.Fatal("a non-activity error must not be retryable")
 	}
+
+	// VPC transient gateway hiccup (#315/#319): the write activity fails with
+	// "Failed to load configuration via API: …502 Bad Gateway…nginx…". The lead
+	// phrase requires a 502 / Bad Gateway corroboration (AND-match): the matcher
+	// is GLOBAL (it also gates VIF/compute retries), so the lead phrase alone is
+	// too broad — a genuine PERMANENT config-load failure could carry it. A bare
+	// 502 without the lead phrase is also rejected: a non-idempotent upstream 502
+	// must stay fatal. Fail-closed (a false negative beats a false positive).
+	vpcFailure := func(reason string) *ActivityCompletionError {
+		return &ActivityCompletionError{activity: &Activity{State: map[string]ActivityState{
+			"failed": {Reason: reason},
+		}}}
+	}
+	if !IsTransientActivityFailure(vpcFailure("Failed to load configuration via API: <html><body><h1>502 Bad Gateway</h1></body></html> nginx/1.22.1")) {
+		t.Fatal("the VPC transient 502 (lead phrase + 502 + Bad Gateway) must be retryable")
+	}
+	if !IsTransientActivityFailure(vpcFailure("Failed to load configuration via API: 502 upstream error")) {
+		t.Fatal("the lead phrase corroborated by 502 alone must be retryable")
+	}
+	if !IsTransientActivityFailure(vpcFailure("Failed to load configuration via API: Bad Gateway from upstream")) {
+		t.Fatal("the lead phrase corroborated by Bad Gateway alone must be retryable")
+	}
+	if IsTransientActivityFailure(vpcFailure("Failed to load configuration via API: invalid schema definition")) {
+		t.Fatal("the lead phrase WITHOUT a 502/Bad Gateway corroboration must NOT be retryable (a permanent config-load failure stays fatal); kills the marker-alone / OR mutant")
+	}
+	if IsTransientActivityFailure(vpcFailure("upstream returned 502 Bad Gateway")) {
+		t.Fatal("a bare 502/Bad Gateway WITHOUT the lead phrase must NOT be retryable (too broad); kills the broaden-to-502 mutant")
+	}
 }
 
 func TestActivityWaitNotFoundToleranceSurvivesTransientBlips(t *testing.T) {

--- a/internal/provider/resource_vpc_floating_ip_binding.go
+++ b/internal/provider/resource_vpc_floating_ip_binding.go
@@ -85,6 +85,31 @@ type vpcFloatingIPBindingFuncs struct {
 	corroborate func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error)
 	// sleep waits between confirmation attempts; returns ctx.Err() on cancel.
 	sleep func(ctx context.Context, attempt int) error
+	// retrySleep backs off between transient-failure retries of the async
+	// write (bind/unbind). Defaults to defaultVPCSleep (attempt*10s) when nil.
+	// Distinct from sleep, which paces the post-mutation confirmation reads.
+	retrySleep func(ctx context.Context, attempt int) error
+	// isTransient classifies an activity failure as a retryable transient
+	// platform error. Defaults to client.IsTransientActivityFailure when nil.
+	isTransient func(err error) bool
+}
+
+// classifyFloatingIPBindingLive resolves the live binding state of fipID
+// relative to staticID, using the per-id read first and falling back to the
+// strict listing when that read is ambiguous (nil/403/mismatched-id). It
+// mirrors the create pre-bind evidence rules so a transient-failure retry
+// re-classifies on the same basis before re-issuing a write. A read error is
+// returned as-is (it is NOT an activity failure, so the retry helper stops on
+// it) rather than acting on stale evidence.
+func classifyFloatingIPBindingLive(ctx context.Context, fipID, staticID string, funcs vpcFloatingIPBindingFuncs) (client.FloatingIPBindingState, error) {
+	rawFip, err := funcs.read(ctx, fipID)
+	if err != nil {
+		return client.FloatingIPBindingInconclusive, err
+	}
+	if fip, ok := usableFloatingIPRead(rawFip, fipID); ok {
+		return client.ClassifyFloatingIPBinding(fip, staticID), nil
+	}
+	return funcs.corroborate(ctx, fipID, staticID)
 }
 
 // usableFloatingIPRead applies the #312 R7 id-match guard to a per-id read
@@ -280,13 +305,47 @@ func createVPCFloatingIPBinding(ctx context.Context, d *schema.ResourceData, fip
 		}
 	}
 
-	// 2. Bind, then wait for the activity (skipped on a 409-idempotent bind).
-	activityID, err := funcs.bind(ctx, fipID, staticID)
-	if err != nil {
-		return diag.Errorf("failed to bind floating IP %s to static IP %s: %s", fipID, staticID, err)
-	}
-	if err := funcs.wait(ctx, activityID); err != nil {
-		return diag.Errorf("failed to bind floating IP %s to static IP %s: %s", fipID, staticID, err)
+	// 2. Bind, then wait for the activity (skipped on a 409-idempotent bind) —
+	//    with a bounded retry on the transient platform gateway 502 (#315/#319).
+	//    The retry wraps ONLY the bind+wait; the pre-bind anti-clobber decision
+	//    (above) and the post-bind confirmation (below) stay OUTSIDE it. The
+	//    FIRST attempt binds directly (the pre-bind read already proved the FIP
+	//    free); a RETRY first re-reads and re-classifies so it never clobbers a
+	//    binding that appeared in between, and short-circuits to success once
+	//    the bind has converged platform-side.
+	firstBindAttempt := true
+	bindErr := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+		label:       fmt.Sprintf("bind floating IP %s to static IP %s", fipID, staticID),
+		sleep:       funcs.retrySleep,
+		isTransient: funcs.isTransient,
+		attempt: func(ctx context.Context) error {
+			if !firstBindAttempt {
+				state, serr := classifyFloatingIPBindingLive(ctx, fipID, staticID, funcs)
+				if serr != nil {
+					return serr
+				}
+				switch state {
+				case client.FloatingIPBindingBoundToTarget:
+					// The bind converged platform-side despite the transient
+					// failure: success (the external confirmation sets the id).
+					return nil
+				case client.FloatingIPBindingBoundToOther:
+					return fmt.Errorf("floating IP %s became bound to a different static IP between retries; refusing to clobber it by binding it to %s", fipID, staticID)
+				case client.FloatingIPBindingInconclusive:
+					return fmt.Errorf("floating IP %s has an inconclusive binding state between retries; refusing to re-bind it to %s on ambiguous evidence", fipID, staticID)
+				}
+				// Unbound: still free, re-bind below.
+			}
+			firstBindAttempt = false
+			activityID, berr := funcs.bind(ctx, fipID, staticID)
+			if berr != nil {
+				return berr
+			}
+			return funcs.wait(ctx, activityID)
+		},
+	})
+	if bindErr != nil {
+		return diag.Errorf("failed to bind floating IP %s to static IP %s: %s", fipID, staticID, bindErr)
 	}
 
 	// 3. Bounded confirmation retry: SetId ONLY after the binding is confirmed
@@ -412,17 +471,49 @@ func readVPCFloatingIPBinding(ctx context.Context, d *schema.ResourceData, fipID
 // the floating IP is no longer bound to our static IP. A 403 alone is NEVER
 // "gone".
 func deleteVPCFloatingIPBinding(ctx context.Context, d *schema.ResourceData, fipID, staticID string, funcs vpcFloatingIPBindingFuncs) diag.Diagnostics {
-	activityID, err := funcs.unbind(ctx, fipID, staticID)
-	if err != nil {
-		// A 404/403 on the unbind CALL itself is idempotent ONLY after a strict
-		// positive confirmation that the pair is gone.
-		if isVPCStatusCode(err, http.StatusNotFound) || isVPCStatusCode(err, http.StatusForbidden) {
-			return confirmFloatingIPUnbound(ctx, fipID, staticID, funcs, err)
-		}
-		return diag.Errorf("failed to unbind floating IP %s from static IP %s: %s", fipID, staticID, err)
-	}
-	if err := funcs.wait(ctx, activityID); err != nil {
-		return diag.Errorf("failed to unbind floating IP %s from static IP %s: %s", fipID, staticID, err)
+	// Unbind, then wait for the activity — with a bounded retry on the
+	// transient platform gateway 502 (#315/#319). The retry wraps ONLY the
+	// unbind+wait; the post-unbind confirmation (confirmFloatingIPUnbound)
+	// stays OUTSIDE it and rules on the final state. The FIRST attempt unbinds
+	// directly; a RETRY first re-reads and re-classifies, and re-issues the
+	// unbind ONLY while the pair is still bound to OUR target — otherwise the
+	// unbind already took effect (or the pair was never ours) and re-issuing it
+	// could disturb a binding that is no longer ours.
+	firstUnbindAttempt := true
+	unbindErr := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+		label:       fmt.Sprintf("unbind floating IP %s from static IP %s", fipID, staticID),
+		sleep:       funcs.retrySleep,
+		isTransient: funcs.isTransient,
+		attempt: func(ctx context.Context) error {
+			if !firstUnbindAttempt {
+				state, serr := classifyFloatingIPBindingLive(ctx, fipID, staticID, funcs)
+				if serr != nil {
+					return serr
+				}
+				if state != client.FloatingIPBindingBoundToTarget {
+					// No longer bound to OUR pair (Unbound / BoundToOther /
+					// Inconclusive): the unbind took effect (or the pair was
+					// never ours). Stop; the external confirmation rules.
+					return nil
+				}
+				// Still our pair: re-issue the unbind below.
+			}
+			firstUnbindAttempt = false
+			activityID, uerr := funcs.unbind(ctx, fipID, staticID)
+			if uerr != nil {
+				// A 404/403 on the unbind CALL itself is idempotent: the pair
+				// is (probably) gone. Stop here and let the strict external
+				// confirmation prove it; never retry a permission/absence code.
+				if isVPCStatusCode(uerr, http.StatusNotFound) || isVPCStatusCode(uerr, http.StatusForbidden) {
+					return nil
+				}
+				return uerr
+			}
+			return funcs.wait(ctx, activityID)
+		},
+	})
+	if unbindErr != nil {
+		return diag.Errorf("failed to unbind floating IP %s from static IP %s: %s", fipID, staticID, unbindErr)
 	}
 
 	return confirmFloatingIPUnbound(ctx, fipID, staticID, funcs, nil)

--- a/internal/provider/resource_vpc_floating_ip_binding_retry_test.go
+++ b/internal/provider/resource_vpc_floating_ip_binding_retry_test.go
@@ -163,6 +163,119 @@ func TestCreateVPCFloatingIPBindingRetriesTransient502(t *testing.T) {
 			t.Fatalf("a non-transient failure must NOT be retried, got %d bind POSTs", bindCalls)
 		}
 	})
+
+	t.Run("transient wait then AMBIGUOUS re-read corroborated UNBOUND -> re-bind, converges", func(t *testing.T) {
+		// The retry's per-id re-read is ambiguous (nil/403) and must fall back to
+		// the strict listing (corroborate). A corroborated UNBOUND unlocks a re-bind.
+		d := emptyBindingState(t)
+		var bindCalls, waitCalls, readCalls, corrCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // pre-bind: free
+				readResult{nil, nil},          // retry re-classify: ambiguous -> corroborate
+				readResult{boundFIP(), nil},   // confirmation
+			),
+			bind: func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait: func(ctx context.Context, activityID string) error {
+				waitCalls++
+				if waitCalls == 1 {
+					return errVPCTransient
+				}
+				return nil
+			},
+			corroborate: func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+				corrCalls++
+				return client.FloatingIPBindingUnbound, nil
+			},
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if diags.HasError() {
+			t.Fatalf("an ambiguous re-read corroborated UNBOUND must allow a re-bind, got: %v", diags)
+		}
+		if corrCalls != 1 {
+			t.Fatalf("the retry must fall back to the strict listing on an ambiguous re-read, got %d corroborate calls", corrCalls)
+		}
+		if bindCalls != 2 {
+			t.Fatalf("a corroborated-unbound retry must re-bind, got %d bind POSTs", bindCalls)
+		}
+		if d.Id() != testBindID {
+			t.Fatalf("the id must be set after convergence, got %q", d.Id())
+		}
+	})
+
+	t.Run("transient wait then AMBIGUOUS re-read corroborated BOUND-TO-OTHER -> abort, NO second bind POST", func(t *testing.T) {
+		// The retry's per-id re-read is ambiguous; the strict listing shows the FIP
+		// bound elsewhere -> anti-clobber abort, never re-bind on ambiguous evidence.
+		d := emptyBindingState(t)
+		var bindCalls, readCalls, corrCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // pre-bind: free
+				readResult{nil, nil},          // retry re-classify: ambiguous -> corroborate
+			),
+			bind: func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait: func(ctx context.Context, activityID string) error { return errVPCTransient },
+			corroborate: func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+				corrCalls++
+				return client.FloatingIPBindingBoundToOther, nil
+			},
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if !diags.HasError() {
+			t.Fatal("an ambiguous re-read corroborated BOUND-TO-OTHER must ABORT (anti-clobber)")
+		}
+		if corrCalls != 1 {
+			t.Fatalf("the retry must corroborate on an ambiguous re-read, got %d corroborate calls", corrCalls)
+		}
+		if bindCalls != 1 {
+			t.Fatalf("a corroborated-bound-elsewhere retry must NOT re-bind, got %d bind POSTs", bindCalls)
+		}
+		if d.Id() != "" {
+			t.Fatalf("an aborted create must not set the id, got %q", d.Id())
+		}
+	})
+
+	t.Run("transient wait then AMBIGUOUS re-read corroborated INCONCLUSIVE -> abort, NO second bind POST", func(t *testing.T) {
+		// The retry's per-id re-read is ambiguous; the strict listing is itself
+		// Inconclusive -> fail-closed abort, never re-bind on ambiguous evidence
+		// (the dedicated Inconclusive branch, distinct from BoundToOther).
+		d := emptyBindingState(t)
+		var bindCalls, readCalls, corrCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // pre-bind: free
+				readResult{nil, nil},          // retry re-classify: ambiguous -> corroborate
+			),
+			bind: func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait: func(ctx context.Context, activityID string) error { return errVPCTransient },
+			corroborate: func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+				corrCalls++
+				return client.FloatingIPBindingInconclusive, nil
+			},
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if !diags.HasError() {
+			t.Fatal("an ambiguous re-read corroborated INCONCLUSIVE must FAIL CLOSED (no re-bind on ambiguous evidence)")
+		}
+		if corrCalls != 1 {
+			t.Fatalf("the retry must corroborate on an ambiguous re-read, got %d corroborate calls", corrCalls)
+		}
+		if bindCalls != 1 {
+			t.Fatalf("a corroborated-inconclusive retry must NOT re-bind, got %d bind POSTs; kills the Inconclusive-falls-through-to-rebind mutant", bindCalls)
+		}
+		if d.Id() != "" {
+			t.Fatalf("a fail-closed create must not set the id, got %q", d.Id())
+		}
+	})
 }
 
 func TestDeleteVPCFloatingIPBindingRetriesTransient502(t *testing.T) {

--- a/internal/provider/resource_vpc_floating_ip_binding_retry_test.go
+++ b/internal/provider/resource_vpc_floating_ip_binding_retry_test.go
@@ -1,0 +1,229 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// These tests pin the bounded retry on the transient platform gateway 502
+// (#315/#319) wired into bind/unbind. The transient activity failure is
+// simulated with the errVPCTransient sentinel + the vpcIsTransient classifier
+// (both from vpc_write_retry_test.go), because the provider package cannot
+// build a real client.ActivityCompletionError (its fields are unexported).
+//
+// The overriding invariant: a retry NEVER clobbers a binding that changed
+// between attempts, and NEVER re-issues a write that already converged.
+
+func TestCreateVPCFloatingIPBindingRetriesTransient502(t *testing.T) {
+	ctx := context.Background()
+	inconclusiveCorroborate := func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+		return client.FloatingIPBindingInconclusive, nil
+	}
+
+	t.Run("transient wait then UNBOUND on re-read -> re-bind, converges", func(t *testing.T) {
+		// Pre-bind shows the FIP free -> bind proceeds. Attempt 1's wait fails
+		// transient; attempt 2 re-reads UNBOUND -> re-bind, wait OK; the
+		// confirmation read then shows our pair.
+		d := emptyBindingState(t)
+		var bindCalls, waitCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // pre-bind: free
+				readResult{unboundFIP(), nil}, // retry re-classify: still free -> re-bind
+				readResult{boundFIP(), nil},   // confirmation: converged
+			),
+			bind: func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait: func(ctx context.Context, activityID string) error {
+				waitCalls++
+				if waitCalls == 1 {
+					return errVPCTransient
+				}
+				return nil
+			},
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if diags.HasError() {
+			t.Fatalf("a transient wait failure must be retried to convergence, got: %v", diags)
+		}
+		if bindCalls != 2 {
+			t.Fatalf("expected 2 bind POSTs (initial + one retry while still unbound), got %d", bindCalls)
+		}
+		if d.Id() != testBindID {
+			t.Fatalf("the id must be set after convergence, got %q", d.Id())
+		}
+	})
+
+	t.Run("transient wait then BOUND-TO-TARGET on re-read -> success, NO second bind POST", func(t *testing.T) {
+		// The bind converged platform-side despite the transient wait failure:
+		// the retry re-reads BoundToTarget and must SUCCEED without re-binding.
+		d := emptyBindingState(t)
+		var bindCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // pre-bind: free
+				readResult{boundFIP(), nil},   // retry re-classify: converged platform-side
+				readResult{boundFIP(), nil},   // confirmation
+			),
+			bind:        func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait:        func(ctx context.Context, activityID string) error { return errVPCTransient }, // every wait fails
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if diags.HasError() {
+			t.Fatalf("a bind that converged platform-side after a transient failure must succeed, got: %v", diags)
+		}
+		if bindCalls != 1 {
+			t.Fatalf("a converged bind must NOT be re-issued on retry, got %d bind POSTs; kills the re-bind-on-converged mutant", bindCalls)
+		}
+		if d.Id() != testBindID {
+			t.Fatalf("the id must be set after adopting the converged bind, got %q", d.Id())
+		}
+	})
+
+	t.Run("transient wait then BOUND-TO-OTHER on re-read -> anti-clobber abort, NO second bind POST", func(t *testing.T) {
+		// Between retries the FIP becomes bound to a DIFFERENT static IP: the
+		// retry must ABORT, never re-bind (anti-clobber).
+		d := emptyBindingState(t)
+		var bindCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil},    // pre-bind: free
+				readResult{otherBoundFIP(), nil}, // retry re-classify: clobber risk
+			),
+			bind:        func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait:        func(ctx context.Context, activityID string) error { return errVPCTransient },
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if !diags.HasError() {
+			t.Fatal("a FIP that became bound to a different static IP between retries must ABORT (anti-clobber)")
+		}
+		if bindCalls != 1 {
+			t.Fatalf("the retry must NOT re-bind a FIP bound elsewhere, got %d bind POSTs; kills the re-bind-on-bound-to-other mutant", bindCalls)
+		}
+		if d.Id() != "" {
+			t.Fatalf("an aborted create must not set the id, got %q", d.Id())
+		}
+	})
+
+	t.Run("persistent transient wait -> bounded, fails without converging", func(t *testing.T) {
+		d := emptyBindingState(t)
+		var bindCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			// Pre-bind free, and every retry re-read still free -> re-bind each time.
+			read:        readSeq(&readCalls, readResult{unboundFIP(), nil}),
+			bind:        func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait:        func(ctx context.Context, activityID string) error { return errVPCTransient },
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if !diags.HasError() {
+			t.Fatal("a persistent transient failure must eventually fail (bounded)")
+		}
+		if bindCalls != maxTransientVPCAttempts {
+			t.Fatalf("expected exactly %d bind POSTs (bounded budget), got %d", maxTransientVPCAttempts, bindCalls)
+		}
+		if d.Id() != "" {
+			t.Fatalf("a failed create must not set the id, got %q", d.Id())
+		}
+	})
+
+	t.Run("non-transient wait failure is NOT retried", func(t *testing.T) {
+		d := emptyBindingState(t)
+		var bindCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read:        func(ctx context.Context, fipID string) (*client.FloatingIP, error) { return unboundFIP(), nil },
+			bind:        func(ctx context.Context, fipID, staticID string) (string, error) { bindCalls++; return "act", nil },
+			wait:        func(ctx context.Context, activityID string) error { return errVPCPermanent },
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := createVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if !diags.HasError() {
+			t.Fatal("a non-transient wait failure must fail the create")
+		}
+		if bindCalls != 1 {
+			t.Fatalf("a non-transient failure must NOT be retried, got %d bind POSTs", bindCalls)
+		}
+	})
+}
+
+func TestDeleteVPCFloatingIPBindingRetriesTransient502(t *testing.T) {
+	ctx := context.Background()
+	inconclusiveCorroborate := func(ctx context.Context, fipID, staticID string) (client.FloatingIPBindingState, error) {
+		return client.FloatingIPBindingInconclusive, nil
+	}
+
+	t.Run("transient wait then UNBOUND on re-read -> success, NO second unbind", func(t *testing.T) {
+		// The unbind converged platform-side despite the transient wait failure:
+		// the retry re-classifies Unbound and must SUCCEED without re-unbinding.
+		d := bindingState(t)
+		var unbindCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{unboundFIP(), nil}, // retry re-classify: no longer our pair
+				readResult{unboundFIP(), nil}, // external confirm: unbound
+			),
+			unbind:      func(ctx context.Context, fipID, staticID string) (string, error) { unbindCalls++; return "act", nil },
+			wait:        func(ctx context.Context, activityID string) error { return errVPCTransient }, // attempt 1 wait fails
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := deleteVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if diags.HasError() {
+			t.Fatalf("an unbind that converged platform-side after a transient failure must succeed, got: %v", diags)
+		}
+		if unbindCalls != 1 {
+			t.Fatalf("a converged unbind must NOT be re-issued on retry, got %d unbind calls; kills the re-unbind-on-converged mutant", unbindCalls)
+		}
+	})
+
+	t.Run("transient wait then STILL-BOUND on re-read -> re-unbind, converges", func(t *testing.T) {
+		d := bindingState(t)
+		var unbindCalls, waitCalls, readCalls int
+		funcs := vpcFloatingIPBindingFuncs{
+			read: readSeq(&readCalls,
+				readResult{boundFIP(), nil},   // retry re-classify: still our pair
+				readResult{unboundFIP(), nil}, // external confirm: unbound after the re-unbind
+			),
+			unbind: func(ctx context.Context, fipID, staticID string) (string, error) { unbindCalls++; return "act", nil },
+			wait: func(ctx context.Context, activityID string) error {
+				waitCalls++
+				if waitCalls == 1 {
+					return errVPCTransient
+				}
+				return nil
+			},
+			corroborate: inconclusiveCorroborate,
+			sleep:       noSleep,
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := deleteVPCFloatingIPBinding(ctx, d, testFIPID, testStaticID, funcs)
+		if diags.HasError() {
+			t.Fatalf("a still-bound pair must be re-unbound to convergence, got: %v", diags)
+		}
+		if unbindCalls != 2 {
+			t.Fatalf("expected 2 unbind calls (initial + one retry while still bound), got %d", unbindCalls)
+		}
+	})
+}

--- a/internal/provider/resource_vpc_static_ip.go
+++ b/internal/provider/resource_vpc_static_ip.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -232,39 +233,97 @@ func readVPCStaticIPInto(ctx context.Context, d *schema.ResourceData, read vpcSt
 	return sw.diags
 }
 
+// vpcStaticIPUpdateFuncs abstracts the static IP update API surface so the
+// PATCH logic is unit tested without HTTP calls or real sleeps. retrySleep /
+// isTransient default to defaultVPCSleep / client.IsTransientActivityFailure.
+type vpcStaticIPUpdateFuncs struct {
+	read        vpcStaticIPReadFunc
+	update      func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error)
+	wait        vpcActivityWaitFunc
+	retrySleep  func(ctx context.Context, attempt int) error
+	isTransient func(err error) bool
+}
+
 func resourceVPCStaticIPUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
-
-	// Diff-driven PATCH body: send ONLY the changed updatable fields. The
-	// UpdateStaticIpPayload schema contains exactly resourceDescription and
-	// macAddress (no ipAddress), so only those can change here; ip_address and
-	// private_network_id are ForceNew and never reach this path.
-	req := &client.UpdateStaticIPRequest{}
-	changed := false
-	if d.HasChange("mac_address") {
-		v := d.Get("mac_address").(string)
-		req.MacAddress = &v
-		changed = true
+	if diags := updateVPCStaticIPWith(ctx, d, vpcStaticIPUpdateFuncs{
+		read:   c.VPC().StaticIP().Read,
+		update: c.VPC().StaticIP().Update,
+		wait: func(ctx context.Context, activityID string) error {
+			_, err := c.Activity().WaitForCompletion(ctx, activityID, getWaiterOptions(ctx))
+			return err
+		},
+	}); diags.HasError() {
+		return diags
 	}
-	if d.HasChange("resource_description") {
-		v := d.Get("resource_description").(string)
-		req.ResourceDescription = &v
-		changed = true
-	}
-
-	if changed {
-		// Update is ASYNCHRONOUS: the PATCH returns an activity (Location); wait
-		// for its completion before reading back.
-		activityID, err := c.VPC().StaticIP().Update(ctx, d.Id(), req)
-		if err != nil {
-			return diag.Errorf("failed to update VPC static IP %s: %s", d.Id(), err)
-		}
-		if _, err := c.Activity().WaitForCompletion(ctx, activityID, getWaiterOptions(ctx)); err != nil {
-			return diag.Errorf("failed to update VPC static IP %s: %s", d.Id(), err)
-		}
-	}
-
 	return resourceVPCStaticIPRead(ctx, d, meta)
+}
+
+// updateVPCStaticIPWith holds the testable update logic. The PATCH body
+// (UpdateStaticIpPayload = exactly resourceDescription + macAddress; ip_address
+// and private_network_id are ForceNew and never reach this path) is wrapped in
+// the bounded transient-502 retry (#315/#319).
+//
+// Codex PLAN strict guard: the diff is rebuilt against a FRESH LIVE read before
+// EVERY attempt, never from the state alone — so a retry after a transient
+// failure that actually applied the change re-reads an already-converged static
+// IP and returns success WITHOUT a second PATCH. A nil/ambiguous read (403/absent
+// or an id-inconsistent body) FAILS CLOSED: never PATCH on ambiguous evidence.
+func updateVPCStaticIPWith(ctx context.Context, d *schema.ResourceData, funcs vpcStaticIPUpdateFuncs) diag.Diagnostics {
+	desiredMAC := d.Get("mac_address").(string)
+	desiredDesc := d.Get("resource_description").(string)
+	// Canonicalise the MAC for comparison (lowercase, ":"-separated), mirroring
+	// the client's create-time matching, so a pure formatting difference between
+	// the config and the live read never triggers a needless PATCH.
+	normMAC := func(m string) string { return strings.ToLower(strings.ReplaceAll(m, "-", ":")) }
+
+	updateErr := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+		label:       fmt.Sprintf("update VPC static IP %s", d.Id()),
+		sleep:       funcs.retrySleep,
+		isTransient: funcs.isTransient,
+		attempt: func(ctx context.Context) error {
+			live, rerr := funcs.read(ctx, d.Id())
+			if rerr != nil {
+				return rerr
+			}
+			if live == nil || live.ID != d.Id() {
+				return fmt.Errorf("VPC static IP %s could not be read consistently before updating it; refusing to PATCH on ambiguous evidence", d.Id())
+			}
+
+			req := &client.UpdateStaticIPRequest{}
+			changed := false
+			if normMAC(desiredMAC) != normMAC(live.MacAddress) {
+				v := desiredMAC
+				req.MacAddress = &v
+				changed = true
+			}
+			liveDesc := ""
+			if live.ResourceDescription != nil {
+				liveDesc = *live.ResourceDescription
+			}
+			if desiredDesc != liveDesc {
+				v := desiredDesc
+				req.ResourceDescription = &v
+				changed = true
+			}
+			if !changed {
+				// Live already matches the desired state: converged, no PATCH.
+				return nil
+			}
+
+			// Update is ASYNCHRONOUS: the PATCH returns an activity (Location);
+			// wait for its completion.
+			activityID, uerr := funcs.update(ctx, d.Id(), req)
+			if uerr != nil {
+				return uerr
+			}
+			return funcs.wait(ctx, activityID)
+		},
+	})
+	if updateErr != nil {
+		return diag.Errorf("failed to update VPC static IP %s: %s", d.Id(), updateErr)
+	}
+	return nil
 }
 
 func resourceVPCStaticIPDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -309,6 +368,18 @@ type vpcActivityWaitFunc func(ctx context.Context, activityID string) error
 //     So a 403 is confirmed via a strict, complete (200-only) listing before the
 //     delete is accepted; anything inconclusive FAILS CLOSED.
 func deleteVPCStaticIPWith(ctx context.Context, d *schema.ResourceData, del vpcStaticIPDeleteFunc, listStrict vpcStaticIPListStrictFunc, wait vpcActivityWaitFunc) diag.Diagnostics {
+	return deleteVPCStaticIPWithRetry(ctx, d, del, listStrict, wait, nil, nil)
+}
+
+// deleteVPCStaticIPWithRetry is deleteVPCStaticIPWith with the transient-502
+// retry seams exposed for unit tests; retrySleep / isTransient default to
+// defaultVPCSleep / client.IsTransientActivityFailure when nil.
+//
+// The DELETE+wait is wrapped in the bounded transient-502 retry (#315/#319); the
+// 403-absence confirmation (confirmStaticIPDeleted) stays OUTSIDE it. No live
+// re-read is needed between attempts: a re-DELETE is idempotent and the re-DELETE
+// itself is the probe — a 404 proves the static IP is already gone (success).
+func deleteVPCStaticIPWithRetry(ctx context.Context, d *schema.ResourceData, del vpcStaticIPDeleteFunc, listStrict vpcStaticIPListStrictFunc, wait vpcActivityWaitFunc, retrySleep func(context.Context, int) error, isTransient func(error) bool) diag.Diagnostics {
 	// Preflight (#311): only CUSTOM static IPs are deletable via the API. If the
 	// state already knows this is a platform-managed one (e.g. source "xoa"),
 	// surface an actionable diagnostic instead of issuing a doomed delete. Import
@@ -321,22 +392,31 @@ func deleteVPCStaticIPWith(ctx context.Context, d *schema.ResourceData, del vpcS
 		)
 	}
 
-	activityID, err := del(ctx, d.Id())
-	if err != nil {
-		// 404: unambiguous absence -> idempotent success.
-		if isVPCStatusCode(err, http.StatusNotFound) {
-			return nil
-		}
+	delErr := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+		label:       fmt.Sprintf("delete VPC static IP %s", d.Id()),
+		sleep:       retrySleep,
+		isTransient: isTransient,
+		attempt: func(ctx context.Context) error {
+			activityID, err := del(ctx, d.Id())
+			if err != nil {
+				// 404: unambiguous absence -> idempotent success.
+				if isVPCStatusCode(err, http.StatusNotFound) {
+					return nil
+				}
+				// 403 (ambiguous, #303) and any other error are non-transient:
+				// surface them so the caller can apply the right rule below.
+				return err
+			}
+			return wait(ctx, activityID)
+		},
+	})
+	if delErr != nil {
 		// 403: ambiguous (#303). Confirm absence before accepting the delete, so a
 		// genuine permission error never silently drops the resource from the state.
-		if isVPCStatusCode(err, http.StatusForbidden) {
-			return confirmStaticIPDeleted(ctx, d, listStrict, err)
+		if isVPCStatusCode(delErr, http.StatusForbidden) {
+			return confirmStaticIPDeleted(ctx, d, listStrict, delErr)
 		}
-		return diag.Errorf("failed to delete VPC static IP %s: %s", d.Id(), staticIPDeleteErrorDetail(err))
-	}
-
-	if err := wait(ctx, activityID); err != nil {
-		return diag.Errorf("failed to delete VPC static IP %s: %s", d.Id(), staticIPDeleteErrorDetail(err))
+		return diag.Errorf("failed to delete VPC static IP %s: %s", d.Id(), staticIPDeleteErrorDetail(delErr))
 	}
 	return nil
 }

--- a/internal/provider/resource_vpc_static_ip_retry_test.go
+++ b/internal/provider/resource_vpc_static_ip_retry_test.go
@@ -1,0 +1,249 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// These tests pin the bounded retry on the transient platform gateway 502
+// (#315/#319) wired into the static IP delete and update. The transient
+// activity failure is simulated with errVPCTransient + vpcIsTransient (from
+// vpc_write_retry_test.go), since the provider package cannot build a real
+// client.ActivityCompletionError.
+
+func siDescPtr(s string) *string { return &s }
+
+// delSeq scripts a delete func: yields the supplied (activityID, err) outcomes
+// in order, repeating the last; counts the calls.
+func delSeq(calls *int, results ...struct {
+	id  string
+	err error
+}) vpcStaticIPDeleteFunc {
+	return func(ctx context.Context, id string) (string, error) {
+		i := *calls
+		*calls++
+		if i >= len(results) {
+			i = len(results) - 1
+		}
+		return results[i].id, results[i].err
+	}
+}
+
+type delResult = struct {
+	id  string
+	err error
+}
+
+func TestDeleteVPCStaticIPRetriesTransient502(t *testing.T) {
+	ctx := context.Background()
+	noList := siListStrict()
+
+	t.Run("transient wait then re-DELETE 404 -> idempotent success", func(t *testing.T) {
+		// Attempt 1's DELETE starts an activity whose wait fails transient; the
+		// delete actually took effect, so attempt 2's re-DELETE returns 404 ->
+		// idempotent success.
+		d := newStaticIPState(t)
+		var delCalls, waitCalls int
+		del := delSeq(&delCalls,
+			delResult{"act", nil},
+			delResult{"", client.StatusError{Code: http.StatusNotFound}},
+		)
+		wait := func(ctx context.Context, activityID string) error { waitCalls++; return errVPCTransient }
+		diags := deleteVPCStaticIPWithRetry(ctx, d, del, noList, wait, noSleep, vpcIsTransient)
+		if diags.HasError() {
+			t.Fatalf("a transient delete must be retried; a re-DELETE 404 proves it converged, got: %v", diags)
+		}
+		if delCalls != 2 {
+			t.Fatalf("expected 2 DELETE calls (initial + one retry), got %d", delCalls)
+		}
+	})
+
+	t.Run("transient wait then re-DELETE+wait OK -> success", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var delCalls, waitCalls int
+		del := delSeq(&delCalls, delResult{"act", nil})
+		wait := func(ctx context.Context, activityID string) error {
+			waitCalls++
+			if waitCalls == 1 {
+				return errVPCTransient
+			}
+			return nil
+		}
+		diags := deleteVPCStaticIPWithRetry(ctx, d, del, noList, wait, noSleep, vpcIsTransient)
+		if diags.HasError() {
+			t.Fatalf("a transient delete must be retried to convergence, got: %v", diags)
+		}
+		if delCalls != 2 || waitCalls != 2 {
+			t.Fatalf("expected 2 DELETE + 2 wait, got %d/%d", delCalls, waitCalls)
+		}
+	})
+
+	t.Run("persistent transient wait -> bounded, fails", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var delCalls int
+		del := delSeq(&delCalls, delResult{"act", nil})
+		wait := func(ctx context.Context, activityID string) error { return errVPCTransient }
+		diags := deleteVPCStaticIPWithRetry(ctx, d, del, noList, wait, noSleep, vpcIsTransient)
+		if !diags.HasError() {
+			t.Fatal("a persistent transient delete must eventually fail (bounded)")
+		}
+		if delCalls != maxTransientVPCAttempts {
+			t.Fatalf("expected exactly %d DELETE calls (bounded), got %d", maxTransientVPCAttempts, delCalls)
+		}
+	})
+
+	t.Run("non-transient wait failure is NOT retried", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var delCalls int
+		del := delSeq(&delCalls, delResult{"act", nil})
+		wait := func(ctx context.Context, activityID string) error { return errVPCPermanent }
+		diags := deleteVPCStaticIPWithRetry(ctx, d, del, noList, wait, noSleep, vpcIsTransient)
+		if !diags.HasError() {
+			t.Fatal("a non-transient delete failure must fail")
+		}
+		if delCalls != 1 {
+			t.Fatalf("a non-transient failure must NOT be retried, got %d DELETE calls", delCalls)
+		}
+	})
+}
+
+func TestUpdateVPCStaticIPRetriesTransient502(t *testing.T) {
+	ctx := context.Background()
+	// newStaticIPState seeds mac=00:50:56:ab:cd:ef, resource_description="seeded";
+	// those are the DESIRED values d.Get returns in the update path.
+	const desiredMAC = "00:50:56:ab:cd:ef"
+
+	live := func(desc string) *client.StaticIP {
+		return &client.StaticIP{ID: "si-1", MacAddress: desiredMAC, ResourceDescription: siDescPtr(desc)}
+	}
+
+	t.Run("transient wait then live already converged -> success, NO second PATCH", func(t *testing.T) {
+		// Attempt 1 sees a diverged description -> PATCH; wait fails transient.
+		// The PATCH actually applied: attempt 2 re-reads the converged live and
+		// returns success WITHOUT a second PATCH.
+		d := newStaticIPState(t)
+		var readCalls, updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) {
+				readCalls++
+				if readCalls == 1 {
+					return live("old"), nil // diverged -> PATCH
+				}
+				return live("seeded"), nil // converged after the (transiently-reported) PATCH
+			},
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return errVPCTransient },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if diags.HasError() {
+			t.Fatalf("a PATCH that converged platform-side after a transient failure must succeed, got: %v", diags)
+		}
+		if updateCalls != 1 {
+			t.Fatalf("a converged update must NOT be re-PATCHed on retry, got %d PATCHes; kills the re-PATCH-when-converged / rebuild-from-state mutant", updateCalls)
+		}
+	})
+
+	t.Run("transient wait then still diverged -> re-PATCH, converges", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var updateCalls, waitCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) { return live("old"), nil },
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait: func(ctx context.Context, activityID string) error {
+				waitCalls++
+				if waitCalls == 1 {
+					return errVPCTransient
+				}
+				return nil
+			},
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if diags.HasError() {
+			t.Fatalf("a still-diverged static IP must be re-PATCHed to convergence, got: %v", diags)
+		}
+		if updateCalls != 2 {
+			t.Fatalf("expected 2 PATCHes (initial + one retry while still diverged), got %d", updateCalls)
+		}
+	})
+
+	t.Run("converged from the start -> zero PATCH", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) { return live("seeded"), nil },
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return nil },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if diags.HasError() {
+			t.Fatalf("an already-converged update must succeed, got: %v", diags)
+		}
+		if updateCalls != 0 {
+			t.Fatalf("a converged live must NOT be PATCHed, got %d PATCHes", updateCalls)
+		}
+	})
+
+	t.Run("nil/ambiguous read fails closed (no PATCH)", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) { return nil, nil }, // 403/absent
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return nil },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if !diags.HasError() {
+			t.Fatal("a nil/ambiguous read must FAIL CLOSED, never PATCH on ambiguous evidence")
+		}
+		if updateCalls != 0 {
+			t.Fatalf("a fail-closed update must NOT PATCH, got %d PATCHes; kills the PATCH-on-ambiguous-read mutant", updateCalls)
+		}
+	})
+
+	t.Run("id-inconsistent read fails closed (no PATCH)", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) {
+				return &client.StaticIP{ID: "someone-else", MacAddress: desiredMAC}, nil
+			},
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return nil },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if !diags.HasError() {
+			t.Fatal("an id-inconsistent read must FAIL CLOSED, never PATCH")
+		}
+		if updateCalls != 0 {
+			t.Fatalf("a fail-closed update must NOT PATCH, got %d PATCHes", updateCalls)
+		}
+	})
+}

--- a/internal/provider/resource_vpc_static_ip_retry_test.go
+++ b/internal/provider/resource_vpc_static_ip_retry_test.go
@@ -119,6 +119,9 @@ func TestUpdateVPCStaticIPRetriesTransient502(t *testing.T) {
 	live := func(desc string) *client.StaticIP {
 		return &client.StaticIP{ID: "si-1", MacAddress: desiredMAC, ResourceDescription: siDescPtr(desc)}
 	}
+	liveMAC := func(mac, desc string) *client.StaticIP {
+		return &client.StaticIP{ID: "si-1", MacAddress: mac, ResourceDescription: siDescPtr(desc)}
+	}
 
 	t.Run("transient wait then live already converged -> success, NO second PATCH", func(t *testing.T) {
 		// Attempt 1 sees a diverged description -> PATCH; wait fails transient.
@@ -244,6 +247,56 @@ func TestUpdateVPCStaticIPRetriesTransient502(t *testing.T) {
 		}
 		if updateCalls != 0 {
 			t.Fatalf("a fail-closed update must NOT PATCH, got %d PATCHes", updateCalls)
+		}
+	})
+
+	t.Run("MAC format-only difference (dash + uppercase) -> zero PATCH", func(t *testing.T) {
+		// desired = 00:50:56:ab:cd:ef ; live = the SAME MAC, dash-separated and
+		// uppercased. normMAC canonicalises both -> no diff -> no PATCH.
+		d := newStaticIPState(t)
+		var updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) {
+				return liveMAC("00-50-56-AB-CD-EF", "seeded"), nil
+			},
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return nil },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if diags.HasError() {
+			t.Fatalf("a format-only MAC difference must converge cleanly, got: %v", diags)
+		}
+		if updateCalls != 0 {
+			t.Fatalf("a format-only MAC difference must NOT PATCH (normalised equal), got %d PATCHes", updateCalls)
+		}
+	})
+
+	t.Run("genuinely different MAC -> PATCH", func(t *testing.T) {
+		d := newStaticIPState(t)
+		var updateCalls int
+		funcs := vpcStaticIPUpdateFuncs{
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) {
+				return liveMAC("00:50:56:00:00:01", "seeded"), nil
+			},
+			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
+				updateCalls++
+				return "act", nil
+			},
+			wait:        func(ctx context.Context, activityID string) error { return nil },
+			retrySleep:  noSleep,
+			isTransient: vpcIsTransient,
+		}
+		diags := updateVPCStaticIPWith(ctx, d, funcs)
+		if diags.HasError() {
+			t.Fatalf("a genuinely different MAC must PATCH cleanly, got: %v", diags)
+		}
+		if updateCalls != 1 {
+			t.Fatalf("a genuinely different MAC must PATCH exactly once, got %d PATCHes", updateCalls)
 		}
 	})
 }

--- a/internal/provider/vpc_write_retry.go
+++ b/internal/provider/vpc_write_retry.go
@@ -1,0 +1,110 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// maxTransientVPCAttempts bounds the TOTAL number of attempts (not retries) of
+// a VPC async write whose activity failed for a transient platform reason (the
+// gateway 502 "Failed to load configuration via API: …502 Bad Gateway…",
+// #315/#319). Parity with the VIF retry budget (#251, maxTransientVIFAttempts).
+const maxTransientVPCAttempts = 3
+
+// vpcWriteRetry holds the injectable seams of the bounded VPC write retry so
+// the loop is unit tested without HTTP calls or sleeps.
+//
+// The helper is deliberately MINIMAL: it owns only the retry MECHANICS
+// (attempt budget, backoff, context, the transient gate, the last-error
+// propagation, the log line). It knows NOTHING about static IPs, floating IPs,
+// binding classification or deletion confirmation. Every per-operation decision
+// — re-read the live resource, re-classify safety/convergence, decide whether
+// to re-emit the write, and (crucially) run the source-of-truth confirmations —
+// stays in the caller's `attempt` closure. That separation keeps the anti-clobber
+// and never-orphan invariants (#275/#281/#303/#312) out of this generic loop.
+type vpcWriteRetry struct {
+	// attempt performs ONE full try and returns nil on success/convergence,
+	// or the error to be classified. The caller's closure does, on EVERY call:
+	// (1) re-read the live resource, (2) re-classify safety/convergence (e.g.
+	// already-converged → return nil without re-emitting; bound-to-other →
+	// return a non-transient abort error), (3) if still required, re-emit the
+	// write, (4) wait for the activity. Only a transient activity failure
+	// (isTransient) is retried; anything else returns immediately.
+	attempt func(ctx context.Context) error
+	// sleep waits between attempts; it returns ctx.Err() on cancellation.
+	// Defaults to defaultVPCSleep (attempt*10s) when nil.
+	sleep func(ctx context.Context, attempt int) error
+	// isTransient classifies a failure as retryable; defaults to
+	// client.IsTransientActivityFailure (injectable for tests).
+	isTransient func(err error) bool
+	// label names the operation in the retry log line and wrapped errors.
+	label string
+}
+
+// defaultVPCSleep backs off attempt*10s between attempts, respecting ctx.
+// Mirrors defaultVIFSleep so the two retry paths behave identically.
+func defaultVPCSleep(ctx context.Context, attempt int) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Duration(attempt) * 10 * time.Second):
+		return nil
+	}
+}
+
+// runVPCWriteWithRetry drives r.attempt with a bounded retry on transient
+// platform activity failures. Invariants defended by the unit tests:
+//   - at most maxTransientVPCAttempts TOTAL attempts;
+//   - only an isTransient failure is retried; any other error (a sync POST
+//     StatusError, a non-transient activity failure, a caller abort such as
+//     bind-to-other) returns immediately, never retried;
+//   - no extra attempt after a success (attempt returns nil);
+//   - the context is honoured at the head of every attempt AND while sleeping;
+//   - on budget exhaustion the last transient error is returned (fail-closed).
+//
+// The total wall-clock is NOT bounded by the per-request HTTP timeout: it can
+// span up to maxTransientVPCAttempts full platform activities plus the
+// attempt*10s backoffs and each activity's internal polling. It is bounded by
+// the Terraform operation context — callers rely on that ctx, not on a fixed
+// number of polls (#319 Codex PLAN, budget note).
+func runVPCWriteWithRetry(ctx context.Context, r vpcWriteRetry) error {
+	if r.sleep == nil {
+		r.sleep = defaultVPCSleep
+	}
+	if r.isTransient == nil {
+		r.isTransient = client.IsTransientActivityFailure
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxTransientVPCAttempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if lastErr != nil {
+				return fmt.Errorf("cancelled while retrying %s: %w (last transient failure: %s)", r.label, ctxErr, lastErr)
+			}
+			return ctxErr
+		}
+
+		err := r.attempt(ctx)
+		if err == nil {
+			return nil
+		}
+		if !r.isTransient(err) {
+			return err
+		}
+		lastErr = err
+
+		if attempt == maxTransientVPCAttempts {
+			break
+		}
+		tflog.Warn(ctx, fmt.Sprintf("%s: transient platform failure (attempt %d/%d), retrying: %s",
+			r.label, attempt, maxTransientVPCAttempts, err))
+		if sleepErr := r.sleep(ctx, attempt); sleepErr != nil {
+			return fmt.Errorf("cancelled while retrying %s: %w (last transient failure: %s)", r.label, sleepErr, lastErr)
+		}
+	}
+	return lastErr
+}

--- a/internal/provider/vpc_write_retry_test.go
+++ b/internal/provider/vpc_write_retry_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+var (
+	errVPCTransient = errors.New("transient platform failure")
+	errVPCPermanent = errors.New("permanent failure")
+)
+
+// vpcIsTransient is the injected classifier for the mechanics tests: only the
+// sentinel transient error is retryable. The real wiring uses
+// client.IsTransientActivityFailure (covered by TestIsTransientActivityFailure).
+func vpcIsTransient(err error) bool { return errors.Is(err, errVPCTransient) }
+
+// scriptedAttempts replays the given per-attempt outcomes in order and counts
+// the calls; the last outcome repeats if the loop attempts beyond the script.
+func scriptedAttempts(calls *int, outcomes ...error) func(context.Context) error {
+	return func(ctx context.Context) error {
+		i := *calls
+		if i >= len(outcomes) {
+			i = len(outcomes) - 1
+		}
+		*calls++
+		return outcomes[i]
+	}
+}
+
+func countingSleep(sleeps *int) func(context.Context, int) error {
+	return func(ctx context.Context, attempt int) error {
+		*sleeps++
+		return nil
+	}
+}
+
+func TestRunVPCWriteWithRetry(t *testing.T) {
+	t.Run("success on the first attempt: no retry, no sleep", func(t *testing.T) {
+		calls, sleeps := 0, 0
+		err := runVPCWriteWithRetry(context.Background(), vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, nil),
+			sleep:       countingSleep(&sleeps),
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if err != nil {
+			t.Fatalf("want success, got %v", err)
+		}
+		if calls != 1 || sleeps != 0 {
+			t.Fatalf("calls=%d sleeps=%d, want 1/0", calls, sleeps)
+		}
+	})
+
+	t.Run("transient then success: retried once", func(t *testing.T) {
+		calls, sleeps := 0, 0
+		err := runVPCWriteWithRetry(context.Background(), vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, errVPCTransient, nil),
+			sleep:       countingSleep(&sleeps),
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if err != nil {
+			t.Fatalf("want success after one transient retry, got %v", err)
+		}
+		if calls != 2 || sleeps != 1 {
+			t.Fatalf("calls=%d sleeps=%d, want 2/1", calls, sleeps)
+		}
+	})
+
+	t.Run("non-transient failure: returned immediately, never retried", func(t *testing.T) {
+		calls, sleeps := 0, 0
+		// The second outcome (nil) would make a WRONG retry succeed — proving
+		// the helper does not retry a non-transient error.
+		err := runVPCWriteWithRetry(context.Background(), vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, errVPCPermanent, nil),
+			sleep:       countingSleep(&sleeps),
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if !errors.Is(err, errVPCPermanent) {
+			t.Fatalf("want the permanent error, got %v", err)
+		}
+		if calls != 1 || sleeps != 0 {
+			t.Fatalf("calls=%d sleeps=%d, want 1/0 (no retry on non-transient); kills the missing-isTransient-gate mutant", calls, sleeps)
+		}
+	})
+
+	t.Run("always transient: bounded at maxTransientVPCAttempts", func(t *testing.T) {
+		calls, sleeps := 0, 0
+		err := runVPCWriteWithRetry(context.Background(), vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, errVPCTransient),
+			sleep:       countingSleep(&sleeps),
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if !errors.Is(err, errVPCTransient) {
+			t.Fatalf("want the last transient error returned, got %v", err)
+		}
+		if calls != maxTransientVPCAttempts || sleeps != maxTransientVPCAttempts-1 {
+			t.Fatalf("calls=%d sleeps=%d, want %d/%d (bounded budget); kills the over-budget mutant",
+				calls, sleeps, maxTransientVPCAttempts, maxTransientVPCAttempts-1)
+		}
+	})
+
+	t.Run("context cancelled before the first attempt: never attempted", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls, sleeps := 0, 0
+		err := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, nil),
+			sleep:       countingSleep(&sleeps),
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if err == nil {
+			t.Fatal("want a context error")
+		}
+		if calls != 0 {
+			t.Fatalf("calls=%d, want 0 (no attempt after cancellation)", calls)
+		}
+	})
+
+	t.Run("cancellation during sleep stops without another attempt", func(t *testing.T) {
+		calls := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		cancelSleep := func(c context.Context, attempt int) error {
+			cancel()
+			return c.Err()
+		}
+		err := runVPCWriteWithRetry(ctx, vpcWriteRetry{
+			attempt:     scriptedAttempts(&calls, errVPCTransient),
+			sleep:       cancelSleep,
+			isTransient: vpcIsTransient,
+			label:       "test",
+		})
+		if err == nil {
+			t.Fatal("want a cancellation error")
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1 (cancelled during the first backoff, no second attempt); kills the cancel-during-sleep mutant", calls)
+		}
+	})
+}


### PR DESCRIPTION
Refs #319, #315.

## Problème

Le bug plateforme VPC #315 frappe les **writes asynchrones** : certaines activités échouent transitoirement avec `State: failed — Reason: "Failed to load configuration via API: …502 Bad Gateway…nginx…"`. C'est exactement l'échec observé sur un run live `tf vm` (le bind de l'IP publique a échoué sur ce 502). Le provider subissait l'échec au lieu de l'absorber.

## Approche (PLAN + DIFF Codex GO-WITH-CHANGES)

Le 502 est porté par les activités → on retente les writes **asynchrones idempotents** au niveau de l'opération, en réutilisant le pattern établi `runVIFUpdateWithRetry` (#251) et le classifieur `IsTransientActivityFailure`.

**4 commits :**

1. **Classifieur AND-match** (`activity.go`) — un nouveau marqueur composite `"Failed to load configuration via API"` **ET** (`502`|`Bad Gateway`). Pas le marqueur seul : `IsTransientActivityFailure` est **global** (il garde aussi les retries VIF/compute), donc le lead phrase seul est trop large. Fail-closed : un faux négatif est préféré à un faux positif qui retenterait un échec permanent non-idempotent.
2. **Helper générique** `runVPCWriteWithRetry` (`vpc_write_retry.go`) — **mécanique de retry pure** : ≤ 3 tentatives, backoff `attempt*10s` injectable, contexte respecté en tête de tentative ET pendant le sleep, gate `isTransient`, fail-closed sur la dernière erreur. **Aucune** logique métier dedans.
3. **Câblage Floating IP bind/unbind** — le retry enveloppe **uniquement** bind+wait / unbind+wait ; les confirmations source-de-vérité (`confirmAndSetFloatingIPBinding`, `confirmFloatingIPUnbound`) restent **dehors**. La 1ʳᵉ tentative agit directement (comportement et tests existants inchangés) ; une re-tentative re-lit + re-classifie (`classifyFloatingIPBindingLive` : read par-id puis listing strict). Bind : `BoundToTarget` = succès sans re-POST, **seul** `Unbound` autorise un re-bind, `BoundToOther`/`Inconclusive` = abort anti-clobber. Unbind : re-émission **seulement** si encore `BoundToTarget`.
4. **Câblage Static IP delete/update** — Delete : re-DELETE idempotent (404 = succès), le 403 sort du retry vers `confirmStaticIPDeleted` ; la signature publique `deleteVPCStaticIPWith` est préservée (tests intacts). Update : factorisé en `updateVPCStaticIPWith`, le diff (macAddress/resourceDescription) est **reconstruit contre un read live** à chaque tentative (jamais depuis le state) — convergé → 0 PATCH, read nil/ambigu → fail-closed.

**Hors scope :** le Create du static IP est un **POST synchrone** non idempotent (502 → `StatusError`, jamais retenté) → traité séparément dans **#348**.

## Invariants préservés

- Confirmations / preuves de suppression **hors** du retry → invariants #275/#281/#303/#312 intacts.
- Jamais de double-create / clobber : un retry ne re-binde jamais un FIP `BoundToOther`, ne re-binde pas un bind convergé, ne PATCHe pas sur preuve ambiguë.
- Seul un échec d'activité **transitoire** est retenté ; une erreur sync n'est jamais retentée.
- Le wall-clock est borné par le **contexte Terraform** (pas par le timeout HTTP 600s) — documenté.

## Tests (mutation-proven)

Chaque garde est prouvé par une mutation RED : retrait du marqueur AND, retrait du gate `isTransient`, retrait de l'abort `BoundToOther`, retrait du court-circuit de convergence Update. Ajout des cas d'attaque de la revue DIFF (fallback `corroborate` ambigu sur bind ; normalisation MAC format-only vs vraie différence).

## Revue

- **PLAN Codex** : GO-WITH-CHANGES (6 contraintes appliquées : AND-match, helper pur, re-classify dans les callers, Update garde stricte, Create exclu, budget documenté).
- **DIFF Codex** : GO-WITH-CHANGES — aucun blocker code/state-safety ; 2 ajouts de tests demandés, appliqués (+ confirmation Codex).
- Gates verts : gofmt, vet, staticcheck, build, `go test -race`. Couverture client 21.3 %, provider 15.1 % (en hausse).
