### PR TITLE
fix(#350): stop the data-disk connected drift on a powered-off VM

### DIFF
--- a/internal/provider/resource_compute_iaas_opensource_virtual_disk.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_disk.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -213,6 +214,67 @@ func confirmOpenIaaSVirtualDiskDeleted(ctx context.Context, c *client.Client, id
 	return classifyMissingDevice(id, scopedIDs, tenantIDs), nil
 }
 
+// normalizeOpenIaaSPowerState maps the platform power state to "on"/"off", or
+// "" when it is none of the known states (so the caller can fail closed). It
+// mirrors the normalisation used by the VM resource's Read.
+func normalizeOpenIaaSPowerState(s string) string {
+	switch s {
+	case "Running":
+		return "on"
+	case "Halted", "Paused":
+		return "off"
+	default:
+		return ""
+	}
+}
+
+// resolveOpenIaaSDiskConnected decides the `connected` value to write to state
+// for the disk's attachment to vmID, guarding against the power-off drift (#350).
+//
+// `connected` maps to the VBD PLUG state (connect/disconnect = currently_attached,
+// a RUNTIME fact), NOT to the attach/detach LINK. On a halted/paused VM the
+// platform reports every VBD unplugged (Connected=false), which does not reflect
+// the user's intent (it re-plugs on boot). So:
+//   - VM running  -> mirror the runtime (vm.Connected): a real disconnect is visible;
+//   - VM off       -> preserve the known intent (priorConnected) to avoid a drift;
+//   - power unknown -> fail closed (cannot decide).
+//
+// A disk that is readable but NO LONGER attached to vmID is an ATTACHMENT drift
+// (attach/detach), never a mere connected=false (connect/disconnect cannot fix
+// it): fail closed so it is surfaced, not silently flattened away.
+func resolveOpenIaaSDiskConnected(disk *client.OpenIaaSVirtualDisk, vmID string, priorConnected bool, powerState string) (bool, error) {
+	found := false
+	vbdConnected := false
+	for _, vm := range disk.VirtualMachines {
+		if vm.ID == vmID {
+			found = true
+			vbdConnected = vm.Connected
+			break
+		}
+	}
+	if !found {
+		return false, fmt.Errorf(
+			"virtual disk %s is readable but is no longer attached to virtual machine %s (attachment drift); refusing to report it as merely disconnected — re-attach the disk or fix the configuration",
+			disk.ID, vmID,
+		)
+	}
+	switch normalizeOpenIaaSPowerState(powerState) {
+	case "on":
+		// VM running: the runtime plug state is the source of truth (a genuine
+		// disconnect is observable and must surface as drift).
+		return vbdConnected, nil
+	case "off":
+		// VM halted/paused: every VBD is reported unplugged, which is NOT the
+		// intent — preserve the known intent to avoid a perpetual power-off drift.
+		return priorConnected, nil
+	default:
+		return false, fmt.Errorf(
+			"virtual machine %s (attached to disk %s) has an unknown power state %q; refusing to decide the disk connection state on ambiguous evidence",
+			vmID, disk.ID, powerState,
+		)
+	}
+}
+
 func openIaasVirtualDiskRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := getClient(meta)
 	var diags diag.Diagnostics
@@ -250,6 +312,32 @@ func openIaasVirtualDiskRead(ctx context.Context, d *schema.ResourceData, meta i
 	// Mapper les données en utilisant la fonction helper
 	vmID := d.Get("virtual_machine_id").(string)
 	diskData := helpers.FlattenOpenIaaSVirtualDisk(virtualDisk, vmID)
+
+	// #350: the flatten copies `connected` from the runtime VBD plug state, which
+	// the platform reports false for EVERY VBD of a halted VM — not the user's
+	// intent. Override it with a power-state-aware decision so stopping a VM never
+	// produces a perpetual `connected: false -> true` drift. Done HERE (not in the
+	// pure flatten helper) because it needs the VM power state and the prior intent.
+	// Only meaningful when the disk is attached to a configured VM; an id-only
+	// import (virtual_machine_id not yet known) keeps the flattened value until the
+	// configuration provides the VM.
+	if vmID != "" {
+		vm, vmErr := c.Compute().OpenIaaS().VirtualMachine().Read(ctx, vmID)
+		if vmErr != nil {
+			return diag.Errorf("failed to read virtual machine %s to resolve disk %s connection state: %s", vmID, d.Id(), vmErr)
+		}
+		if vm == nil {
+			// The OpenIaaS API maps 403 for an unknown OR forbidden id to nil:
+			// we cannot tell a halted VM from a running one, so we must not decide
+			// the connection state. Fail closed rather than risk a wrong plug state.
+			return diag.Errorf("virtual machine %s (attached to disk %s) could not be read; refusing to resolve the disk connection state on ambiguous evidence", vmID, d.Id())
+		}
+		connected, resErr := resolveOpenIaaSDiskConnected(virtualDisk, vmID, d.Get("connected").(bool), vm.PowerState)
+		if resErr != nil {
+			return diag.FromErr(resErr)
+		}
+		diskData["connected"] = connected
+	}
 
 	// Définir les données dans le state
 	for k, v := range diskData {

--- a/internal/provider/resource_compute_iaas_opensource_virtual_disk_connected_test.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_disk_connected_test.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// diskWithVBD builds a virtual disk whose VBD list attaches it to vmID with the
+// given runtime plug state (Connected).
+func diskWithVBD(diskID, vmID string, connected bool) *client.OpenIaaSVirtualDisk {
+	return &client.OpenIaaSVirtualDisk{
+		ID: diskID,
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+			{ID: vmID, Connected: connected},
+		},
+	}
+}
+
+// TestResolveOpenIaaSDiskConnected pins the power-off drift fix (#350):
+// `connected` mirrors the runtime VBD plug state ONLY while the VM runs; on a
+// halted/paused VM (where every VBD is reported unplugged) it preserves the
+// known intent; a VBD no longer attached to the configured VM and an unknown
+// power state both fail closed.
+func TestResolveOpenIaaSDiskConnected(t *testing.T) {
+	const diskID, vmID = "disk-1", "vm-1"
+
+	t.Run("VM running, runtime unplugged, intent connected -> mirror runtime false (real disconnect surfaces)", func(t *testing.T) {
+		got, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, false), vmID, true, "Running")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("a running VM must mirror the runtime plug state (false), so a genuine disconnect surfaces as drift")
+		}
+	})
+
+	t.Run("VM running, runtime plugged -> connected true (nominal, no drift)", func(t *testing.T) {
+		got, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, true), vmID, true, "Running")
+		if err != nil || !got {
+			t.Fatalf("want true,<nil> got %v,%v", got, err)
+		}
+	})
+
+	t.Run("VM halted, runtime unplugged, intent connected -> preserve intent true (no power-off drift)", func(t *testing.T) {
+		got, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, false), vmID, true, "Halted")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("a halted VM must preserve the intent (true), not mirror the runtime unplug; kills the mirror-runtime-when-off mutant")
+		}
+	})
+
+	t.Run("VM paused behaves like halted -> preserve intent true", func(t *testing.T) {
+		got, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, false), vmID, true, "Paused")
+		if err != nil || !got {
+			t.Fatalf("paused must preserve intent true, got %v,%v", got, err)
+		}
+	})
+
+	t.Run("VM halted, intent disconnected -> preserve false", func(t *testing.T) {
+		got, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, false), vmID, false, "Halted")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("a halted VM with a disconnected intent must preserve false")
+		}
+	})
+
+	t.Run("VBD absent for the configured VM -> attachment drift error, never a plain false", func(t *testing.T) {
+		// The disk is readable but attached only to a DIFFERENT VM.
+		disk := diskWithVBD(diskID, "other-vm", true)
+		got, err := resolveOpenIaaSDiskConnected(disk, vmID, true, "Running")
+		if err == nil {
+			t.Fatal("a disk no longer attached to the configured VM must error (attachment drift), not be reported as merely disconnected")
+		}
+		if got {
+			t.Fatalf("the error path must return the false zero-value, got %v", got)
+		}
+	})
+
+	t.Run("unknown power state -> fail closed", func(t *testing.T) {
+		_, err := resolveOpenIaaSDiskConnected(diskWithVBD(diskID, vmID, false), vmID, true, "Suspended")
+		if err == nil {
+			t.Fatal("an unknown power state must fail closed (cannot decide the connection state)")
+		}
+	})
+}
+
+// vdReadHandler routes a PRESENT disk read plus the VM power-state read used by
+// the #350 override in openIaasVirtualDiskRead. The disk per-id GET returns
+// diskBody (200); the VM per-id GET returns vmCode (+vmBody when 200). Any other
+// call is a 500 (the Read must not mutate).
+func vdReadHandler(diskBody string, vmCode int, vmBody string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/virtual_machines/"):
+			if vmCode != http.StatusOK {
+				w.WriteHeader(vmCode)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(vmBody))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/virtual_disks/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(diskBody))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+const vdPresentDiskBody = `{"id":"disk-x","virtualMachines":[{"id":"vm-1","connected":false}]}`
+
+// TestOpenIaasVirtualDiskReadPowerOffPreservesIntent is the end-to-end wiring of
+// the #350 fix: a halted VM reports the VBD unplugged, but Read must preserve the
+// configured intent (connected=true) instead of writing the runtime false — so a
+// stopped VM produces NO `connected: false -> true` drift.
+func TestOpenIaasVirtualDiskReadPowerOffPreservesIntent(t *testing.T) {
+	c := newAssignTestClient(t, vdReadHandler(vdPresentDiskBody, http.StatusOK, `{"id":"vm-1","powerState":"Halted"}`))
+	d := diskTestData("disk-x", "vm-1")
+	if err := d.Set("connected", true); err != nil { // the known intent
+		t.Fatalf("seeding connected: %v", err)
+	}
+	if diags := openIaasVirtualDiskRead(context.Background(), d, c); diags.HasError() {
+		t.Fatalf("a halted-VM disk read must succeed, got: %v", diags)
+	}
+	if !d.Get("connected").(bool) {
+		t.Fatal("a halted VM must preserve connected=true (no power-off drift); the runtime unplug must not overwrite the intent")
+	}
+}
+
+// TestOpenIaasVirtualDiskReadRunningMirrorsRuntime pins that while the VM runs, a
+// genuine runtime disconnect IS reflected (so a real drift still surfaces).
+func TestOpenIaasVirtualDiskReadRunningMirrorsRuntime(t *testing.T) {
+	c := newAssignTestClient(t, vdReadHandler(vdPresentDiskBody, http.StatusOK, `{"id":"vm-1","powerState":"Running"}`))
+	d := diskTestData("disk-x", "vm-1")
+	if err := d.Set("connected", true); err != nil {
+		t.Fatalf("seeding connected: %v", err)
+	}
+	if diags := openIaasVirtualDiskRead(context.Background(), d, c); diags.HasError() {
+		t.Fatalf("a running-VM disk read must succeed, got: %v", diags)
+	}
+	if d.Get("connected").(bool) {
+		t.Fatal("a running VM must mirror the runtime plug state (false): a genuine disconnect must surface as drift")
+	}
+}
+
+// TestOpenIaasVirtualDiskReadFailsClosedWhenVMUnreadable pins the fail-closed
+// guard: if the VM read maps to nil (403), the provider cannot tell halted from
+// running, so it must error rather than guess the connection state.
+func TestOpenIaasVirtualDiskReadFailsClosedWhenVMUnreadable(t *testing.T) {
+	c := newAssignTestClient(t, vdReadHandler(vdPresentDiskBody, http.StatusForbidden, ``))
+	d := diskTestData("disk-x", "vm-1")
+	if err := d.Set("connected", true); err != nil {
+		t.Fatalf("seeding connected: %v", err)
+	}
+	diags := openIaasVirtualDiskRead(context.Background(), d, c)
+	if !diags.HasError() {
+		t.Fatal("an unreadable VM (403 -> nil) must fail closed, never silently keep or guess the connection state")
+	}
+}
+
+// TestOpenIaasVirtualDiskReadFailsClosedWhenVMReadErrors pins that a VM read that
+// ERRORS (a non-403 HTTP error, distinct from the 403 -> nil path) also fails
+// closed — the provider never decides the connection state on a failed VM read.
+func TestOpenIaasVirtualDiskReadFailsClosedWhenVMReadErrors(t *testing.T) {
+	c := newAssignTestClient(t, vdReadHandler(vdPresentDiskBody, http.StatusBadRequest, ``))
+	d := diskTestData("disk-x", "vm-1")
+	if err := d.Set("connected", true); err != nil {
+		t.Fatalf("seeding connected: %v", err)
+	}
+	if diags := openIaasVirtualDiskRead(context.Background(), d, c); !diags.HasError() {
+		t.Fatal("a VM read error must fail closed, never decide the connection state")
+	}
+}
+
+// TestOpenIaasVirtualDiskReadImportIdOnlySkipsVMRead pins that an id-only read
+// (virtual_machine_id not yet known, e.g. right after import) SKIPS the override
+// entirely and issues NO VM read — there is no intent/power state to resolve yet.
+func TestOpenIaasVirtualDiskReadImportIdOnlySkipsVMRead(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/virtual_machines/"):
+			t.Errorf("an id-only read must NOT read the VM, got: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/virtual_disks/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(vdPresentDiskBody))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+	c := newAssignTestClient(t, handler)
+	d := resourceOpenIaasVirtualDisk().TestResourceData()
+	d.SetId("disk-x") // virtual_machine_id intentionally NOT set (id-only import)
+	if diags := openIaasVirtualDiskRead(context.Background(), d, c); diags.HasError() {
+		t.Fatalf("an id-only read must succeed without a VM read, got: %v", diags)
+	}
+}


### PR DESCRIPTION
Refs #350.

## Problem

After stopping a VM through Terraform, the next plan showed a perpetual in-place update on the attached data disk:

```
# cloudtemple_compute_iaas_opensource_virtual_disk.data will be updated in-place
  ~ connected = false -> true
Plan: 0 to add, 1 to change, 0 to destroy.
```

Applying it would issue a `connect` (`PATCH .../connect`) against a halted VM. **TF prod breaker**, captured on a live `tf vm` lifecycle run (create → stop → converge).

## Root cause

`connected` is `Optional + Default: true` (an *intent*), but `Read` flattened it from the **runtime** VBD plug state (`vm.Connected`). The OpenIaaS API distinguishes `connect`/`disconnect` (plug/unplug — `currently_attached`, runtime) from `attach`/`detach` (the VBD link). On a **halted/paused** VM the platform reports every VBD unplugged, so `Read` wrote `connected=false` while the intent stayed `true` → perpetual drift.

## Fix (Codex PLAN GO-WITH-CHANGES — Option D)

In `openIaasVirtualDiskRead`, after the pure flatten, override `connected` with a power-state-aware decision (`resolveOpenIaaSDiskConnected`):

- **VM running** → mirror the runtime (`vm.Connected`): a genuine disconnect still surfaces as drift;
- **VM halted/paused** → preserve the known intent (`d.Get("connected")`): a powered-off VBD unplug is **not** drift;
- **VM unreadable (403 → nil) / unknown power state** → **fail closed** with an actionable error;
- **disk readable but no longer attached to the configured VM** → attachment-drift error, never a plain `connected=false` (connect/disconnect cannot fix a detach).

The decision lives **outside** the pure flatten helper (it needs the VM power state and the prior intent). `os_disk.connected` on the VM resource is **untouched** (Computed-only, does not drift) — no scope creep. An id-only import (`virtual_machine_id` not yet known) keeps the flattened value until the configuration provides the VM (documented).

## Tests (mutation-proven)

- `resolveOpenIaaSDiskConnected` unit tests cover all 7 Codex cases; mutating the off-case to mirror the runtime makes the power-off tests RED.
- Wiring tests (HTTP mock) pin the end-to-end power-off-no-drift, running-mirrors-runtime, and fail-closed-on-unreadable-VM.

## Review & gates

- **PLAN Codex**: GO-WITH-CHANGES (Option D + fail-closed guards, applied).
- **DIFF Codex**: see review-trace comment.
- gofmt, vet, staticcheck, build, `go test -race`: green. Provider coverage 15.8% (up).
