### PR TITLE
test(#293): pin the VM StateUpgrader (V0->V1 extra_config migration)

### DIFF
--- a/internal/provider/resource_compute_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_virtual_machine_unit_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -92,4 +94,114 @@ func TestBuildVMwareBootOptionsFromRaw(t *testing.T) {
 			t.Fatalf("unconfigured enter_bios_setup must stay omitted: %+v", opts)
 		}
 	})
+}
+
+// TestMigrateVirtualMachineStateV0toV1 pins the only StateUpgrader in the
+// provider (#293, S7). The V0 schema stored extra_config as a list of
+// {key,value} objects; V1 stores it as a map. The migration must convert the
+// list to the map, but must NEVER panic, drop a valid pair, invent a key, or
+// corrupt sibling state keys on an N-1 -> N upgrade — the catastrophic class
+// this state-safety program guards against. Non-complacent: each case reds out
+// if the conversion is dropped, mishandles already-migrated / absent / nil /
+// malformed input, changes the duplicate-key resolution, or loses other keys.
+func TestMigrateVirtualMachineStateV0toV1(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "v0 list is converted to the v1 map",
+			in: map[string]interface{}{
+				"extra_config": []interface{}{
+					map[string]interface{}{"key": "a", "value": "1"},
+					map[string]interface{}{"key": "b", "value": "2"},
+				},
+			},
+			want: map[string]interface{}{
+				"extra_config": map[string]interface{}{"a": "1", "b": "2"},
+			},
+		},
+		{
+			name: "an already-migrated map is left unchanged (idempotent)",
+			in: map[string]interface{}{
+				"extra_config": map[string]interface{}{"a": "1"},
+			},
+			want: map[string]interface{}{
+				"extra_config": map[string]interface{}{"a": "1"},
+			},
+		},
+		{
+			name: "absent extra_config is untouched (no key invented, no panic)",
+			in:   map[string]interface{}{"id": "vm-1"},
+			want: map[string]interface{}{"id": "vm-1"},
+		},
+		{
+			name: "nil extra_config stays nil (no panic)",
+			in:   map[string]interface{}{"extra_config": nil},
+			want: map[string]interface{}{"extra_config": nil},
+		},
+		{
+			name: "empty list becomes an empty map",
+			in:   map[string]interface{}{"extra_config": []interface{}{}},
+			want: map[string]interface{}{"extra_config": map[string]interface{}{}},
+		},
+		{
+			name: "malformed items are skipped without dropping valid pairs or panicking",
+			in: map[string]interface{}{
+				"extra_config": []interface{}{
+					map[string]interface{}{"key": "a", "value": "1"}, // valid
+					"garbage",                            // not a map
+					42,                                   // not a map
+					map[string]interface{}{"key": "b"},   // missing value
+					map[string]interface{}{"value": "2"}, // missing key
+					map[string]interface{}{"key": 123, "value": "x"}, // non-string key
+					map[string]interface{}{"key": "c", "value": 456}, // non-string value
+					map[string]interface{}{"key": "d", "value": "4"}, // valid
+				},
+			},
+			want: map[string]interface{}{
+				"extra_config": map[string]interface{}{"a": "1", "d": "4"},
+			},
+		},
+		{
+			name: "duplicate keys: the last value wins",
+			in: map[string]interface{}{
+				"extra_config": []interface{}{
+					map[string]interface{}{"key": "k", "value": "1"},
+					map[string]interface{}{"key": "k", "value": "2"},
+				},
+			},
+			want: map[string]interface{}{
+				"extra_config": map[string]interface{}{"k": "2"},
+			},
+		},
+		{
+			name: "sibling state keys are preserved across the migration",
+			in: map[string]interface{}{
+				"id":   "vm-1",
+				"name": "web",
+				"extra_config": []interface{}{
+					map[string]interface{}{"key": "a", "value": "1"},
+				},
+			},
+			want: map[string]interface{}{
+				"id":           "vm-1",
+				"name":         "web",
+				"extra_config": map[string]interface{}{"a": "1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := migrateVirtualMachineStateV0toV1(context.Background(), tt.in, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("migration mismatch:\n got  = %#v\n want = %#v", got, tt.want)
+			}
+		})
+	}
 }

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -2,5 +2,5 @@
 # Raised as coverage improves (scripts/coverage_ratchet.sh --update);
 # CI fails if coverage drops below these values. Never lower by hand.
 internal/client 21.0
-internal/provider 13.4
+internal/provider 16.1
 internal/provider/helpers 68.1


### PR DESCRIPTION
Refs #293. Refs #257.

## Problem

`migrateVirtualMachineStateV0toV1` is the **only** `StateUpgrader` in the provider, and it was **untested** — the highest state-safety gap in the S7 coverage roadmap (#293). A buggy StateUpgrader silently corrupts a client's Terraform state on an N-1 → N provider upgrade.

The V0 schema stored `extra_config` as a list of `{key, value}` objects; V1 stores it as a map. The upgrader converts the list to the map.

## Change (test-only)

A mutation-proven, table-driven unit test (`TestMigrateVirtualMachineStateV0toV1`) covering:

- V0 list → V1 map conversion;
- idempotence on already-migrated (map) state;
- absent / nil `extra_config` (no panic, no invented key);
- empty list → empty map;
- malformed items skipped without dropping the valid pairs or panicking (non-map item, missing key/value, non-string key/value);
- duplicate keys: last value wins;
- sibling state keys preserved across the migration.

No production code changes. The `internal/provider` coverage floor is raised 13.4 → 16.1 to lock in the gain (the upgrader was at 0%).

## Mutation proof (non-complacency)

- Dropping the conversion (the `rawState["extra_config"] = extraConfigMap` assignment removed) → 5 cases RED.
- First-wins on duplicate keys → the duplicate case RED.

## Review & gates

- **DIFF Codex** (adversarial, read-only): **GO** — no blocking findings; the test is faithful to the function's real behavior (the `exists && != nil` guard, the `[]interface{}` type assertion, the per-item key/value type asserts, last-write-wins, and in-place sibling preservation are all verified). Optional non-blocking ideas (unexpected top-level type, nil item) are corrupted-state / out-of-SDK-pipeline cases. The `SchemaVersion` / `StateUpgrader` wiring itself is already frozen by the schema golden snapshot (#298/#299).
- gofmt, `go vet ./...`, staticcheck, `go build ./...`, `go test -race`: green.
- Coverage ratchet: `internal/provider` 16.1% (floor raised to 16.1).
