### PR TITLE
fix(#293): guard setIdFromActivityConcernedItems against an empty id + pin both id resolvers

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -564,7 +564,9 @@ func setIdFromActivityConcernedItems(d *schema.ResourceData, activity *client.Ac
 	}
 
 	i := slices.IndexFunc(activity.ConcernedItems, func(concernedItem client.ActivityConcernedItem) bool { return concernedItem.Type == expectedType })
-	if i > -1 {
+	if i > -1 && activity.ConcernedItems[i].ID != "" {
+		// Symmetric with setIdFromActivityState: never adopt an empty id, which
+		// would clobber a previously-set id and make the resource untrackable.
 		d.SetId(activity.ConcernedItems[i].ID)
 	}
 }

--- a/internal/provider/provider_set_id_from_activity_unit_test.go
+++ b/internal/provider/provider_set_id_from_activity_unit_test.go
@@ -1,0 +1,193 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// newEmptyResourceData returns a ResourceData backed by an empty schema. The
+// functions under test only touch SetId/Id, which are schema-independent.
+func newEmptyResourceData() *schema.ResourceData {
+	return (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+}
+
+// TestSetIdFromActivityState pins how a resource id is resolved from an async
+// activity's State (#293, S7). Setting the wrong id makes Terraform track the
+// wrong remote object — a state-safety hazard. The function must set the id
+// ONLY when there is exactly one state carrying a non-empty Result, and must
+// never guess (ambiguous) or clobber on a no-op. Non-complacent: dropping the
+// "exactly one" guard reds the multi-state case.
+func TestSetIdFromActivityState(t *testing.T) {
+	tests := []struct {
+		name     string
+		activity *client.Activity
+		priorID  string
+		wantID   string
+	}{
+		{
+			name:     "nil activity is a no-op",
+			activity: nil,
+			wantID:   "",
+		},
+		{
+			name:     "empty state is a no-op",
+			activity: &client.Activity{State: map[string]client.ActivityState{}},
+			wantID:   "",
+		},
+		{
+			name: "exactly one state with a result sets the id",
+			activity: &client.Activity{State: map[string]client.ActivityState{
+				"step-1": {Result: "vm-123"},
+			}},
+			wantID: "vm-123",
+		},
+		{
+			name: "exactly one state with an empty result is a no-op",
+			activity: &client.Activity{State: map[string]client.ActivityState{
+				"step-1": {Result: ""},
+			}},
+			wantID: "",
+		},
+		{
+			name: "more than one state is a no-op (ambiguous, never guess the id)",
+			activity: &client.Activity{State: map[string]client.ActivityState{
+				"step-1": {Result: "vm-1"},
+				"step-2": {Result: "vm-2"},
+			}},
+			wantID: "",
+		},
+		{
+			name:     "a nil activity never clobbers a pre-existing id",
+			activity: nil,
+			priorID:  "pre-existing",
+			wantID:   "pre-existing",
+		},
+		{
+			name: "exactly one state with an empty result never clobbers a pre-existing id",
+			activity: &client.Activity{State: map[string]client.ActivityState{
+				"step-1": {Result: ""},
+			}},
+			priorID: "pre-existing",
+			wantID:  "pre-existing",
+		},
+		{
+			name: "more than one state never clobbers a pre-existing id",
+			activity: &client.Activity{State: map[string]client.ActivityState{
+				"step-1": {Result: "vm-1"},
+				"step-2": {Result: "vm-2"},
+			}},
+			priorID: "pre-existing",
+			wantID:  "pre-existing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newEmptyResourceData()
+			if tt.priorID != "" {
+				d.SetId(tt.priorID)
+			}
+			setIdFromActivityState(d, tt.activity)
+			if d.Id() != tt.wantID {
+				t.Fatalf("id = %q, want %q", d.Id(), tt.wantID)
+			}
+		})
+	}
+}
+
+// TestSetIdFromActivityConcernedItems pins how a resource id is resolved from
+// an activity's ConcernedItems (#293, S7). The id must come from the item
+// matching the expected type — regardless of its position — and the function
+// must never adopt a wrong-typed or empty id, never panic when no item matches,
+// and never clobber on a no-op. Non-complacent: dropping the index guard panics
+// the no-match case; ignoring the type filter reds the position case; dropping
+// the empty-id guard reds the empty-id case.
+func TestSetIdFromActivityConcernedItems(t *testing.T) {
+	tests := []struct {
+		name         string
+		activity     *client.Activity
+		expectedType string
+		priorID      string
+		wantID       string
+	}{
+		{
+			name:         "nil activity is a no-op",
+			activity:     nil,
+			expectedType: "virtual_machine",
+			wantID:       "",
+		},
+		{
+			name:         "empty concerned items is a no-op",
+			activity:     &client.Activity{ConcernedItems: nil},
+			expectedType: "virtual_machine",
+			wantID:       "",
+		},
+		{
+			name: "the item matching the expected type sets the id",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "vm-1", Type: "virtual_machine"},
+			}},
+			expectedType: "virtual_machine",
+			wantID:       "vm-1",
+		},
+		{
+			name: "no item of the expected type is a no-op (never adopt a wrong-typed id)",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "net-1", Type: "network"},
+			}},
+			expectedType: "virtual_machine",
+			wantID:       "",
+		},
+		{
+			name: "the expected type is selected regardless of position (not index 0)",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "net-1", Type: "network"},
+				{ID: "vm-1", Type: "virtual_machine"},
+			}},
+			expectedType: "virtual_machine",
+			wantID:       "vm-1",
+		},
+		{
+			name: "the first item of the expected type wins on duplicates",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "vm-1", Type: "virtual_machine"},
+				{ID: "vm-2", Type: "virtual_machine"},
+			}},
+			expectedType: "virtual_machine",
+			wantID:       "vm-1",
+		},
+		{
+			name: "a no match never clobbers a pre-existing id",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "net-1", Type: "network"},
+			}},
+			expectedType: "virtual_machine",
+			priorID:      "pre-existing",
+			wantID:       "pre-existing",
+		},
+		{
+			name: "a matching item with an empty id is a no-op (never clobber with an empty id)",
+			activity: &client.Activity{ConcernedItems: []client.ActivityConcernedItem{
+				{ID: "", Type: "virtual_machine"},
+			}},
+			expectedType: "virtual_machine",
+			priorID:      "pre-existing",
+			wantID:       "pre-existing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newEmptyResourceData()
+			if tt.priorID != "" {
+				d.SetId(tt.priorID)
+			}
+			setIdFromActivityConcernedItems(d, tt.activity, tt.expectedType)
+			if d.Id() != tt.wantID {
+				t.Fatalf("id = %q, want %q", d.Id(), tt.wantID)
+			}
+		})
+	}
+}

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -2,5 +2,5 @@
 # Raised as coverage improves (scripts/coverage_ratchet.sh --update);
 # CI fails if coverage drops below these values. Never lower by hand.
 internal/client 21.0
-internal/provider 16.1
+internal/provider 16.4
 internal/provider/helpers 68.1


### PR DESCRIPTION
Refs #293. Refs #257.

## Problem

`setIdFromActivityState` and `setIdFromActivityConcernedItems` resolve a resource id from an async activity, and were **untested** (S7 coverage roadmap, #293). Setting the wrong — or empty — id makes Terraform track the wrong remote object, or makes the resource untrackable: a state-safety hazard.

A review also surfaced an **asymmetry**: `setIdFromActivityConcernedItems` would `SetId("")` when a matching `ConcernedItem` carried an empty `ID`, clobbering a previously-set id — whereas `setIdFromActivityState` already refuses an empty `Result`.

## Change

**Fix (1 line, production):** `setIdFromActivityConcernedItems` now refuses an empty id (`i > -1 && ConcernedItems[i].ID != ""`), symmetric with `setIdFromActivityState`. An empty id is not a trackable Terraform id, so not setting it is strictly safer than clobbering with `""`.

**Tests (mutation-proven, table-driven):**

- `setIdFromActivityState`: id set **only** on exactly one state with a non-empty `Result`; nil / empty / multi-state / empty-result are no-ops that never clobber a pre-existing id.
- `setIdFromActivityConcernedItems`: id from the item matching the expected type **regardless of position**, first-match wins on duplicates; no match / nil / empty / empty-id are no-ops that never clobber.

The `internal/provider` coverage floor is raised 16.1 → 16.4.

## Mutation proof (non-complacency)

- Drop the exactly-one-state guard → the multi-state case REDs.
- Drop the not-found index guard → the no-match case panics (REDs).
- Drop the empty-id guard → the empty-id case REDs (clobber to `""`).

## Review & gates

- **DIFF Codex** (adversarial, read-only): GO on the technical change — the short-circuit guard is safe (no panic on no-match), the fix does not break a legitimate path, the tests faithfully reflect the corrected behavior, and the mutation proof covers the new guard. Known non-blocking residuals: a same-type duplicate where the first item has an empty id falls through to a no-op (the caller should fail closed on an empty `d.Id()`); several callers set the id before checking the `WaitForCompletion` error (pre-existing, not introduced here).
- gofmt, `go vet ./...`, staticcheck, `go build ./...`, `go test -race`: green.
- Coverage ratchet: `internal/provider` 16.4% (floor raised to 16.4).
