### PR TITLE
test(#293): pin WaitFor* waiter invariants with no-real-sleep unit tests

### DIFF
--- a/internal/client/backup_inventory_unit_test.go
+++ b/internal/client/backup_inventory_unit_test.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// These tests pin the two inventory waiters (backup virtual disk + virtual
+// machine). They share the same shape: ANY read error is fatal at once (no
+// transient retry — #293 Finding F1, pinned NOT fixed here), a nil result keeps
+// polling (bounded by the injected backoff / context), and a found object returns.
+
+type bvdOutcome struct {
+	disk *BackupVirtualDisk
+	err  error
+}
+
+func scriptedBackupVirtualDiskReads(calls *int, outcomes ...bvdOutcome) backupVirtualDiskReadFunc {
+	return func(ctx context.Context) (*BackupVirtualDisk, error) {
+		i := *calls
+		if i >= len(outcomes) {
+			i = len(outcomes) - 1
+		}
+		*calls++
+		return outcomes[i].disk, outcomes[i].err
+	}
+}
+
+type bvmOutcome struct {
+	vm  *BackupVirtualMachine
+	err error
+}
+
+func scriptedBackupVirtualMachineReads(calls *int, outcomes ...bvmOutcome) backupVirtualMachineReadFunc {
+	return func(ctx context.Context) (*BackupVirtualMachine, error) {
+		i := *calls
+		if i >= len(outcomes) {
+			i = len(outcomes) - 1
+		}
+		*calls++
+		return outcomes[i].vm, outcomes[i].err
+	}
+}
+
+func TestWaitForBackupVirtualDiskInventory(t *testing.T) {
+	t.Run("a transient 5xx read error is FATAL at once (F1: no transient retry)", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualDiskReads(&calls, bvdOutcome{err: StatusError{Code: http.StatusInternalServerError}})
+		_, err := waitForBackupVirtualDiskInventory(context.Background(), "disk-1", read, immediateBackoff(20), nil)
+		if err == nil {
+			t.Fatal("the current behavior treats ANY read error as fatal; a transient 5xx must fail (pins F1)")
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want exactly 1 (no retry, even on a transient 5xx)", calls)
+		}
+	})
+
+	t.Run("nil then found: waits then returns", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualDiskReads(&calls,
+			bvdOutcome{}, // not yet in inventory
+			bvdOutcome{disk: &BackupVirtualDisk{}},
+		)
+		disk, err := waitForBackupVirtualDiskInventory(context.Background(), "disk-1", read, immediateBackoff(20), nil)
+		if err != nil || disk == nil {
+			t.Fatalf("a nil result must keep polling until the disk appears, got err=%v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2", calls)
+		}
+	})
+
+	t.Run("stuck-nil is bounded by the injected backoff", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualDiskReads(&calls, bvdOutcome{}) // nil forever
+		_, err := waitForBackupVirtualDiskInventory(context.Background(), "disk-1", read, immediateBackoff(3), nil)
+		if err == nil {
+			t.Fatal("a never-appearing disk must be bounded by the backoff/context, not loop forever")
+		}
+		if calls != 4 {
+			t.Fatalf("calls=%d, want 4 (initial + 3 retries)", calls)
+		}
+	})
+
+	t.Run("context cancellation stops polling", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		read := func(c context.Context) (*BackupVirtualDisk, error) {
+			calls++
+			cancel()
+			return nil, nil
+		}
+		_, err := waitForBackupVirtualDiskInventory(ctx, "disk-1", read, immediateBackoff(50), nil)
+		if err == nil {
+			t.Fatal("context cancellation must stop the polling")
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1 (the loop must honour the retry ctx)", calls)
+		}
+	})
+
+	t.Run("found returns immediately", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualDiskReads(&calls, bvdOutcome{disk: &BackupVirtualDisk{}})
+		disk, err := waitForBackupVirtualDiskInventory(context.Background(), "disk-1", read, immediateBackoff(20), nil)
+		if err != nil || disk == nil {
+			t.Fatalf("a found disk must return at once, got err=%v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1", calls)
+		}
+	})
+}
+
+func TestWaitForBackupVirtualMachineInventory(t *testing.T) {
+	t.Run("a transient 5xx read error is FATAL at once (F1: no transient retry)", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualMachineReads(&calls, bvmOutcome{err: StatusError{Code: http.StatusInternalServerError}})
+		_, err := waitForBackupVirtualMachineInventory(context.Background(), "vm-1", read, immediateBackoff(20), nil)
+		if err == nil {
+			t.Fatal("the current behavior treats ANY read error as fatal; a transient 5xx must fail (pins F1)")
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want exactly 1 (no retry, even on a transient 5xx)", calls)
+		}
+	})
+
+	t.Run("nil then found: waits then returns", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualMachineReads(&calls,
+			bvmOutcome{},
+			bvmOutcome{vm: &BackupVirtualMachine{}},
+		)
+		vm, err := waitForBackupVirtualMachineInventory(context.Background(), "vm-1", read, immediateBackoff(20), nil)
+		if err != nil || vm == nil {
+			t.Fatalf("a nil result must keep polling until the VM appears, got err=%v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2", calls)
+		}
+	})
+
+	t.Run("stuck-nil is bounded by the injected backoff", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualMachineReads(&calls, bvmOutcome{})
+		_, err := waitForBackupVirtualMachineInventory(context.Background(), "vm-1", read, immediateBackoff(3), nil)
+		if err == nil {
+			t.Fatal("a never-appearing VM must be bounded by the backoff/context, not loop forever")
+		}
+		if calls != 4 {
+			t.Fatalf("calls=%d, want 4 (initial + 3 retries)", calls)
+		}
+	})
+
+	t.Run("context cancellation stops polling", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		read := func(c context.Context) (*BackupVirtualMachine, error) {
+			calls++
+			cancel()
+			return nil, nil
+		}
+		_, err := waitForBackupVirtualMachineInventory(ctx, "vm-1", read, immediateBackoff(50), nil)
+		if err == nil {
+			t.Fatal("context cancellation must stop the polling")
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1 (the loop must honour the retry ctx)", calls)
+		}
+	})
+
+	t.Run("found returns immediately", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupVirtualMachineReads(&calls, bvmOutcome{vm: &BackupVirtualMachine{}})
+		vm, err := waitForBackupVirtualMachineInventory(context.Background(), "vm-1", read, immediateBackoff(20), nil)
+		if err != nil || vm == nil {
+			t.Fatalf("a found VM must return at once, got err=%v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls=%d, want 1", calls)
+		}
+	})
+}

--- a/internal/client/backup_job.go
+++ b/internal/client/backup_job.go
@@ -116,12 +116,29 @@ func (c *BackupJobClient) WaitForCompletion(ctx context.Context, id string, opti
 	b := retry.NewFibonacci(1 * time.Second)
 	b = retry.WithCappedDuration(30*time.Second, b)
 
+	return waitForBackupJobCompletion(ctx, id, func(ctx context.Context) (*BackupJob, error) {
+		return c.Read(ctx, id)
+	}, b, options)
+}
+
+// backupJobReadFunc abstracts the job read so the polling loop can be unit
+// tested without HTTP calls or real sleeps.
+type backupJobReadFunc func(ctx context.Context) (*BackupJob, error)
+
+// waitForBackupJobCompletion is the polling loop behind WaitForCompletion, with
+// the read and the backoff injected (mirrors waitForActivityCompletion). Behavior
+// is preserved exactly: transient read errors are retried, permanent/timeout/ctx
+// errors fail at once, an IDLE job is completion, RUNNING keeps polling, anything
+// else is a failure, and the not-found tolerance is `count == 1` ONLY — i.e. a nil
+// job on the FIRST polling attempt; any prior attempt (a transient blip or a
+// RUNNING status) consumes it (see #293 Finding F2; NOT changed here).
+func waitForBackupJobCompletion(ctx context.Context, id string, read backupJobReadFunc, b retry.Backoff, options *WaiterOptions) (*BackupJob, error) {
 	var res *BackupJob
 	var count int
 
 	err := retry.Do(ctx, b, func(ctx context.Context) error {
 		count++
-		job, err := c.Read(ctx, id)
+		job, err := read(ctx)
 		if err != nil {
 			// Only a transient read error is worth retrying. A configured request
 			// timeout, a context error or a permanent error (4xx, decode) must fail

--- a/internal/client/backup_job_unit_test.go
+++ b/internal/client/backup_job_unit_test.go
@@ -1,0 +1,157 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// bjOutcome scripts one read of the backup-job waiter.
+type bjOutcome struct {
+	job *BackupJob
+	err error
+}
+
+// scriptedBackupJobReads replays the given outcomes in order and counts calls;
+// the last outcome repeats if the loop polls beyond the script.
+func scriptedBackupJobReads(calls *int, outcomes ...bjOutcome) backupJobReadFunc {
+	return func(ctx context.Context) (*BackupJob, error) {
+		i := *calls
+		if i >= len(outcomes) {
+			i = len(outcomes) - 1
+		}
+		*calls++
+		return outcomes[i].job, outcomes[i].err
+	}
+}
+
+func idleJob() *BackupJob    { return &BackupJob{ID: "job-1", Status: "IDLE"} }
+func runningJob() *BackupJob { return &BackupJob{ID: "job-1", Status: "RUNNING"} }
+
+func TestWaitForBackupJobTransientReadErrorsAreRetried(t *testing.T) {
+	calls := 0
+	read := scriptedBackupJobReads(&calls,
+		bjOutcome{err: StatusError{Code: http.StatusInternalServerError}},
+		bjOutcome{err: StatusError{Code: http.StatusBadGateway}},
+		bjOutcome{job: idleJob()},
+	)
+	job, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+	if err != nil || job == nil {
+		t.Fatalf("transient read errors must be survived then IDLE succeeds, got err=%v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls=%d, want 3 (two transient + IDLE)", calls)
+	}
+}
+
+// TestWaitForBackupJobNonRetryableReadErrorsFailAtOnce covers permanent errors
+// AND configured timeout / context errors: the waiter doc (backup_job.go) requires
+// a configured request timeout or a context error to fail at once, never retried
+// (retrying a timeout would stall for minutes).
+func TestWaitForBackupJobNonRetryableReadErrorsFailAtOnce(t *testing.T) {
+	nonRetryable := []error{
+		StatusError{Code: http.StatusBadRequest},
+		errors.New("json: cannot unmarshal string into Go value"),
+		context.Canceled,
+		context.DeadlineExceeded,
+		&url.Error{Op: "Get", URL: "https://shiva.example", Err: timeoutErr{}},
+	}
+	for _, e := range nonRetryable {
+		t.Run(fmt.Sprintf("%v", e), func(t *testing.T) {
+			calls := 0
+			read := scriptedBackupJobReads(&calls, bjOutcome{err: e})
+			_, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+			if err == nil {
+				t.Fatal("a non-retryable read error must fail the wait")
+			}
+			if calls != 1 {
+				t.Fatalf("calls=%d, want exactly 1 (no retry on a permanent/timeout/ctx error)", calls)
+			}
+		})
+	}
+}
+
+// TestWaitForBackupJobNotFoundToleranceIsFirstAttemptOnly pins the CURRENT
+// count==1 semantics (#293 Finding F2): the not-found tolerance is "nil job on the
+// very FIRST polling attempt", not "first nil occurrence". A prior attempt — here a
+// transient blip — consumes the tolerance, so a subsequent nil job is immediately
+// fatal. T6(b) is the mutation-killer that forbids "fixing" this into activity-style
+// notFoundTolerated/activitySeen (FF-3) under this test PR.
+func TestWaitForBackupJobNotFoundToleranceIsFirstAttemptOnly(t *testing.T) {
+	t.Run("nil job on the first attempt then IDLE succeeds", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupJobReads(&calls,
+			bjOutcome{}, // nil job, nil err: not found on attempt 1 (tolerated)
+			bjOutcome{job: idleJob()},
+		)
+		job, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+		if err != nil || job == nil {
+			t.Fatalf("a first-attempt not-found must be tolerated, got err=%v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2", calls)
+		}
+	})
+
+	t.Run("a transient blip before the nil job consumes the count==1 tolerance => fatal", func(t *testing.T) {
+		calls := 0
+		read := scriptedBackupJobReads(&calls,
+			bjOutcome{err: StatusError{Code: http.StatusInternalServerError}}, // attempt 1 (count==1) consumed here
+			bjOutcome{}, // attempt 2: nil job, count!=1 => permanent
+		)
+		_, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+		if err == nil {
+			t.Fatal("a nil job after the count==1 tolerance was consumed must be fatal (pins current behavior, F2)")
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2 (the prior transient attempt consumed the tolerance)", calls)
+		}
+	})
+}
+
+func TestWaitForBackupJobRunningKeepsPolling(t *testing.T) {
+	calls := 0
+	read := scriptedBackupJobReads(&calls,
+		bjOutcome{job: runningJob()},
+		bjOutcome{job: idleJob()},
+	)
+	job, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+	if err != nil || job == nil {
+		t.Fatalf("RUNNING must keep polling then IDLE succeeds, got err=%v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d, want 2 (RUNNING is not terminal)", calls)
+	}
+}
+
+func TestWaitForBackupJobUnknownStatusIsTerminal(t *testing.T) {
+	calls := 0
+	read := scriptedBackupJobReads(&calls, bjOutcome{job: &BackupJob{ID: "job-1", Status: "FAILED"}})
+	_, err := waitForBackupJobCompletion(context.Background(), "job-1", read, immediateBackoff(20), nil)
+	if err == nil {
+		t.Fatal("a non-IDLE/non-RUNNING status must fail without retry")
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want exactly 1 (unknown status is terminal)", calls)
+	}
+}
+
+func TestWaitForBackupJobContextCancellationStopsPolling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	read := func(c context.Context) (*BackupJob, error) {
+		calls++
+		cancel()
+		return runningJob(), nil
+	}
+	_, err := waitForBackupJobCompletion(ctx, "job-1", read, immediateBackoff(50), nil)
+	if err == nil {
+		t.Fatal("context cancellation must stop the polling")
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1 (the loop must honour the retry ctx, not context.Background())", calls)
+	}
+}

--- a/internal/client/backup_virtual_disk.go
+++ b/internal/client/backup_virtual_disk.go
@@ -73,12 +73,28 @@ func (c *BackupVirtualDiskClient) WaitForInventory(ctx context.Context, id strin
 	b := retry.NewFibonacci(1 * time.Second)
 	b = retry.WithCappedDuration(30*time.Second, b)
 
+	return waitForBackupVirtualDiskInventory(ctx, id, func(ctx context.Context) (*BackupVirtualDisk, error) {
+		return c.Read(ctx, id)
+	}, b, options)
+}
+
+// backupVirtualDiskReadFunc abstracts the read so the inventory polling loop can
+// be unit tested without HTTP calls or real sleeps.
+type backupVirtualDiskReadFunc func(ctx context.Context) (*BackupVirtualDisk, error)
+
+// waitForBackupVirtualDiskInventory is the polling loop behind WaitForInventory,
+// with read and backoff injected. Behavior preserved exactly: ANY read error is
+// fatal at once (no transient-vs-permanent distinction — see #293 Finding F1; NOT
+// changed here), a nil result keeps polling (waiting for the disk to appear in the
+// inventory), and a found disk returns. The poll is bounded only by the injected
+// backoff / context.
+func waitForBackupVirtualDiskInventory(ctx context.Context, id string, read backupVirtualDiskReadFunc, b retry.Backoff, options *WaiterOptions) (*BackupVirtualDisk, error) {
 	var res *BackupVirtualDisk
 	var count int
 
 	err := retry.Do(ctx, b, func(ctx context.Context) error {
 		count++
-		virtualDisk, err := c.Read(ctx, id)
+		virtualDisk, err := read(ctx)
 		if err != nil {
 			return options.error(err)
 		}

--- a/internal/client/backup_virtual_machine.go
+++ b/internal/client/backup_virtual_machine.go
@@ -85,12 +85,27 @@ func (c *BackupVirtualMachineClient) WaitForInventory(ctx context.Context, id st
 	b := retry.NewFibonacci(1 * time.Second)
 	b = retry.WithCappedDuration(30*time.Second, b)
 
+	return waitForBackupVirtualMachineInventory(ctx, id, func(ctx context.Context) (*BackupVirtualMachine, error) {
+		return c.Read(ctx, id)
+	}, b, options)
+}
+
+// backupVirtualMachineReadFunc abstracts the read so the inventory polling loop
+// can be unit tested without HTTP calls or real sleeps.
+type backupVirtualMachineReadFunc func(ctx context.Context) (*BackupVirtualMachine, error)
+
+// waitForBackupVirtualMachineInventory is the polling loop behind WaitForInventory,
+// with read and backoff injected. Behavior preserved exactly (same shape as the
+// disk inventory waiter): ANY read error is fatal at once (no transient distinction
+// — see #293 Finding F1; NOT changed here), a nil result keeps polling, a found VM
+// returns. The poll is bounded only by the injected backoff / context.
+func waitForBackupVirtualMachineInventory(ctx context.Context, id string, read backupVirtualMachineReadFunc, b retry.Backoff, options *WaiterOptions) (*BackupVirtualMachine, error) {
 	var res *BackupVirtualMachine
 	var count int
 
 	err := retry.Do(ctx, b, func(ctx context.Context) error {
 		count++
-		virtualMachine, err := c.Read(ctx, id)
+		virtualMachine, err := read(ctx)
 		if err != nil {
 			return options.error(err)
 		}

--- a/internal/client/compute_iaas_opensource_virtual_machine.go
+++ b/internal/client/compute_iaas_opensource_virtual_machine.go
@@ -234,20 +234,58 @@ func (c *OpenIaaSVirtualMachineClient) WaitForDrivers(
 	timeout time.Duration,
 	options *WaiterOptions,
 ) (*OpenIaaSVirtualMachine, error) {
+	return waitForDrivers(ctx, id, timeout,
+		func(d time.Duration) (<-chan time.Time, func()) {
+			t := time.NewTicker(d)
+			return t.C, t.Stop
+		},
+		func(ctx context.Context) (*OpenIaaSVirtualMachine, error) {
+			return c.Read(ctx, id)
+		},
+		options,
+	)
+}
+
+// driverReadFunc abstracts the VM read; newTickerFunc abstracts the poll ticker
+// (it returns the tick channel and a stop func). Both are injected so
+// waitForDrivers is unit tested without HTTP calls or a real 5s tick (a
+// test-controlled channel drives the ticks). A channel seam is used rather than a
+// fake *time.Ticker to avoid depending on time.Ticker internals.
+type driverReadFunc func(ctx context.Context) (*OpenIaaSVirtualMachine, error)
+type newTickerFunc func(d time.Duration) (<-chan time.Time, func())
+
+// waitForDrivers is the polling loop behind WaitForDrivers, with the ticker and
+// read injected. Behavior is preserved EXACTLY:
+//   - timeout == 0: ONE read with the PARENT ctx, no ticker, return it (best-effort skip);
+//   - timeout > 0: a timeout ctx is created BEFORE the ticker (factory called with 5s);
+//     reads use the TIMEOUT ctx, not the parent;
+//   - the timeout firing (before any tick, or via the guard on a late tick) returns
+//     (lastVM, nil) — best-effort, NEVER an error;
+//   - a read error returns (nil, fmt.Errorf("[WAITER] failed to read ...: %s", id, err)) —
+//     note %s, NOT %w (the original error is not wrapped);
+//   - a nil VM returns (nil, fmt.Errorf("[WAITER] the virtual machine %q could not be found", id)).
+func waitForDrivers(
+	ctx context.Context,
+	id string,
+	timeout time.Duration,
+	newTicker newTickerFunc,
+	read driverReadFunc,
+	options *WaiterOptions,
+) (*OpenIaaSVirtualMachine, error) {
 
 	if timeout == 0 {
 		options.log(fmt.Sprintf(
 			"[WAITER] skipping wait for drivers for virtual machine %q (timeout = 0)",
 			id,
 		))
-		return c.Read(ctx, id)
+		return read(ctx)
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
+	tickC, stop := newTicker(5 * time.Second)
+	defer stop()
 
 	var lastVM *OpenIaaSVirtualMachine
 
@@ -261,14 +299,14 @@ func (c *OpenIaaSVirtualMachineClient) WaitForDrivers(
 			))
 			return lastVM, nil
 
-		case <-ticker.C:
+		case <-tickC:
 
 			if timeoutCtx.Err() != nil {
 				options.log("[WAITER] timeout reached while waiting, continuing without PV drivers")
 				return lastVM, nil
 			}
 
-			vm, err := c.Read(timeoutCtx, id)
+			vm, err := read(timeoutCtx)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"[WAITER] failed to read virtual machine %q while waiting for drivers: %s",

--- a/internal/client/compute_iaas_opensource_virtual_machine_drivers_unit_test.go
+++ b/internal/client/compute_iaas_opensource_virtual_machine_drivers_unit_test.go
@@ -1,0 +1,193 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// These tests pin OpenIaaSVirtualMachineClient.WaitForDrivers via the
+// waitForDrivers seam, driving ticks through an injected channel so there is no
+// real 5s wait. They lock the exact behavior the live method relies on (best-effort
+// on timeout, parent-vs-timeout ctx, error message format with %s not %w).
+
+func detectedDriverVM() *OpenIaaSVirtualMachine {
+	vm := &OpenIaaSVirtualMachine{ID: "vm-1"}
+	vm.PVDrivers.Detected = true
+	return vm
+}
+
+func undetectedDriverVM() *OpenIaaSVirtualMachine {
+	return &OpenIaaSVirtualMachine{ID: "vm-1"} // PVDrivers.Detected == false
+}
+
+type driverResult struct {
+	vm  *OpenIaaSVirtualMachine
+	err error
+}
+
+func TestWaitForDriversTimeoutZeroSkipsWithParentCtx(t *testing.T) {
+	tickerCalled := false
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) {
+		tickerCalled = true
+		return nil, func() {}
+	}
+	var gotCtx context.Context
+	read := func(ctx context.Context) (*OpenIaaSVirtualMachine, error) {
+		gotCtx = ctx
+		return detectedDriverVM(), nil
+	}
+
+	vm, err := waitForDrivers(context.Background(), "vm-1", 0, newTicker, read, nil)
+	if err != nil || vm == nil {
+		t.Fatalf("timeout==0 must do a single read and return it, got err=%v", err)
+	}
+	if tickerCalled {
+		t.Fatal("timeout==0 must NOT create a ticker")
+	}
+	if _, ok := gotCtx.Deadline(); ok {
+		t.Fatal("timeout==0 must read with the PARENT ctx (no deadline), not a timeout ctx")
+	}
+}
+
+func TestWaitForDriversTickerIsFiveSecondsAndReadUsesTimeoutCtx(t *testing.T) {
+	tickCh := make(chan time.Time, 1)
+	var gotDur time.Duration
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) {
+		gotDur = d
+		return tickCh, func() {}
+	}
+	var hadDeadline bool
+	read := func(ctx context.Context) (*OpenIaaSVirtualMachine, error) {
+		_, hadDeadline = ctx.Deadline()
+		return detectedDriverVM(), nil // detected => returns, terminating the loop
+	}
+
+	resCh := make(chan driverResult, 1)
+	go func() {
+		vm, err := waitForDrivers(context.Background(), "vm-1", time.Hour, newTicker, read, nil)
+		resCh <- driverResult{vm, err}
+	}()
+	tickCh <- time.Now()
+	res := <-resCh
+
+	if res.err != nil || res.vm == nil {
+		t.Fatalf("a detected VM on a tick must return it, got err=%v", res.err)
+	}
+	if gotDur != 5*time.Second {
+		t.Fatalf("ticker interval=%s, want 5s", gotDur)
+	}
+	if !hadDeadline {
+		t.Fatal("reads while waiting must use the TIMEOUT ctx (with a deadline), not the parent")
+	}
+}
+
+func TestWaitForDriversTimeoutAfterReadIsBestEffort(t *testing.T) {
+	tickCh := make(chan time.Time, 1)
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) { return tickCh, func() {} }
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	read := func(c context.Context) (*OpenIaaSVirtualMachine, error) {
+		calls++
+		cancel() // after this read, the timeout ctx is Done; the loop hits the timeout case
+		return undetectedDriverVM(), nil
+	}
+
+	resCh := make(chan driverResult, 1)
+	go func() {
+		vm, err := waitForDrivers(ctx, "vm-1", time.Hour, newTicker, read, nil)
+		resCh <- driverResult{vm, err}
+	}()
+	tickCh <- time.Now()
+	res := <-resCh
+
+	if res.err != nil {
+		t.Fatalf("a timeout AFTER a non-detected read must be best-effort (nil error), got %v", res.err)
+	}
+	if res.vm == nil {
+		t.Fatal("the timeout path must return the last seen VM (lastVM), not nil")
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
+	}
+}
+
+func TestWaitForDriversTimeoutBeforeFirstTickReadsNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled: the timeout ctx is Done before any tick
+	tickCh := make(chan time.Time, 1)
+	calls := 0
+	read := func(c context.Context) (*OpenIaaSVirtualMachine, error) {
+		calls++
+		return detectedDriverVM(), nil
+	}
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) { return tickCh, func() {} }
+
+	vm, err := waitForDrivers(ctx, "vm-1", time.Hour, newTicker, read, nil)
+	if err != nil {
+		t.Fatalf("a timeout before the first tick must return (nil, nil), got err=%v", err)
+	}
+	if vm != nil {
+		t.Fatalf("no read happened, so there is no lastVM; got %v", vm)
+	}
+	if calls != 0 {
+		t.Fatalf("calls=%d, want 0 (timeout fired before any tick)", calls)
+	}
+}
+
+func TestWaitForDriversReadErrorIsWrappedNotUnwrappable(t *testing.T) {
+	tickCh := make(chan time.Time, 1)
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) { return tickCh, func() {} }
+	sentinel := errors.New("read boom")
+	read := func(c context.Context) (*OpenIaaSVirtualMachine, error) {
+		return nil, sentinel
+	}
+
+	resCh := make(chan driverResult, 1)
+	go func() {
+		vm, err := waitForDrivers(context.Background(), "vm-1", time.Hour, newTicker, read, nil)
+		resCh <- driverResult{vm, err}
+	}()
+	tickCh <- time.Now()
+	res := <-resCh
+
+	if res.vm != nil {
+		t.Fatalf("a read error must return a nil VM, got %v", res.vm)
+	}
+	// Exact message equality pins the full current format (not just a substring).
+	wantMsg := `[WAITER] failed to read virtual machine "vm-1" while waiting for drivers: read boom`
+	if res.err == nil || res.err.Error() != wantMsg {
+		t.Fatalf("read error message must be exactly %q, got %v", wantMsg, res.err)
+	}
+	// Current behavior formats with a non-wrapping verb (not an error-wrapping one):
+	// the original error is not reachable. Pinning this kills both a raw-err return
+	// and an error-wrapping "improvement" slipping in under a test PR.
+	if errors.Is(res.err, sentinel) {
+		t.Fatal("the read error must NOT be wrapped (current non-wrapping semantics); errors.Is must be false")
+	}
+}
+
+func TestWaitForDriversNilVMIsNotFound(t *testing.T) {
+	tickCh := make(chan time.Time, 1)
+	newTicker := func(d time.Duration) (<-chan time.Time, func()) { return tickCh, func() {} }
+	read := func(c context.Context) (*OpenIaaSVirtualMachine, error) {
+		return nil, nil
+	}
+
+	resCh := make(chan driverResult, 1)
+	go func() {
+		vm, err := waitForDrivers(context.Background(), "vm-1", time.Hour, newTicker, read, nil)
+		resCh <- driverResult{vm, err}
+	}()
+	tickCh <- time.Now()
+	res := <-resCh
+
+	if res.vm != nil {
+		t.Fatalf("a nil VM must return a nil result, got %v", res.vm)
+	}
+	wantMsg := `[WAITER] the virtual machine "vm-1" could not be found`
+	if res.err == nil || res.err.Error() != wantMsg {
+		t.Fatalf("a nil VM must return exactly %q, got %v", wantMsg, res.err)
+	}
+}

--- a/internal/client/waiter_options_unit_test.go
+++ b/internal/client/waiter_options_unit_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sethvargo/go-retry"
+)
+
+// TestWaiterOptionsErrorIsNotRetryable pins that WaiterOptions.error wraps an
+// error as NON-retryable: a retry.Do whose body returns options.error(...) must
+// stop after exactly one attempt (it is the terminal-failure signal for every
+// waiter loop). Kills a mutant that routes error() through RetryableError, which
+// would make every permanent failure (4xx, decode, terminal state) loop until the
+// backoff/context bound — masking real failures.
+func TestWaiterOptionsErrorIsNotRetryable(t *testing.T) {
+	opts := &WaiterOptions{}
+	sentinel := errors.New("boom")
+	calls := 0
+	err := retry.Do(context.Background(), immediateBackoff(5), func(ctx context.Context) error {
+		calls++
+		return opts.error(sentinel)
+	})
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1 (error() must be terminal, not retried)", calls)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error() must return the original error unchanged, got %v", err)
+	}
+}
+
+// TestWaiterOptionsRetryableErrorIsRetryableAndWraps pins that
+// WaiterOptions.retryableError makes an error retryable AND keeps the original
+// reachable via errors.Is. The behavioral half (a retry.Do retries it then
+// succeeds) kills a mutant that returns the bare error (no retry); the wrapping
+// half kills a mutant that drops the cause.
+func TestWaiterOptionsRetryableErrorIsRetryableAndWraps(t *testing.T) {
+	opts := &WaiterOptions{}
+
+	base := errors.New("transient cause")
+	if !errors.Is(opts.retryableError(base), base) {
+		t.Fatal("retryableError must keep the original error reachable via errors.Is")
+	}
+
+	calls := 0
+	err := retry.Do(context.Background(), immediateBackoff(5), func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			return opts.retryableError(errors.New("transient"))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("a retryableError must be retried then succeed, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d, want 2 (retryableError must be retried)", calls)
+	}
+}
+
+// TestWaiterOptionsLogIsNilSafe pins that log never panics on a nil receiver or a
+// nil Logger, and forwards the message to a configured Logger. nil-safety is
+// asserted ONLY for log: error(nil)/retryableError(nil) would call err.Error() on
+// a nil error and panic, but callers never pass a nil error, so that path is not a
+// supported invariant and is deliberately not exercised.
+func TestWaiterOptionsLogIsNilSafe(t *testing.T) {
+	var nilOpts *WaiterOptions
+	nilOpts.log("must not panic on a nil receiver")
+	(&WaiterOptions{}).log("must not panic on a nil Logger")
+
+	got := ""
+	(&WaiterOptions{Logger: func(m string) { got = m }}).log("hello")
+	if got != "hello" {
+		t.Fatalf("a configured Logger must receive the message, got %q", got)
+	}
+}

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -1,6 +1,6 @@
 # Per-package statement-coverage floor (percent) for the pure packages.
 # Raised as coverage improves (scripts/coverage_ratchet.sh --update);
 # CI fails if coverage drops below these values. Never lower by hand.
-internal/client 21.0
+internal/client 24.8
 internal/provider 16.4
 internal/provider/helpers 70.0


### PR DESCRIPTION
## What

Closes the last open increment of #293 (S7 test coverage, "P2 — activity invariants"):
pins the `WaitFor*` waiter invariants with mutation-proven unit tests, **with no real
sleeps**, mirroring the `waitForActivityCompletion` pattern (#249).

## How — behavior-preserving seams

Each public waiter now delegates to an extracted, testable seam (read + backoff
injected); the public method builds the identical backoff/ticker, so runtime behavior
is unchanged.

- **`WaiterOptions.{log,error,retryableError}`** — `error()` non-retryable vs
  `retryableError()` retryable (+ `errors.Is` wrapping), `log` nil-safe.
- **`backup_job` `waitForBackupJobCompletion`** — transient retried; permanent / configured
  timeout / context errors fatal at once; `IDLE` completes; `RUNNING` polls; unknown status
  terminal; not-found tolerance is `count == 1`.
- **`backup_virtual_disk` / `backup_virtual_machine` `waitForBackup*Inventory`** — any read
  error fatal; nil result polls (bounded by the injected backoff); found returns; context
  cancellation stops.
- **`WaitForDrivers` `waitForDrivers`** (injected ticker channel) — `timeout == 0` skips with
  the parent ctx and no ticker; otherwise a timeout ctx is created before the 5s ticker and
  reads use it; timeout is best-effort `(lastVM, nil)`; read-error / not-found messages
  unchanged (`%s`, not `%w`).

`internal/client` coverage floor raised 21.0 → 24.8 (ratchet green).

## Findings flagged, NOT fixed here (follow-up issue)

- **F1**: `backup_virtual_disk/machine.WaitForInventory` treat **any** read error as fatal (no
  transient-vs-permanent distinction), unlike `activity`/`backup_job` (#245 class).
- **F2**: `backup_job` not-found tolerance is `count == 1` — a prior transient/`RUNNING` attempt
  consumes it, unlike `activity`'s FF-3 `notFoundTolerated` logic.

Both are pinned as current behavior; alignment is proposed in a separate issue.

## Validation

- `go build ./...` green; `internal/client` unit tests green under `-race`.
- Two RED-without-fix mutation proofs executed (F2 `count==1`; `WaitForDrivers` best-effort
  timeout), then reverted.
- Coverage ratchet green with the raised floor.
- Plan adversarially reviewed (Codex, 3 rounds → GO); committed diff reviewed (Codex → GO).

Refs #293
