### PR TITLE
fix(#348): VPC static IP create is async, not sync

### DIFF
--- a/cmd/ct-validate/cleanup_seams.go
+++ b/cmd/ct-validate/cleanup_seams.go
@@ -102,10 +102,22 @@ func confirmComputeDeleteByPriorDelete(err error, priorDeleteOK bool, id string)
 
 // staticIPDeleteErrResult is the SHARED static-IP delete idempotency decision
 // (#312): a 404 is idempotent success; a 403 is AMBIGUOUS (#303 conflates
-// absent/forbidden) and is confirmed via a strict 200-only listing of the
-// private network before being accepted; any other error surfaces. listStrict
-// is injected so the decision is unit-testable offline.
-func staticIPDeleteErrResult(err error, listStrict func() ([]*client.StaticIP, error), privateNetworkID, id string) error {
+// absent/forbidden) and is accepted as "gone" ONLY on strict positive evidence;
+// any other error surfaces. There are TWO independent positive channels:
+//
+//   - priorDeleteOK: this cycle's explicit delete of THIS exact id already
+//     succeeded (a 200, or a definitive 404) — strict same-cycle proof of absence,
+//     identical to confirmComputeDeleteByPriorDelete. A deferred 403-on-absent is
+//     then the conflation, not an orphan, and is accepted WITHOUT re-listing.
+//   - the strict 200-only listing of the private network: unlike the OpenIaaS
+//     compute delete (whose Read/list conflate 403/404 and so CANNOT prove
+//     absence, hence priorDeleteOK is its only channel), the VPC per-network
+//     listing CAN prove absence, so it is the independent fallback when there is
+//     no same-cycle proof. Found → still present → fail; provably-absent → success.
+//
+// Neither channel proving absence (no proof AND an inconclusive/failed listing)
+// FAILS CLOSED. listStrict is injected so the decision is unit-testable offline.
+func staticIPDeleteErrResult(err error, priorDeleteOK bool, listStrict func() ([]*client.StaticIP, error), privateNetworkID, id string) error {
 	if err == nil {
 		return nil
 	}
@@ -113,8 +125,13 @@ func staticIPDeleteErrResult(err error, listStrict func() ([]*client.StaticIP, e
 		return nil
 	}
 	if isStatusCode(err, http.StatusForbidden) {
+		// Channel 1: strict same-cycle explicit-delete proof — accept without a list.
+		if priorDeleteOK {
+			return nil
+		}
+		// Channel 2: confirm via the strict, provably-complete per-network listing.
 		if privateNetworkID == "" {
-			return fmt.Errorf("static IP %s delete returned 403 and its absence could not be confirmed (no private network scope): %w", id, err)
+			return fmt.Errorf("static IP %s delete returned 403 and its absence could not be confirmed (no same-cycle delete proof and no private network scope): %w", id, err)
 		}
 		list, lerr := listStrict()
 		if lerr != nil {
@@ -154,8 +171,8 @@ func fipUnbindOutcome(state client.FloatingIPBindingState, corrErr error, fipID,
 
 // --- VPC static IP -----------------------------------------------------------
 //
-// DEPRECATED CONTRACT (/vpc/v1, frozen — see internal/client/vpc.go): used only
-// by the opt-in vpcCycle teardown, kept for the rebuild, not on the default path.
+// REBUILDING CONTRACT (/vpc/v1, v1.9.0 rebuild — see internal/client/vpc.go): used
+// only by the opt-in vpcCycle teardown, not on the default read-only path.
 
 // staticIPSeam is the subset of the VPC static-IP client a static-IP teardown
 // needs. *client.Client satisfies it via vpcStaticIPSeam.
@@ -164,27 +181,55 @@ type staticIPSeam interface {
 	// static IPs (fails closed otherwise — see the client doc).
 	ListStrict(ctx context.Context, privateNetworkID string) ([]*client.StaticIP, error)
 	// DeleteAndWait deletes a static IP by id and waits for the delete activity.
-	// It is idempotent under the F3 contract: a 404 is success; a 403 is
-	// confirmed absent via a strict listing of privateNetworkID before being
-	// accepted (mirrors #312); any other error is surfaced.
-	DeleteAndWait(ctx context.Context, privateNetworkID, id string) error
+	// It is idempotent under the F3 contract: a 404 is success; a 403 is accepted
+	// as gone only on strict positive evidence (mirrors #312). priorDeleteOK is the
+	// same-cycle explicit-delete proof for THIS id: when true, a deferred 403 is
+	// accepted without re-listing; when false, the 403 is confirmed via a strict
+	// listing of privateNetworkID, else fails closed. Any other error is surfaced.
+	DeleteAndWait(ctx context.Context, privateNetworkID, id string, priorDeleteOK bool) error
 }
 
-// registerStaticIPTeardown registers a teardown that finds the custom static IP
-// carrying our MAC on the private network and deletes it if present. It is
-// registered BEFORE Create, so even an ambiguous/failed create (201 empty body,
-// id unresolved) is still swept by the next teardown pass. The deterministic key
-// is (privateNetworkID, mac); no created id is needed.
+// staticIPTeardownRef carries the static-IP identity for teardown, filled as the
+// cycle progresses (shared pointer, like adapterTeardownRef/diskTeardownRef). The
+// teardown deletes by the resolved ID when Resolved; otherwise it finds the custom
+// static IP carrying MAC via a strict per-network listing. ExplicitlyDeleted is the
+// strict same-cycle proof that the RESOLVED id was deleted this cycle (lets a
+// deferred 403-on-absent be accepted). ActivityID is kept for postmortem
+// diagnostics only — the teardown never re-waits or re-resolves it.
+type staticIPTeardownRef struct {
+	PrivateNetworkID  string
+	MAC               string
+	ID                string
+	ActivityID        string
+	Resolved          bool
+	ExplicitlyDeleted bool
+}
+
+// registerStaticIPTeardown registers the static-IP teardown BEFORE CreateStart, so
+// it covers process-death AND the "POST accepted server-side but the create call
+// errored before yielding an id" ambiguous window (the pre-POST fallback). It
+// mirrors registerNetworkAdapterTeardown: when the id resolved, delete by that
+// exact id (the same-cycle explicit-delete proof accepts a deferred 403-on-absent);
+// otherwise — UNRESOLVED or FAILED create, NOT special-cased — find the custom
+// static IP carrying our MAC via a STRICT (provably-complete) listing and delete it.
 //
-// Idempotent: if no custom static IP carries our MAC, the network is already
-// clean and the teardown succeeds.
-func registerStaticIPTeardown(cl *Cleanup, seam staticIPSeam, privateNetworkID, mac string) {
-	cl.Register(fmt.Sprintf("vpc.static_ip by-mac %s on %s", mac, privateNetworkID), func(tctx context.Context) error {
-		list, err := seam.ListStrict(tctx, privateNetworkID)
+// A FAILED create is never short-circuited to "success": it flows through the
+// strict-listing fallback exactly like an unresolved one, because failure alone is
+// not positive evidence of absence (§5). Idempotent: an absent IP (provably-complete
+// listing without our MAC) is already clean → success.
+func registerStaticIPTeardown(cl *Cleanup, seam staticIPSeam, ref *staticIPTeardownRef) {
+	cl.Register(fmt.Sprintf("vpc.static_ip by-mac %s on %s", ref.MAC, ref.PrivateNetworkID), func(tctx context.Context) error {
+		if ref.Resolved && ref.ID != "" {
+			// Resolved id: the same-cycle explicit-delete proof (ExplicitlyDeleted)
+			// accepts a deferred 403-on-absent without re-listing; absent the proof,
+			// the seam confirms the 403 via a strict listing or fails closed.
+			return seam.DeleteAndWait(tctx, ref.PrivateNetworkID, ref.ID, ref.ExplicitlyDeleted)
+		}
+		list, err := seam.ListStrict(tctx, ref.PrivateNetworkID)
 		if err != nil {
 			return err
 		}
-		want := normalizeMACForCleanup(mac)
+		want := normalizeMACForCleanup(ref.MAC)
 		for _, si := range list {
 			if si == nil || si.Source != "custom" {
 				continue
@@ -192,8 +237,10 @@ func registerStaticIPTeardown(cl *Cleanup, seam staticIPSeam, privateNetworkID, 
 			if normalizeMACForCleanup(si.MacAddress) != want {
 				continue
 			}
-			// Found our created-but-maybe-unresolved static IP: delete by id.
-			return seam.DeleteAndWait(tctx, privateNetworkID, si.ID)
+			// Found by listing: no same-cycle proof for this id (priorDeleteOK=false),
+			// so a 403 here must be re-confirmed by the seam's strict listing or fail
+			// closed — never accepted on the find alone.
+			return seam.DeleteAndWait(tctx, ref.PrivateNetworkID, si.ID, false)
 		}
 		// Absent → already clean → success (idempotent).
 		return nil
@@ -225,13 +272,14 @@ func (s vpcStaticIPSeam) ListStrict(ctx context.Context, privateNetworkID string
 	return s.c.VPC().StaticIP().ListStrict(ctx, privateNetworkID)
 }
 
-func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string) error {
+func (s vpcStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string, priorDeleteOK bool) error {
 	activityID, err := s.c.VPC().StaticIP().Delete(ctx, id)
 	if err != nil {
-		// 404 → idempotent success; 403 → confirm absence via the strict listing
-		// (#312); anything else surfaces. The decision lives in a shared, offline-
-		// testable helper so production and tests cannot drift.
-		return staticIPDeleteErrResult(err, func() ([]*client.StaticIP, error) {
+		// 404 → idempotent success; 403 → accepted on the same-cycle proof
+		// (priorDeleteOK) else confirmed via the strict listing (#312); anything else
+		// surfaces. The decision lives in a shared, offline-testable helper so
+		// production and tests cannot drift.
+		return staticIPDeleteErrResult(err, priorDeleteOK, func() ([]*client.StaticIP, error) {
 			return s.ListStrict(ctx, privateNetworkID)
 		}, privateNetworkID, id)
 	}
@@ -316,8 +364,8 @@ func (s objectStorageACLSeam) RevokeAndWait(ctx context.Context, bucket, role, a
 
 // --- VPC floating IP binding --------------------------------------------------
 //
-// DEPRECATED CONTRACT (/vpc/v1, frozen — see internal/client/vpc.go): used only
-// by the opt-in vpcCycle teardown, kept for the rebuild, not on the default path.
+// REBUILDING CONTRACT (/vpc/v1, v1.9.0 rebuild — see internal/client/vpc.go): used
+// only by the opt-in vpcCycle teardown, not on the default read-only path.
 
 // fipBindSeam is the subset of the floating-IP client a binding teardown needs.
 type fipBindSeam interface {

--- a/cmd/ct-validate/cleanup_seams_test.go
+++ b/cmd/ct-validate/cleanup_seams_test.go
@@ -36,15 +36,17 @@ func (f *fakeStaticIPSeam) ListStrict(_ context.Context, _ string) ([]*client.St
 
 // DeleteAndWait routes the injected delete error through the SAME production
 // helper (staticIPDeleteErrResult) the real vpcStaticIPSeam uses, so a mutation
-// in that helper breaks both production and this test (no parallel copy).
-func (f *fakeStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string) error {
+// in that helper breaks both production and this test (no parallel copy). It
+// forwards priorDeleteOK (the same-cycle explicit-delete proof) untouched, so a
+// test can exercise channel 1 (proof) and channel 2 (strict listing) distinctly.
+func (f *fakeStaticIPSeam) DeleteAndWait(ctx context.Context, privateNetworkID, id string, priorDeleteOK bool) error {
 	f.deleted = append(f.deleted, id)
 	err := f.deleteErr
 	if len(f.deleteErrs) > 0 {
 		err = f.deleteErrs[0]
 		f.deleteErrs = f.deleteErrs[1:]
 	}
-	return staticIPDeleteErrResult(err, func() ([]*client.StaticIP, error) {
+	return staticIPDeleteErrResult(err, priorDeleteOK, func() ([]*client.StaticIP, error) {
 		return f.ListStrict(ctx, privateNetworkID)
 	}, privateNetworkID, id)
 }
@@ -64,7 +66,7 @@ func TestStaticIPTeardownSweepsCreatedButUnresolved(t *testing.T) {
 		},
 	}
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	if cl.Pending() != 1 {
 		t.Fatalf("teardown must be registered before Create; Pending=%d", cl.Pending())
 	}
@@ -81,12 +83,83 @@ func TestStaticIPTeardownSweepsCreatedButUnresolved(t *testing.T) {
 func TestStaticIPTeardownIdempotentWhenAbsent(t *testing.T) {
 	seam := &fakeStaticIPSeam{list: []*client.StaticIP{}}
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
 		t.Fatalf("absent static IP must be idempotent success, got %+v", fails)
 	}
 	if len(seam.deleted) != 0 {
 		t.Fatalf("nothing should be deleted when absent, deleted %v", seam.deleted)
+	}
+}
+
+// TestStaticIPTeardownByIDWhenResolved proves that once the create resolves the
+// id (shared ref, set AFTER registration — the adapter/disk/PAT precedent), the
+// teardown deletes by THAT id and does NOT fall back to the by-MAC strict
+// listing. Non-complacent: the listing is seeded with a DIFFERENT custom id for
+// the same MAC, so dropping the resolved branch (always listing) deletes the
+// wrong id → RED.
+func TestStaticIPTeardownByIDWhenResolved(t *testing.T) {
+	seam := &fakeStaticIPSeam{
+		list: []*client.StaticIP{{ID: "by-mac-id", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}},
+	}
+	cl := NewCleanup()
+	ref := &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"}
+	registerStaticIPTeardown(cl, seam, ref)
+	// The create resolves the id AFTER registration (the shared-ref pattern).
+	ref.ID = "si-resolved"
+	ref.Resolved = true
+
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("resolved teardown should succeed, got %+v", fails)
+	}
+	if len(seam.deleted) != 1 || seam.deleted[0] != "si-resolved" {
+		t.Fatalf("a resolved static IP must be deleted by its id, not the by-MAC listing match, deleted=%v", seam.deleted)
+	}
+}
+
+// TestStaticIPTeardownResolved403WithProofSucceeds proves the same-cycle
+// explicit-delete proof (ref.ExplicitlyDeleted) is a REAL, non-vestigial accept
+// channel: a deferred 403-on-absent for the RESOLVED id is accepted WITHOUT a
+// confirming listing — even a listing that STILL shows the id — because this
+// cycle already deleted it (#303 conflates absent/forbidden). Non-complacent: the
+// listing is rigged to still contain the id, so success comes ONLY via the
+// priorDeleteOK short-circuit; dropping `if priorDeleteOK { return nil }` in
+// staticIPDeleteErrResult makes the still-present listing fail closed → RED.
+func TestStaticIPTeardownResolved403WithProofSucceeds(t *testing.T) {
+	seam := &fakeStaticIPSeam{
+		list:      []*client.StaticIP{{ID: "si-resolved", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}}, // STILL present
+		deleteErr: client.StatusError{Code: 403},
+	}
+	cl := NewCleanup()
+	ref := &staticIPTeardownRef{
+		PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00",
+		ID: "si-resolved", Resolved: true, ExplicitlyDeleted: true,
+	}
+	registerStaticIPTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
+		t.Fatalf("a deferred 403 WITH a same-cycle delete proof must be accepted without re-listing, got %+v", fails)
+	}
+}
+
+// TestStaticIPTeardownResolved403WithoutProofFailsClosed proves the converse and
+// is what makes ExplicitlyDeleted non-vestigial: with the SAME 403 and the SAME
+// still-present listing but NO same-cycle proof, the teardown confirms via the
+// strict listing, finds the id still present, and FAILS CLOSED (never assumes
+// gone). The pair — with-proof succeeds, without-proof fails — pins that the
+// proof is the only thing that flips the outcome.
+func TestStaticIPTeardownResolved403WithoutProofFailsClosed(t *testing.T) {
+	seam := &fakeStaticIPSeam{
+		list:      []*client.StaticIP{{ID: "si-resolved", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}}, // STILL present
+		deleteErr: client.StatusError{Code: 403},
+	}
+	cl := NewCleanup()
+	ref := &staticIPTeardownRef{
+		PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00",
+		ID: "si-resolved", Resolved: true, ExplicitlyDeleted: false,
+	}
+	registerStaticIPTeardown(cl, seam, ref)
+	if fails := cl.TeardownAll(context.Background()); len(fails) != 1 {
+		t.Fatalf("a deferred 403 with NO same-cycle proof and a still-present listing must fail closed, got %+v", fails)
 	}
 }
 
@@ -572,10 +645,14 @@ func TestPATDelete403Surfaced(t *testing.T) {
 // classifyStaticDeleteErr drives the REAL production helper
 // (staticIPDeleteErrResult) against an injected delete error and confirmation
 // listing, so the contract is unit-tested offline without a client and a
-// mutation in the helper is caught here.
+// mutation in the helper is caught here. priorDeleteOK is false: this harness
+// exercises CHANNEL 2 (the strict-listing confirmation), so a 403 is resolved
+// purely by the listing. The same-cycle-proof CHANNEL 1 (priorDeleteOK=true) is
+// exercised end-to-end by the registration tests (a resolved ref + a 403 the
+// listing CANNOT clear, accepted only via the proof).
 func classifyStaticDeleteErr(t *testing.T, deleteErr error, confirmList []*client.StaticIP, listErr error) error {
 	t.Helper()
-	return staticIPDeleteErrResult(deleteErr, func() ([]*client.StaticIP, error) {
+	return staticIPDeleteErrResult(deleteErr, false, func() ([]*client.StaticIP, error) {
 		return confirmList, listErr
 	}, "pn-1", "sip-1")
 }
@@ -597,7 +674,7 @@ func TestStaticIPDoubleDeleteNoFalseFailure(t *testing.T) {
 		deleteErrs: []error{client.StatusError{Code: 404}}, // the deferred (second) delete
 	}
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
 		t.Fatalf("a deferred delete of an already-removed static IP (404) must NOT be a failure, got %+v", fails)
 	}
@@ -628,7 +705,7 @@ type transientThenStaticSeam struct {
 func (s *transientThenStaticSeam) ListStrict(_ context.Context, _ string) ([]*client.StaticIP, error) {
 	return []*client.StaticIP{{ID: "custom-1", MacAddress: "02:00:5e:f0:00:00", Source: "custom"}}, nil
 }
-func (s *transientThenStaticSeam) DeleteAndWait(_ context.Context, _, _ string) error {
+func (s *transientThenStaticSeam) DeleteAndWait(_ context.Context, _, _ string, _ bool) error {
 	s.calls++
 	if s.until > 0 && s.calls >= s.until {
 		return nil
@@ -641,7 +718,7 @@ func (s *transientThenStaticSeam) DeleteAndWait(_ context.Context, _, _ string) 
 func TestStaticIPDeleteTransientRetriedThenSucceeds(t *testing.T) {
 	seam := &transientThenStaticSeam{until: 2}
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	if fails := cl.TeardownAll(context.Background()); len(fails) != 0 {
 		t.Fatalf("a transient 5xx that recovers must succeed, got %+v", fails)
 	}
@@ -656,7 +733,7 @@ func TestStaticIPDeleteTransientRetriedThenSucceeds(t *testing.T) {
 func TestStaticIPDeleteTransientExhaustedSurfaced(t *testing.T) {
 	seam := &transientThenStaticSeam{} // never succeeds
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	fails := cl.TeardownAll(context.Background())
 	if len(fails) != 1 {
 		t.Fatalf("a persistent 5xx must surface as a teardown failure, got %+v", fails)
@@ -671,7 +748,7 @@ func TestStaticIPDeleteTransientExhaustedSurfaced(t *testing.T) {
 func TestStaticIPTeardownSurfacesListError(t *testing.T) {
 	seam := &fakeStaticIPSeam{listErr: client.StatusError{Code: 403}}
 	cl := NewCleanup()
-	registerStaticIPTeardown(cl, seam, "pn-1", "02:00:5e:f0:00:00")
+	registerStaticIPTeardown(cl, seam, &staticIPTeardownRef{PrivateNetworkID: "pn-1", MAC: "02:00:5e:f0:00:00"})
 	fails := cl.TeardownAll(context.Background())
 	if len(fails) != 1 {
 		t.Fatalf("a strict-listing error must surface as a teardown failure, got %+v", fails)

--- a/cmd/ct-validate/cycle.go
+++ b/cmd/ct-validate/cycle.go
@@ -58,12 +58,14 @@ type Cycle interface {
 }
 
 // quarantined is an OPTIONAL capability a Cycle may implement to exclude itself
-// from the "all" selector. It exists for a cycle that drives a deprecated or
-// frozen contract and is kept only as an explicit, opt-in harness (currently
-// vpcCycle, on the frozen /vpc/v1). A quarantined cycle still runs when named
-// explicitly (`-cycles <name>`), but a blanket `-cycles all` must NEVER reach
-// it — so a full validation sweep can never accidentally hammer a dead contract
-// (the 2026-06-15 incident was exactly a VPC write loop amplifying an outage).
+// from the "all" selector. It exists for a cycle whose contract is not safe to
+// reach from a blanket sweep — currently because it is under active rebuild —
+// and is kept only as an explicit, opt-in harness (currently vpcCycle: /vpc/v1
+// is UNDER ACTIVE REBUILD for v1.9.0 and stays quarantined until its end-to-end
+// write cycle is proven). A quarantined cycle still runs when named explicitly
+// (`-cycles <name>`), but a blanket `-cycles all` must NEVER reach it — so a
+// full validation sweep can never accidentally hammer an unstable contract (the
+// 2026-06-15 incident was exactly a VPC write loop amplifying an outage).
 type quarantined interface {
 	Quarantined() bool
 }
@@ -240,7 +242,7 @@ func (r *Registry) All() []Cycle {
 
 // unquarantinedNames returns the sorted names of every registered cycle that is
 // NOT quarantined. The "all" selector expands to exactly these: a quarantined
-// cycle (e.g. the frozen /vpc/v1 write cycle) is reachable only by naming it
+// cycle (e.g. the rebuilding /vpc/v1 write cycle) is reachable only by naming it
 // explicitly, so a blanket `-cycles all -write` never fires it.
 func (r *Registry) unquarantinedNames() []string {
 	all := r.Names()
@@ -262,7 +264,7 @@ func (r *Registry) unquarantinedNames() []string {
 //     ignored; an all-empty spec is an error.
 //   - the special token "all" expands to every registered UNQUARANTINED cycle
 //     (ordered by name); "all" combined with other tokens is still just "all".
-//     A quarantined cycle (opt-in only, frozen contract) is excluded from "all"
+//     A quarantined cycle (opt-in only, e.g. under rebuild) is excluded from "all"
 //     and runs only when named explicitly.
 //   - an unknown name is a hard error (no silent skip).
 //   - duplicates collapse to a single entry, preserving first-seen order.
@@ -292,7 +294,7 @@ func (r *Registry) Select(spec string, write bool) (selected []Cycle, skipped []
 
 	if useAll {
 		// "all" supersedes any explicit list — but it expands only to the
-		// UNQUARANTINED cycles. A quarantined cycle (frozen contract, opt-in
+		// UNQUARANTINED cycles. A quarantined cycle (e.g. under rebuild, opt-in
 		// only) is excluded from the sweep even if it was also named alongside
 		// "all": fail closed, so a blanket run can never fire it.
 		names = r.unquarantinedNames()

--- a/cmd/ct-validate/cycle_readonly.go
+++ b/cmd/ct-validate/cycle_readonly.go
@@ -33,10 +33,10 @@ func (rc readonlyCycle) Run(ctx context.Context, c *client.Client, r *Run) error
 	})
 
 	rc.runIAM(ctx, c, r, tenantID, companyID)
-	// VPC is intentionally NOT swept here: the /vpc/v1 contract is deprecated and
-	// frozen pending the rebuild (see internal/client/vpc.go), so probing it in
-	// the always-on default path would only emit false squeaks on a contract we
-	// have abandoned. The opt-in -write "vpc" cycle still exercises it on demand.
+	// VPC is intentionally NOT swept here: the /vpc/v1 contract is being rebuilt for
+	// v1.9.0 and is not yet end-to-end validated (see internal/client/vpc.go), so it
+	// is kept off the always-on default path to avoid false squeaks on a still-
+	// evolving contract. The opt-in -write "vpc" cycle still exercises it on demand.
 	rc.runCompute(ctx, c, r)
 	rc.runBackup(ctx, c, r)
 	rc.runObjectStorage(ctx, c, r)
@@ -316,11 +316,11 @@ func (rc readonlyCycle) runTag(ctx context.Context, c *client.Client, r *Run) {
 	// The Tag service exposes only per-resource Read/Create/Delete (no global
 	// list endpoint), so a safe read needs an EXISTING resource id. The only id
 	// source this read-only sweep had was a VPC floating IP, but the /vpc/v1
-	// contract is deprecated and quarantined out of the default path (see
-	// internal/client/vpc.go); firing it here would reintroduce the very
-	// deprecated read we just removed, and fabricating an id would be dishonest.
-	// So the tag read is skipped until a non-deprecated taggable resource is
-	// wired in (expected with the VPC rebuild). ctx/c are kept for signature
-	// symmetry with the sibling run* methods and the future re-wiring.
+	// contract is under active rebuild (v1.9.0) and quarantined out of the
+	// default path (see internal/client/vpc.go); firing it here would reintroduce
+	// the very read we removed when VPC was pulled in v1.8.0, and fabricating an
+	// id would be dishonest. So the tag read is skipped until a stable taggable
+	// resource is wired in (expected with the VPC rebuild). ctx/c are kept for
+	// signature symmetry with the sibling run* methods and the future re-wiring.
 	r.skip(rc, "tag.resource.read")
 }

--- a/cmd/ct-validate/cycle_test.go
+++ b/cmd/ct-validate/cycle_test.go
@@ -184,8 +184,9 @@ func TestSelectAllExcludesQuarantinedButExplicitRuns(t *testing.T) {
 
 // TestBuildRegistryQuarantinesVPC proves the REAL registry wiring: the shipped
 // vpcCycle declares itself quarantined, so the production `-cycles all -write`
-// path can never fire the deprecated /vpc/v1 write cycle, while `-cycles vpc
-// -write` still does. Without vpcCycle.Quarantined()==true this fails.
+// path can never fire the (still-rebuilding, not yet E2E-validated) /vpc/v1 write
+// cycle, while `-cycles vpc -write` still does. Without vpcCycle.Quarantined()==true
+// this fails.
 func TestBuildRegistryQuarantinesVPC(t *testing.T) {
 	reg := buildRegistry()
 

--- a/cmd/ct-validate/cycle_vpc.go
+++ b/cmd/ct-validate/cycle_vpc.go
@@ -12,12 +12,13 @@ import (
 // stdout.
 var silentWaiter = &client.WaiterOptions{Logger: func(string) {}}
 
-// DEPRECATED CONTRACT — opt-in only. This cycle exercises the /vpc/v1 API,
-// which is deprecated and frozen pending the rebuild (see
-// internal/client/vpc.go). It is QUARANTINED: excluded from the "all" selector
-// and from the default read-only sweep, so a blanket `-cycles all -write` can
-// never fire it. It runs ONLY when named explicitly: `-cycles vpc -write`.
-// Kept as the validation harness the rebuild will reuse.
+// REBUILDING CONTRACT — opt-in only. This cycle exercises the /vpc/v1 API, which
+// is being rebuilt for v1.9.0 (see internal/client/vpc.go): the client now speaks
+// the new async contract, but the rebuild is not yet end-to-end validated. It
+// stays QUARANTINED: excluded from the "all" selector and from the default
+// read-only sweep, so a blanket `-cycles all -write` can never fire VPC writes
+// against the still-evolving contract. It runs ONLY when named explicitly:
+// `-cycles vpc -write` — which is how the C6 live end-to-end validation invokes it.
 //
 // vpcCycle drives a realistic VPC write business cycle:
 //
@@ -37,9 +38,11 @@ type vpcCycle struct{}
 func (vpcCycle) Name() string { return "vpc" }
 func (vpcCycle) Kind() Kind   { return KindWrite }
 
-// Quarantined excludes vpcCycle from the "all" selector (see cycle.go): /vpc/v1
-// is deprecated and frozen, so a blanket `-cycles all -write` must never fire
-// it. It runs only when named explicitly: `-cycles vpc -write`.
+// Quarantined excludes vpcCycle from the "all" selector (see cycle.go): the
+// v1.9.0 /vpc/v1 rebuild is not yet end-to-end validated, so a blanket `-cycles
+// all -write` must never fire VPC writes against it. It runs only when named
+// explicitly: `-cycles vpc -write`. (TestBuildRegistryQuarantinesVPC pins this;
+// lifting it is a deliberate end-of-rebuild step, not a C1 change.)
 func (vpcCycle) Quarantined() bool { return true }
 
 func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
@@ -53,54 +56,79 @@ func (vc vpcCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
 	// or repeated runs. The 02:00:5e:f0:XX:YY range is locally-administered.
 	mac := fmt.Sprintf("02:00:5e:f0:%02x:%02x", byte(r.Iteration), byte(r.Worker))
 
-	// F3: register the by-MAC teardown BEFORE Create. The client documents that a
-	// 201 empty body means the static IP MAY already exist and id-resolution can
-	// fail (vpc_static_ip.go) — a created-but-unresolved static IP would orphan.
-	// Keying the teardown on the deterministic (private network, MAC) lets the
-	// safety net find and delete it even when Create returns no usable id.
-	registerStaticIPTeardown(r.Cleanup, vpcStaticIPSeam{c}, pn.ID, mac)
+	// F3 + the async-teardown doctrine (mirrors registerVirtualDiskTeardown /
+	// registerNetworkAdapterTeardown): register ONE ref-based teardown BEFORE the
+	// create. Registered pre-POST, it covers process-death AND the "POST accepted
+	// server-side but CreateStart errored before yielding an id" ambiguous window
+	// (the static IP would otherwise orphan). The ref is filled as the cycle
+	// advances: ActivityID/ID/Resolved on create, ExplicitlyDeleted after delete.
+	ref := &staticIPTeardownRef{PrivateNetworkID: pn.ID, MAC: mac}
+	registerStaticIPTeardown(r.Cleanup, vpcStaticIPSeam{c}, ref)
 
 	var staticID string
 	if err := r.op(vc, "vpc.static_ip.create", func() error {
-		id, cerr := c.VPC().StaticIP().Create(ctx, pn.ID, &client.CreateStaticIPRequest{
+		// CreateStart + WaitCreate (not the composed Create) so the cycle records
+		// the create ACTIVITY id in the ref BEFORE waiting: if the wait then fails,
+		// the orphan-window diagnostic can name the activity. This also exercises
+		// live the exact split the provider (C3) will use.
+		activityID, syncID, cerr := c.VPC().StaticIP().CreateStart(ctx, pn.ID, &client.CreateStaticIPRequest{
 			MacAddress:          mac,
 			ResourceDescription: "ct-validate",
 		})
 		if cerr != nil {
 			return cerr
 		}
+		ref.ActivityID = activityID
+		id := syncID
+		if activityID != "" {
+			waited, werr := c.VPC().StaticIP().WaitCreate(ctx, activityID, silentWaiter)
+			if werr != nil {
+				return fmt.Errorf("static IP create activity %s did not complete: %w", activityID, werr)
+			}
+			id = waited
+		}
 		staticID = id
+		ref.ID = id
+		ref.Resolved = true
 		return nil
 	}); err != nil || staticID == "" {
-		// Either the create failed (recorded) or returned no id. The by-MAC
-		// teardown registered above still sweeps a created-but-unresolved static
-		// IP, so we can safely return here.
+		// Create failed or yielded no id. ref.Resolved stays false, so the
+		// pre-registered teardown sweeps a created-but-unresolved (or failed) static
+		// IP via the strict by-MAC listing. Safe to return.
 		return err
 	}
 
-	// Also register the precise by-id teardown now that the id is resolved (LIFO:
-	// it runs before the broader by-MAC sweep). Both are idempotent.
-	r.Cleanup.Register(fmt.Sprintf("vpc.static_ip %s", staticID), func(tctx context.Context) error {
-		return vpcStaticIPSeam{c}.DeleteAndWait(tctx, pn.ID, staticID)
-	})
-
 	vc.bindSubCycle(ctx, c, r, staticID)
 
-	// Explicit delete step (recorded). It overlaps with the registered
-	// teardown intentionally: the cycle deletes on the happy path; the
-	// teardown is the safety net if we never reach here.
+	// Explicit delete (recorded), overlapping the teardown by design: the cycle
+	// deletes on the happy path; the teardown is the safety net if we never reach
+	// here. The same-cycle absence proof is set ONLY on real success.
+	vc.explicitDeleteStaticIP(ctx, c, r, ref)
+	return nil
+}
+
+// explicitDeleteStaticIP runs the breaker-gated explicit delete and records STRICT
+// same-cycle proof of absence into ref.ExplicitlyDeleted ONLY when the delete op
+// actually RAN and succeeded. It mirrors computeLifecycleCycle.explicitDelete
+// (cycle_compute_lifecycle.go): on a breaker skip r.op never invokes the closure,
+// so the proof stays false and the deferred teardown fails closed on a later
+// 403-on-absent (#303) instead of masking a possible orphan. The proof MUST be set
+// from inside the closure — NEVER inferred from r.op's return value, which is nil
+// on a breaker skip too.
+func (vc vpcCycle) explicitDeleteStaticIP(ctx context.Context, c *client.Client, r *Run, ref *staticIPTeardownRef) {
 	_ = r.op(vc, "vpc.static_ip.delete", func() error {
-		activityID, derr := c.VPC().StaticIP().Delete(ctx, staticID)
+		activityID, derr := c.VPC().StaticIP().Delete(ctx, ref.ID)
 		if derr != nil {
 			return derr
 		}
-		if activityID == "" {
-			return nil
+		if activityID != "" {
+			if _, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter); werr != nil {
+				return werr
+			}
 		}
-		_, werr := c.Activity().WaitForCompletion(ctx, activityID, silentWaiter)
-		return werr
+		ref.ExplicitlyDeleted = true
+		return nil
 	})
-	return nil
 }
 
 // pickPrivateNetwork lists private networks and returns the one named "LAN", or

--- a/cmd/ct-validate/cycle_vpc_test.go
+++ b/cmd/ct-validate/cycle_vpc_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestVPCExplicitDeleteStaticIPMarksProofOnlyWhenClosureRuns is the VPC analog of
+// TestExplicitDeleteMarksProofOnlyWhenClosureRuns (compute). The same-cycle delete
+// proof (ref.ExplicitlyDeleted) is what later lets the deferred teardown accept a
+// 403-on-absent as "confirmed deleted" (channel 1 in staticIPDeleteErrResult)
+// instead of falling back to the strict by-network listing (channel 2). It MUST be
+// set from INSIDE the breaker-gated r.op closure, on a delete that actually RAN and
+// fully succeeded — never inferred from r.op's return value, which is nil on a
+// breaker SKIP too.
+//
+// If the proof were (wrongly) set on a skip, a later 403-on-absent would be masked
+// as "already deleted" and a still-present forbidden static IP would orphan
+// silently — the exact never-orphan failure the harness exists to prevent.
+//
+// Mutations this test turns RED:
+//   - set ref.ExplicitlyDeleted from `r.op(...) == nil` instead of inside the
+//     closure → case (a) marks the proof true on a skip → RED.
+//   - set the proof before the `if derr != nil` check → case (c) marks it on a
+//     failed delete → RED.
+func TestVPCExplicitDeleteStaticIPMarksProofOnlyWhenClosureRuns(t *testing.T) {
+	ctx := context.Background()
+
+	// (a) breaker tripped → op skipped → closure NOT run → proof stays false. The
+	// closure holds the ONLY DELETE, so a skip must issue zero HTTP: the stub fails
+	// the test if it receives any request.
+	t.Run("skip_does_not_set_proof", func(t *testing.T) {
+		c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("a breaker-skipped delete must issue NO request, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		b := NewBreaker(1000, 0.99, 1000)
+		b.Trip("force-skip")
+		r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+		ref := &staticIPTeardownRef{ID: "si-1"}
+
+		vpcCycle{}.explicitDeleteStaticIP(ctx, c, r, ref)
+
+		if ref.ExplicitlyDeleted {
+			t.Fatal("a breaker-skipped (never-run) delete must NOT set the same-cycle proof (else a later 403 masks an orphan)")
+		}
+		if op, ok := opsByEndpoint(r)["vpc.static_ip.delete"]; !ok || !op.Skipped {
+			t.Fatalf("expected vpc.static_ip.delete recorded as a skip, got %+v (present=%v)", op, ok)
+		}
+	})
+
+	// (b) breaker allows + delete fully succeeds: the async DELETE returns 200 +
+	// Location, then the delete activity reports "completed" → proof set.
+	t.Run("success_sets_proof", func(t *testing.T) {
+		c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodDelete && r.URL.Path == "/vpc/v1/static_ips/si-1":
+				w.Header().Set("Location", "act-del")
+				w.WriteHeader(http.StatusOK)
+			case r.Method == http.MethodGet && r.URL.Path == "/activity/v1/activities/act-del":
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":"act-del","state":{"completed":{"result":"si-1"}}}`))
+			default:
+				t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		})
+		r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+		ref := &staticIPTeardownRef{ID: "si-1"}
+
+		vpcCycle{}.explicitDeleteStaticIP(ctx, c, r, ref)
+
+		if !ref.ExplicitlyDeleted {
+			t.Fatal("a ran-and-succeeded explicit delete must set the same-cycle proof")
+		}
+	})
+
+	// (c) breaker allows + delete fails (DELETE 500) → the closure returns the error
+	// before reaching the proof assignment → proof NOT set.
+	t.Run("failure_does_not_set_proof", func(t *testing.T) {
+		c := newReadonlyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodDelete && r.URL.Path == "/vpc/v1/static_ips/si-1":
+				w.WriteHeader(http.StatusInternalServerError)
+			default:
+				t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		})
+		r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+		ref := &staticIPTeardownRef{ID: "si-1"}
+
+		vpcCycle{}.explicitDeleteStaticIP(ctx, c, r, ref)
+
+		if ref.ExplicitlyDeleted {
+			t.Fatal("a failed explicit delete must NOT set the same-cycle proof")
+		}
+	})
+}

--- a/internal/client/vpc.go
+++ b/internal/client/vpc.go
@@ -1,22 +1,25 @@
 package client
 
-// DEPRECATED CONTRACT / FROZEN — DO NOT EXTEND.
+// VPC client for the Shiva /vpc/v1 API — UNDER ACTIVE REBUILD (v1.9.0).
 //
-// This VPC client targets the Shiva VPC API at base path /vpc/v1, which is
-// deprecated. A new contract is landing UNDER THE SAME /vpc/v1 URL with
-// breaking changes (no /v2 coexistence), so this code cannot speak the new
-// shape. The client-facing provider surface that consumed it (the
-// cloudtemple_vpc_* datasources and resources) was removed from v1.8.0 to
-// avoid shipping endpoints that will break server-side with no client
-// recourse; the VPC features will be rebuilt against the new contract.
+// History: the platform replaced /vpc/v1 with breaking changes UNDER THE SAME URL
+// (no /v2 coexistence). v1.8.0 removed the client-facing provider surface (the
+// cloudtemple_vpc_* datasources and resources) and FROZE this client, to avoid
+// shipping endpoints that would break server-side with no client recourse.
 //
-// This package is intentionally KEPT (it compiles and its tests run) as the
-// foundation for that rebuild, but it is QUARANTINED: no provider surface
-// references it, and ct-validate no longer exercises it in the default
-// read-only path (only the opt-in, -write "vpc" cycle does). Treat any change
-// here as part of the rebuild, not as maintenance of a live contract.
+// v1.9.0 rebuilds VPC against the new contract, chunk by chunk: this client is the
+// foundation, updated first (e.g. static IP create is now ASYNC — see
+// vpc_static_ip.go CreateStart/WaitCreate), then the provider surface (Layer A) is
+// restored on top in later chunks. So this package is NO LONGER FROZEN — changes
+// here ARE the rebuild — but it is also not yet complete.
 //
-// VPCClient is the entry point for that (frozen) /vpc/v1 API.
+// SAFETY (kept until the rebuild is end-to-end validated): no provider surface
+// references this client on the default path, and ct-validate exercises the /vpc/v1
+// WRITE cycle ONLY via the explicit, opt-in "-cycles vpc -write" — never the blanket
+// "-cycles all" (see vpcCycle.Quarantined in cmd/ct-validate/cycle_vpc.go). A routine
+// sweep can therefore never fire VPC writes against this still-evolving contract.
+//
+// VPCClient is the entry point for the (rebuilding) /vpc/v1 API.
 type VPCClient struct {
 	c *Client
 }

--- a/internal/client/vpc_floating_ip.go
+++ b/internal/client/vpc_floating_ip.go
@@ -67,7 +67,10 @@ func (f *VPCFloatingIPClient) List(ctx context.Context, filter *FloatingIPFilter
 }
 
 // Read retrieves a single floating IP by ID. It returns (nil, nil) when the
-// floating IP does not exist (403; the API returns 403 for an absent resource).
+// floating IP is not found: requireNotFoundOrOK maps BOTH 404 and 403 to not-found
+// (the VPC API conflates absent/forbidden, #303), so an absent floating IP —
+// whether the API answers 404 or 403 — surfaces as (nil, nil) for idempotent read
+// handling.
 func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP, error) {
 	r := f.c.newRequest("GET", "/vpc/v1/floating_ips/%s", id)
 	resp, err := f.c.doRequest(ctx, r)

--- a/internal/client/vpc_live_probe_test.go
+++ b/internal/client/vpc_live_probe_test.go
@@ -1,0 +1,256 @@
+package client
+
+import (
+	"context"
+	crand "crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+// This file is an OPT-IN, human-gated live probe. It is NEVER part of the
+// hermetic `all` cycle: with CT_VPC_LIVE_PROBE unset it Skips immediately, so a
+// plain `go test ./...` touches nothing. It exists to gather the §5 LIVE evidence
+// that the swagger alone cannot prove (a spec is never proof of deployed
+// behaviour), feeding the C0 contract-drift gate (R-Q9) and clearing the
+// async-create premise (R-Q2/R-Q10).
+//
+// SAFETY: Paul GO'd a controlled write probe against the dev environment
+// api.shiva.dev.ctlabs.me, on private network fsn-pn-02, creating then deleting
+// one static IP and one floating IP of test. The probe FAIL-CLOSES unless the
+// configured host is exactly probeHost, so a stale/prod CLOUDTEMPLE_HTTP_ADDR can
+// never be hit by accident. Everything created is deleted (t.Cleanup runs even on
+// a mid-probe Fatal); created ids are logged loudly so any leak can be cleaned by
+// hand.
+const (
+	probeHost      = "api.shiva.dev.ctlabs.me"
+	probePN        = "7f5d6a7a-fbe6-45f4-9a51-c1ea991a5d97" // fsn-pn-02
+	probeBogusUUID = "00000000-0000-0000-0000-000000000000"
+)
+
+func TestVPCLiveContractProbe(t *testing.T) {
+	if os.Getenv("CT_VPC_LIVE_PROBE") != "1" {
+		t.Skip("opt-in live probe; set CT_VPC_LIVE_PROBE=1 (read-only) and CT_VPC_LIVE_PROBE_WRITE=1 (controlled write)")
+	}
+
+	cfg := DefaultConfig()
+	if cfg.Address != probeHost {
+		t.Fatalf("refusing to run: CLOUDTEMPLE_HTTP_ADDR=%q but this probe is authorised ONLY for %q", cfg.Address, probeHost)
+	}
+	c, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	// Auth + identity. Log the tenant so the human can confirm the target; if a
+	// recette tenant allowlist is provided, assert it (extra fail-closed guard).
+	tok, err := c.Token(ctx)
+	if err != nil {
+		t.Fatalf("auth failed (check CLOUDTEMPLE_CLIENT_ID / CLOUDTEMPLE_SECRET_ID): %v", err)
+	}
+	t.Logf("AUTH ok: host=%s tenant=%s user=%s", cfg.Address, tok.TenantID(), tok.UserID())
+	if want := os.Getenv("CLOUDTEMPLE_RECETTE_TENANT_ID"); want != "" && tok.TenantID() != want {
+		t.Fatalf("refusing to run: authenticated tenant %q != allowlisted CLOUDTEMPLE_RECETTE_TENANT_ID %q", tok.TenantID(), want)
+	}
+
+	// rawGet captures the RAW status of a GET (the typed clients hide it behind
+	// requireNotFoundOrOK, which is exactly the 403-vs-404 distinction we probe).
+	rawGet := func(path string, args ...interface{}) (int, string) {
+		r := c.newRequest("GET", path, args...)
+		resp, err := c.doRequest(ctx, r)
+		if err != nil {
+			t.Fatalf("GET %s: %v", fmt.Sprintf(path, args...), err)
+		}
+		defer closeResponseBody(resp)
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(b)
+	}
+
+	// ---- Phase 1: read-only evidence -------------------------------------
+	st, _ := rawGet("/vpc/v1/static_ips/%s", probeBogusUUID)
+	t.Logf("PHASE1 absent-signal: GET static_ips/<bogus> -> HTTP %d  (403=>indistinct access-denied, 404=>distinguishable absent)", st)
+
+	stf, _ := rawGet("/vpc/v1/floating_ips/%s", probeBogusUUID)
+	t.Logf("PHASE1 absent-signal: GET floating_ips/<bogus> -> HTTP %d", stf)
+
+	stl, body := rawGet("/vpc/v1/private_networks/%s/static_ips", probePN)
+	t.Logf("PHASE1 list pn static_ips -> HTTP %d", stl)
+	if stl == 200 {
+		var list []*StaticIP
+		if err := json.Unmarshal([]byte(body), &list); err != nil {
+			t.Logf("PHASE1 list decode error: %v (body head=%.120q)", err, body)
+		} else {
+			sources := map[string]int{}
+			for _, si := range list {
+				if si != nil {
+					sources[si.Source]++
+				}
+			}
+			t.Logf("PHASE1 pn has %d static IPs, live source distribution=%v", len(list), sources)
+		}
+	}
+
+	if os.Getenv("CT_VPC_LIVE_PROBE_WRITE") != "1" {
+		t.Log("PHASE2 skipped (set CT_VPC_LIVE_PROBE_WRITE=1 to run the controlled write probe)")
+		return
+	}
+
+	// ---- Phase 2: controlled write ---------------------------------------
+	waitOpts := &WaiterOptions{Logger: func(m string) { t.Logf("  activity: %s", m) }}
+
+	var createdStaticID, createdFIPID string
+	// deleteAndWait uses an INDEPENDENT context so a timeout on the main probe
+	// never blocks the deletes that prevent orphans.
+	deleteAndWait := func(kind, path, id string) {
+		if id == "" {
+			return
+		}
+		cctx, ccancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer ccancel()
+		r := c.newRequest("DELETE", path, id)
+		loc, err := c.doRequestAndReturnActivity(cctx, r)
+		if err != nil {
+			t.Logf("CLEANUP %s %s: DELETE failed: %v  -- MANUAL CLEANUP MAY BE NEEDED", kind, id, err)
+			return
+		}
+		if _, err := c.Activity().WaitForCompletion(cctx, loc, waitOpts); err != nil {
+			t.Logf("CLEANUP %s %s: delete activity did not complete: %v  -- MANUAL CLEANUP MAY BE NEEDED", kind, id, err)
+			return
+		}
+		t.Logf("CLEANUP %s %s: deleted (activity %s)", kind, id, loc)
+	}
+	// Belt-and-suspenders: guarantee deletion even on a mid-probe Fatal.
+	t.Cleanup(func() { deleteAndWait("static_ip", "/vpc/v1/static_ips/%s", createdStaticID) })
+	t.Cleanup(func() { deleteAndWait("floating_ip", "/vpc/v1/floating_ips/%s", createdFIPID) })
+
+	// (a) static IP create -- ASYNC (201 + Location) vs SYNC (201 + body)?
+	mac := probeRandomLocalMAC()
+	t.Logf("PHASE2 creating static IP on pn=%s mac=%s", probePN, mac)
+	{
+		r := c.newRequest("POST", "/vpc/v1/private_networks/%s/static_ips", probePN)
+		r.obj = &CreateStaticIPRequest{MacAddress: mac, ResourceDescription: "vpc-live-probe"}
+		resp, err := c.doRequest(ctx, r)
+		if err != nil {
+			t.Fatalf("POST static_ip transport error: %v", err)
+		}
+		status := resp.StatusCode
+		loc := resp.Header.Get("Location")
+		b, _ := io.ReadAll(resp.Body)
+		closeResponseBody(resp)
+		t.Logf("PHASE2 RESULT static_ip CREATE -> HTTP %d  Location=%q  body=%.300q", status, loc, string(b))
+
+		switch {
+		case loc != "":
+			t.Log("PHASE2 => static_ip CREATE is ASYNC (Location activity present)")
+			act, werr := c.Activity().WaitForCompletion(ctx, loc, waitOpts)
+			if werr != nil {
+				t.Fatalf("static_ip create activity failed: %v", werr)
+			}
+			createdStaticID = probeSingleActivityResult(t, act)
+			t.Logf("PHASE2 static_ip activity Result UUID=%q", createdStaticID)
+			if createdStaticID == "" {
+				// Fail closed like the production WaitCreate (R-M1): an empty Result is
+				// never a resolved id. But the IP WAS created live, so resolve its id by
+				// MAC and stash it so t.Cleanup deletes it — a probe must never orphan.
+				if si, rerr := c.VPC().StaticIP().ReadByMAC(ctx, mac); rerr == nil && si != nil && si.ID != "" {
+					createdStaticID = si.ID
+					t.Logf("PHASE2 empty Result; resolved the created static_ip id by MAC for cleanup: %s", si.ID)
+				}
+				t.Fatalf("static_ip create activity completed with an EMPTY Result (contradicts WaitCreate fail-closed); mac=%s -- CHECK MANUALLY if no id was resolved above", mac)
+			}
+		default:
+			var sb struct {
+				StaticIPID string `json:"static_ip_id"`
+			}
+			if json.Unmarshal(b, &sb) == nil && sb.StaticIPID != "" {
+				createdStaticID = sb.StaticIPID
+				t.Logf("PHASE2 => static_ip CREATE is SYNC (body static_ip_id=%q)", createdStaticID)
+			} else {
+				t.Fatalf("static_ip CREATE: neither Location nor body static_ip_id (HTTP %d, body %.300q)", status, string(b))
+			}
+		}
+	}
+	if createdStaticID != "" {
+		stv, vb := rawGet("/vpc/v1/static_ips/%s", createdStaticID)
+		t.Logf("PHASE2 verify static_ip %s -> HTTP %d", createdStaticID, stv)
+		if stv == 200 {
+			var si StaticIP
+			if json.Unmarshal([]byte(vb), &si) == nil {
+				t.Logf("PHASE2 created static_ip source=%q ip=%q mac=%q", si.Source, si.IPAddress, si.MacAddress)
+			}
+		}
+		deleteAndWait("static_ip", "/vpc/v1/static_ips/%s", createdStaticID)
+		sta, _ := rawGet("/vpc/v1/static_ips/%s", createdStaticID)
+		t.Logf("PHASE2 post-delete absent-signal: GET static_ips/%s -> HTTP %d", createdStaticID, sta)
+		createdStaticID = "" // already deleted; stop the cleanup re-delete
+	}
+
+	// (b) floating IP provision -- count=1, async, Result multiplicity (R-Q3)
+	t.Log("PHASE2 provisioning floating IP {count:1}")
+	{
+		r := c.newRequest("POST", "/vpc/v1/floating_ips")
+		r.obj = map[string]any{"count": 1}
+		resp, err := c.doRequest(ctx, r)
+		if err != nil {
+			t.Fatalf("POST floating_ips transport error: %v", err)
+		}
+		status := resp.StatusCode
+		loc := resp.Header.Get("Location")
+		b, _ := io.ReadAll(resp.Body)
+		closeResponseBody(resp)
+		t.Logf("PHASE2 RESULT floating_ip CREATE -> HTTP %d  Location=%q  body=%.300q", status, loc, string(b))
+		if loc == "" {
+			t.Fatalf("floating_ip CREATE returned no Location (expected async); HTTP %d body=%.300q", status, string(b))
+		}
+		act, werr := c.Activity().WaitForCompletion(ctx, loc, waitOpts)
+		if werr != nil {
+			t.Fatalf("floating_ip create activity failed: %v", werr)
+		}
+		for name, stt := range act.State {
+			t.Logf("PHASE2 floating_ip activity state=%q Result=%q", name, stt.Result)
+			createdFIPID = stt.Result
+		}
+		t.Logf("PHASE2 floating_ip Result=%q (a comma in Result => multiplicity to handle)", createdFIPID)
+		if createdFIPID == "" {
+			// Fail loud rather than silently skip cleanup: a successful async create
+			// whose Result we cannot read may have provisioned a floating IP we now
+			// cannot address. There is no deterministic key to resolve it by (unlike a
+			// static IP's MAC), so the human must check for an orphan.
+			t.Fatalf("floating_ip create activity completed with an EMPTY Result; cannot resolve the created id for cleanup -- CHECK MANUALLY for an orphaned floating IP")
+		}
+	}
+	if createdFIPID != "" {
+		stv, vb := rawGet("/vpc/v1/floating_ips/%s", createdFIPID)
+		t.Logf("PHASE2 verify floating_ip %s -> HTTP %d body=%.200q", createdFIPID, stv, vb)
+		deleteAndWait("floating_ip", "/vpc/v1/floating_ips/%s", createdFIPID)
+		fa, _ := rawGet("/vpc/v1/floating_ips/%s", createdFIPID)
+		t.Logf("PHASE2 post-delete absent-signal: GET floating_ips/%s -> HTTP %d", createdFIPID, fa)
+		createdFIPID = ""
+	}
+
+	t.Log("PROBE DONE")
+}
+
+func probeSingleActivityResult(t *testing.T, act *Activity) string {
+	t.Helper()
+	if act == nil || len(act.State) != 1 {
+		t.Fatalf("expected exactly one activity state, got %#v", act)
+	}
+	for _, s := range act.State {
+		return s.Result
+	}
+	return ""
+}
+
+func probeRandomLocalMAC() string {
+	b := make([]byte, 6)
+	_, _ = crand.Read(b)
+	b[0] = (b[0] | 0x02) & 0xfe // locally administered, unicast
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", b[0], b[1], b[2], b[3], b[4], b[5])
+}

--- a/internal/client/vpc_static_ip.go
+++ b/internal/client/vpc_static_ip.go
@@ -125,8 +125,10 @@ func (s *VPCStaticIPClient) ListStrict(ctx context.Context, privateNetworkID str
 	return out, nil
 }
 
-// Read retrieves a single static IP by ID. It returns (nil, nil) when the
-// static IP does not exist (403; the API returns 403 for an absent resource).
+// Read retrieves a single static IP by ID. It returns (nil, nil) when the static
+// IP is not found: requireNotFoundOrOK maps BOTH 404 and 403 to not-found (the VPC
+// API conflates absent/forbidden, #303), so an absent static IP — whether the API
+// answers 404 or 403 — surfaces as (nil, nil) for idempotent read handling.
 func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/%s", id)
 	resp, err := s.c.doRequest(ctx, r)
@@ -149,87 +151,127 @@ func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, err
 
 // CreateStaticIPRequest is the body of POST
 // /vpc/v1/private_networks/{privateNetworkId}/static_ips (schema CreateStaticIp).
-// MacAddress is required; IPAddress is optional (auto-assigned when omitted);
-// ResourceDescription is optional. Optional fields are omitempty so an empty
-// value is not sent as an explicit "".
+// MacAddress is required; IPAddress is optional (auto-assigned when omitted, so it
+// keeps omitempty).
+//
+// ResourceDescription is REQUIRED by the live create contract: an empty or omitted
+// value is rejected by the deployed API (live evidence, 2026-06 — the swagger's
+// "optional" is wrong for this field). It therefore carries NO omitempty: an empty
+// string must surface as a CreateStart precondition error (an actionable diagnostic
+// BEFORE the POST), never be silently elided from the body and bounced server-side.
 type CreateStaticIPRequest struct {
 	MacAddress          string `json:"macAddress"`
 	IPAddress           string `json:"ipAddress,omitempty"`
-	ResourceDescription string `json:"resourceDescription,omitempty"`
+	ResourceDescription string `json:"resourceDescription"`
 }
 
-// createStaticIPResponse decodes the 201 body of the create endpoint. The static
-// IP id is returned in the BODY (static_ip_id), NOT in a Location header: the
-// create is synchronous and is NOT an activity, so doRequestAndReturnActivity
-// (which reads Location) must not be used here.
-type createStaticIPResponse struct {
-	Success    bool   `json:"success"`
-	Message    string `json:"message"`
-	StaticIPID string `json:"static_ip_id"`
-}
+// CreateStart issues POST /vpc/v1/private_networks/{id}/static_ips and reports how
+// the platform acknowledged the create WITHOUT waiting. It returns EXACTLY ONE of:
+//   - activityID: the ASYNC path — a 201 carrying a Location header; the new static
+//     IP id is resolved once that activity completes (see WaitCreate). This is the
+//     deployed live contract (2026-06: 201 + Location, EMPTY body).
+//   - syncID: the SYNC path — a 201 carrying a body static_ip_id. Retained as a
+//     DEFENSIVE contract guard so a hypothetical sync 201 surfaces a usable id
+//     instead of an orphan; never observed live.
+//
+// A 201 with NEITHER a Location nor a static_ip_id is a hard error (fail closed):
+// the create may have taken effect server-side, so the never-orphan backstop is the
+// pre-create teardown net (cmd/ct-validate), NOT a silent id guess. This removes the
+// old "resolve the id by listing the network and matching MAC+custom" path, which
+// was orphan-prone (it could bind to a co-resident xoa IP, #311) and is moot now
+// that the contract is proven async.
+//
+// ResourceDescription is REQUIRED (see CreateStaticIPRequest): an empty/whitespace
+// value is rejected HERE, before the POST, with an actionable error — a doomed
+// request never reaches the API.
+func (s *VPCStaticIPClient) CreateStart(ctx context.Context, privateNetworkID string, req *CreateStaticIPRequest) (activityID, syncID string, err error) {
+	if strings.TrimSpace(req.ResourceDescription) == "" {
+		return "", "", fmt.Errorf("static IP create on private network %s: resourceDescription is required by the API and must not be empty or whitespace", privateNetworkID)
+	}
 
-// Create creates a static IP mapping on a private network (synchronous). It
-// returns the new static IP id parsed from the 201 body. A non-201 status, or a
-// 201 with a missing/empty static_ip_id, is an error.
-func (s *VPCStaticIPClient) Create(ctx context.Context, privateNetworkID string, req *CreateStaticIPRequest) (string, error) {
 	r := s.c.newRequest("POST", "/vpc/v1/private_networks/%s/static_ips", privateNetworkID)
 	r.obj = req
-	resp, err := s.c.doRequest(ctx, r)
+	// CreateStart EXPECTS an activity (the live async create returns a Location), so it
+	// must bypass the ErrorOnUnexpectedActivity guard the same way the sibling async
+	// methods Update/Delete do — they go through doRequestAndReturnActivity, which
+	// calls doRequestWithToken directly. Routing through doRequest/doRequestOnce would
+	// instead let that guard (set suite-wide by internal/client/tests) reject the
+	// EXPECTED Location before line 204 can read it. CreateStart cannot reuse
+	// doRequestAndReturnActivity wholesale because it must ALSO accept the defensive
+	// sync path (201 + body static_ip_id, no Location), which that helper rejects.
+	token, err := s.c.JWT(ctx)
 	if err != nil {
-		return "", err
+		return "", "", err
+	}
+	resp, err := s.c.doRequestWithToken(ctx, r, token.Raw)
+	if err != nil {
+		return "", "", err
 	}
 	defer closeResponseBody(resp)
 	if err := requireHttpCodes(resp, 201); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// The swagger documents a 201 body {success, message, static_ip_id}, but the
-	// live API returns 201 with an EMPTY body. The create is synchronous (the
-	// static IP exists immediately), so when the id is absent from the body we
-	// resolve it ourselves. Returning an error on an empty body would be wrong:
-	// the static IP IS created, so the caller would orphan it — created
-	// platform-side but absent from the Terraform state.
-	var out createStaticIPResponse
-	if err := decodeBody(resp, &out); err == nil && out.StaticIPID != "" {
-		return out.StaticIPID, nil
+	// ASYNC: a Location header is the create activity to wait on (live contract).
+	if loc := resp.Header.Get("Location"); loc != "" {
+		return loc, "", nil
 	}
 
-	// Resolve the id from a COMPLETE listing of the private network, matching the
-	// requested MAC AND source=="custom". A by-MAC GET is NOT enough: when a
-	// network adapter is attached to a VPC network the platform auto-creates an
-	// "xoa" static IP for the SAME MAC (#311), so a MAC-only lookup can resolve to
-	// that co-resident platform-managed IP instead of the custom one we just
-	// created — which would bind the state to the wrong id and orphan ours. The
-	// per-network listing lets us pick the custom IP unambiguously, and the create
-	// always produces a "custom" static IP.
-	list, lerr := s.ListStrict(ctx, privateNetworkID)
-	if lerr != nil {
-		return "", fmt.Errorf("static IP created on private network %s but resolving its id by listing failed: %w", privateNetworkID, lerr)
+	// SYNC fallback (defensive): a body static_ip_id. Decoded inline — the old named
+	// createStaticIPResponse type retired with the sync-create design.
+	var body struct {
+		StaticIPID string `json:"static_ip_id"`
 	}
-	want := normalizeMAC(req.MacAddress)
-	var match *StaticIP
-	for _, si := range list {
-		if si == nil || si.Source != "custom" || normalizeMAC(si.MacAddress) != want {
-			continue
-		}
-		if match != nil {
-			return "", fmt.Errorf("static IP created on private network %s but its id is ambiguous: several custom static IPs carry MAC %s", privateNetworkID, req.MacAddress)
-		}
-		match = si
+	if derr := decodeBody(resp, &body); derr == nil && body.StaticIPID != "" {
+		return "", body.StaticIPID, nil
 	}
-	// match.ID == "" must fail just like match == nil: returning an empty id with a
-	// nil error would make the resource SetId("") and orphan the created static IP.
-	if match == nil || match.ID == "" {
-		return "", fmt.Errorf("static IP created on private network %s but could not be resolved among the network's custom static IPs by MAC %s", privateNetworkID, req.MacAddress)
-	}
-	return match.ID, nil
+
+	return "", "", fmt.Errorf("static IP create on private network %s returned 201 with neither a Location activity nor a static_ip_id body; cannot resolve the created id", privateNetworkID)
 }
 
-// normalizeMAC canonicalises a MAC address for comparison: lowercase and
-// ":"-separated (the swagger pattern also tolerates "-"). It lets the created
-// static IP be matched against the requested MAC regardless of input formatting.
-func normalizeMAC(mac string) string {
-	return strings.ToLower(strings.ReplaceAll(mac, "-", ":"))
+// WaitCreate waits for a create activity and returns the new static IP id from the
+// completed activity's single state Result — the same channel the provider reads
+// via setIdFromActivityState. It fails closed when the activity does not complete
+// with EXACTLY ONE state, or completes with an EMPTY Result (R-M1): a created id we
+// cannot read must be an error, never an empty id that would orphan the resource
+// via SetId(""). options controls activity-poll logging (caller-supplied, like
+// every other waiter in this client).
+func (s *VPCStaticIPClient) WaitCreate(ctx context.Context, activityID string, options *WaiterOptions) (string, error) {
+	act, err := s.c.Activity().WaitForCompletion(ctx, activityID, options)
+	if err != nil {
+		return "", err
+	}
+	if act == nil || len(act.State) != 1 {
+		return "", fmt.Errorf("static IP create activity %q did not complete with exactly one state; cannot resolve the created id", activityID)
+	}
+	var id string
+	for _, st := range act.State {
+		id = st.Result
+	}
+	if id == "" {
+		return "", fmt.Errorf("static IP create activity %q completed with an empty Result; cannot resolve the created id", activityID)
+	}
+	return id, nil
+}
+
+// Create creates a static IP mapping on a private network and returns the new id by
+// composing CreateStart + WaitCreate: a SYNC body id (if any) is returned directly;
+// otherwise it waits on the create activity. A wait failure is wrapped WITH the
+// activityID (so a caller/postmortem can correlate the orphan window) and NEVER
+// yields (id, nil) — the provider must fail closed and not SetId (R-Q2).
+func (s *VPCStaticIPClient) Create(ctx context.Context, privateNetworkID string, req *CreateStaticIPRequest, options *WaiterOptions) (string, error) {
+	activityID, syncID, err := s.CreateStart(ctx, privateNetworkID, req)
+	if err != nil {
+		return "", err
+	}
+	if syncID != "" {
+		return syncID, nil
+	}
+	id, werr := s.WaitCreate(ctx, activityID, options)
+	if werr != nil {
+		return "", fmt.Errorf("static IP create on private network %s: activity %q did not complete: %w", privateNetworkID, activityID, werr)
+	}
+	return id, nil
 }
 
 // UpdateStaticIPRequest is the body of PATCH /vpc/v1/static_ips/{id} (schema
@@ -260,7 +302,8 @@ func (s *VPCStaticIPClient) Delete(ctx context.Context, id string) (string, erro
 }
 
 // ReadByMAC retrieves a single static IP by MAC address. It returns (nil, nil)
-// when no static IP matches the MAC (403; the API returns 403 for an absent resource).
+// when no static IP matches: requireNotFoundOrOK maps BOTH 404 and 403 to not-found
+// (the VPC API conflates absent/forbidden, #303).
 func (s *VPCStaticIPClient) ReadByMAC(ctx context.Context, mac string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/mac/%s", mac)
 	resp, err := s.c.doRequest(ctx, r)

--- a/internal/client/vpc_static_ip_write_test.go
+++ b/internal/client/vpc_static_ip_write_test.go
@@ -4,18 +4,33 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
 
-// TestVPCStaticIPCreate pins the SYNCHRONOUS create contract: the id comes from
-// the 201 BODY (static_ip_id), never from a Location header; a missing/empty id
-// or a non-201 status is an error; the request body carries the create fields.
-func TestVPCStaticIPCreate(t *testing.T) {
+// completedActivityBody returns the minimal /activity/v1/activities/{id} payload
+// WaitForCompletion polls and treats as terminal success. The Activity struct
+// carries no json tags, so encoding/json matches "state"/"result"
+// case-insensitively; the map key MUST be "completed" (the only state
+// WaitForCompletion accepts as done) and Result carries the created static IP id.
+// (Named *Body to avoid colliding with activity_unit_test.go's completedActivity,
+// which builds a *Activity struct for the polling-loop unit tests.)
+func completedActivityBody(result string) string {
+	return fmt.Sprintf(`{"id":"act-create","state":{"completed":{"result":%q}}}`, result)
+}
+
+// TestVPCStaticIPCreateStart pins the create POST contract WITHOUT waiting. It
+// reports EXACTLY ONE of activityID (the live ASYNC path: 201 + Location, empty
+// body) or syncID (the defensive SYNC path: 201 + body static_ip_id), posts the
+// right path and body (resourceDescription ALWAYS present — no omitempty), and
+// rejects a doomed request (empty/whitespace resourceDescription) BEFORE the POST.
+func TestVPCStaticIPCreateStart(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("201 parses static_ip_id from the BODY and posts the right path/body", func(t *testing.T) {
+	t.Run("async 201+Location returns ONLY the activity id, posting the right path/body", func(t *testing.T) {
 		var gotBody map[string]any
 		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost || r.URL.Path != "/vpc/v1/private_networks/pn-1/static_ips" {
@@ -23,14 +38,11 @@ func TestVPCStaticIPCreate(t *testing.T) {
 			}
 			b, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(b, &gotBody)
-			// A Location header MUST be ignored: this is a sync create, the id is
-			// in the body. Setting one here proves Create does not read it.
-			w.Header().Set("Location", "should-be-ignored")
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"success":true,"message":"ok","static_ip_id":"si-new"}`))
+			w.Header().Set("Location", "act-create")
+			w.WriteHeader(http.StatusCreated) // empty body, like the live API
 		})
 
-		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{
+		activityID, syncID, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
 			MacAddress:          "00:50:56:ab:cd:ef",
 			IPAddress:           "10.0.1.50",
 			ResourceDescription: "web",
@@ -38,162 +50,128 @@ func TestVPCStaticIPCreate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if id != "si-new" {
-			t.Fatalf("id must come from the body static_ip_id, got %q (a %q here means it read Location)", id, "should-be-ignored")
+		// XOR: a successful async create yields the activity id and NOTHING in syncID.
+		if activityID != "act-create" || syncID != "" {
+			t.Fatalf("async create must return ONLY the activity id, got activityID=%q syncID=%q", activityID, syncID)
 		}
 		if gotBody["macAddress"] != "00:50:56:ab:cd:ef" || gotBody["ipAddress"] != "10.0.1.50" || gotBody["resourceDescription"] != "web" {
 			t.Fatalf("unexpected create body: %v", gotBody)
 		}
 	})
 
-	t.Run("optional fields omitted are not sent", func(t *testing.T) {
+	t.Run("sync 201+body static_ip_id (no Location) returns ONLY the body id", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			// No Location: the defensive sync path resolves the id from the body.
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"static_ip_id":"si-sync"}`))
+		})
+		activityID, syncID, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// XOR: a successful sync create yields the body id and NOTHING in activityID.
+		if syncID != "si-sync" || activityID != "" {
+			t.Fatalf("sync create must return ONLY the body id, got activityID=%q syncID=%q", activityID, syncID)
+		}
+	})
+
+	t.Run("a 201 with neither a Location nor a static_ip_id body fails closed", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated) // empty body, no Location
+		})
+		if _, _, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		}); err == nil {
+			t.Fatal("a 201 carrying no id signal must fail closed (the pre-create teardown is the orphan net), never guess an id by listing")
+		}
+	})
+
+	t.Run("an omitted ipAddress is not sent; a provided resourceDescription is forwarded as-is", func(t *testing.T) {
 		var gotBody map[string]any
 		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 			b, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(b, &gotBody)
+			w.Header().Set("Location", "act-create")
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"static_ip_id":"si-x"}`))
 		})
-		if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err != nil {
+		if _, _, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		// ipAddress keeps omitempty: an omitted (zero) value must NOT be in the body.
+		// Mutation-proof — drop ipAddress's omitempty and "" would serialise, failing here.
 		if _, ok := gotBody["ipAddress"]; ok {
-			t.Fatalf("an omitted ip_address must not be sent, body=%v", gotBody)
+			t.Fatalf("an omitted ipAddress must not be sent, body=%v", gotBody)
 		}
-		if _, ok := gotBody["resourceDescription"]; ok {
-			t.Fatalf("an omitted resource_description must not be sent, body=%v", gotBody)
+		// A provided resourceDescription is forwarded with its value intact. This does
+		// NOT by itself pin the no-omitempty tag (a non-empty value serialises either
+		// way); the tag is pinned directly by the marshal subtest below, and the
+		// REQUIRED-reject-empty contract by the precondition subtests further down.
+		if gotBody["resourceDescription"] != "web" {
+			t.Fatalf("resourceDescription must be forwarded as-is, body=%v", gotBody)
 		}
 	})
 
-	// The LIVE API returns 201 with an EMPTY body (the swagger's static_ip_id is
-	// not actually sent). The create is synchronous, so the id MUST be resolved
-	// from a complete listing of the private network rather than treated as a
-	// failure — a failure would orphan the created static IP (created
-	// platform-side but absent from the Terraform state). The resolution matches
-	// the requested MAC AND source=="custom".
-	//
-	// Non-complacent on TWO axes: (1) the pre-fix code returned an error on an
-	// empty body, so an empty-body success goes RED without the fallback; (2) an
-	// "xoa" static IP shares the SAME MAC (the #311 platform auto-creation), and
-	// it is listed FIRST — without the source=="custom" filter the resolution
-	// would match both and either pick xoa or fail ambiguous, never returning the
-	// custom id this assertion demands.
-	t.Run("a 201 empty body resolves the id from the listing, picking the custom IP over a co-resident xoa one", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodPost:
-				w.WriteHeader(http.StatusCreated) // empty body, like the live API
-			case r.Method == http.MethodGet && r.URL.Path == "/vpc/v1/private_networks/pn-1/static_ips":
-				w.WriteHeader(http.StatusOK)
-				// xoa first (same MAC, #311 co-residence), then our custom one.
-				_, _ = w.Write([]byte(`[
-					{"id":"si-xoa","macAddress":"00:50:56:AB:CD:EF","source":"xoa"},
-					{"id":"si-custom","macAddress":"00:50:56:ab:cd:ef","source":"custom"},
-					{"id":"si-other","macAddress":"00:50:56:11:22:33","source":"custom"}
-				]`))
-			default:
-				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-				w.WriteHeader(http.StatusInternalServerError)
-			}
-		})
-		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"})
+	t.Run("resourceDescription carries no omitempty: an empty value is still serialised", func(t *testing.T) {
+		// The struct deliberately drops omitempty on resourceDescription (the live
+		// contract REQUIRES the field). Pin that directly on the type's serialisation,
+		// independently of CreateStart's precondition. Mutation-proof: re-add omitempty
+		// and the empty value is elided, so the field vanishes and this assertion fails.
+		b, err := json.Marshal(&CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef", ResourceDescription: ""})
 		if err != nil {
-			t.Fatalf("an empty 201 body must resolve the id from the listing, not fail: %v", err)
+			t.Fatalf("marshal: %v", err)
 		}
-		if id != "si-custom" {
-			t.Fatalf("the id must resolve to the CUSTOM static IP for the MAC, got %q (a %q here means the xoa co-resident IP was wrongly picked)", id, "si-xoa")
+		if !strings.Contains(string(b), `"resourceDescription":""`) {
+			t.Fatalf("an empty resourceDescription must still be serialised (no omitempty); got %s", b)
 		}
-	})
-
-	// The API may format the returned MAC differently from the request (the
-	// swagger pattern tolerates "-" and any case). Resolution must normalise both
-	// sides, or a well-created static IP returned as "00-50-56-AB-CD-EF" would not
-	// match the requested "00:50:56:ab:cd:ef" and would be orphaned.
-	// Non-complacent: a raw == comparison reds this case.
-	t.Run("a 201 empty body matches the custom IP across MAC case/separator differences", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				w.WriteHeader(http.StatusCreated) // empty body
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"si-fmt","macAddress":"00-50-56-AB-CD-EF","source":"custom"}]`))
-		})
-		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"})
-		if err != nil {
-			t.Fatalf("MAC formatting differences must be normalised, not fail: %v", err)
-		}
-		if id != "si-fmt" {
-			t.Fatalf("the id must resolve across MAC formatting, got %q", id)
+		// Conversely, the omitempty field IS elided when empty (same marshal, opposite
+		// contract) — so this subtest also guards against accidentally dropping
+		// ipAddress's omitempty.
+		if strings.Contains(string(b), "ipAddress") {
+			t.Fatalf("an empty ipAddress must be elided (omitempty); got %s", b)
 		}
 	})
 
-	t.Run("a 201 empty body with no matching custom IP in the listing is an error (never a silent success)", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				w.WriteHeader(http.StatusCreated) // empty body
-				return
+	// resourceDescription is REQUIRED by the live create contract: an empty or
+	// whitespace-only value is rejected as a CreateStart PRECONDITION error BEFORE
+	// any POST, so a doomed request never reaches the API. Non-complacent: a
+	// `posted` flag asserts the rejection happens BEFORE the HTTP call — not that
+	// the server happened to bounce it. Replaces the old "omitted resource_
+	// description is silently not sent" test, which encoded the wrong contract.
+	for _, tc := range []struct {
+		name string
+		desc string
+	}{
+		{"empty resourceDescription", ""},
+		{"whitespace-only resourceDescription", "   "},
+	} {
+		tc := tc
+		t.Run(tc.name+" is rejected before the POST", func(t *testing.T) {
+			var posted bool
+			c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posted = true
+				}
+				w.WriteHeader(http.StatusCreated)
+			})
+			_, _, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+				MacAddress:          "00:50:56:ab:cd:ef",
+				ResourceDescription: tc.desc,
+			})
+			if err == nil {
+				t.Fatal("an empty/whitespace resourceDescription must be a precondition error")
 			}
-			w.WriteHeader(http.StatusOK)
-			// Only a co-resident xoa IP for the MAC, plus an unrelated custom one.
-			_, _ = w.Write([]byte(`[
-				{"id":"si-xoa","macAddress":"00:50:56:ab:cd:ef","source":"xoa"},
-				{"id":"si-other","macAddress":"00:50:56:11:22:33","source":"custom"}
-			]`))
-		})
-		if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err == nil {
-			t.Fatal("no matching custom IP must error, not silently succeed (or bind to the xoa one)")
-		}
-	})
-
-	t.Run("a 201 empty body with a failing strict listing is an error", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				w.WriteHeader(http.StatusCreated) // empty body
-				return
+			if posted {
+				t.Fatal("the precondition must reject BEFORE the POST (no doomed request reaches the API)")
 			}
-			// A 206/403/5xx is rejected by ListStrict -> cannot resolve -> error.
-			w.WriteHeader(http.StatusForbidden)
 		})
-		if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err == nil {
-			t.Fatal("an empty body whose listing fails must error, not silently succeed")
-		}
-	})
-
-	// A listing entry WITHOUT an id must error rather than resolve to an empty id
-	// (which would orphan the created static IP via SetId("")). This is now caught
-	// upstream by ListStrict's structural guard (an id-less entry makes the whole
-	// listing untrusted); Create keeps a defensive match.ID=="" check too.
-	t.Run("a 201 empty body whose listing has an id-less entry is an error", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				w.WriteHeader(http.StatusCreated) // empty body
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"macAddress":"00:50:56:ab:cd:ef","source":"custom"}]`)) // no id
-		})
-		if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err == nil {
-			t.Fatal("a matched custom entry without an id must error, not return an empty id with nil error")
-		}
-	})
-
-	t.Run("a 201 empty body with two custom IPs sharing the MAC is an ambiguity error", func(t *testing.T) {
-		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				w.WriteHeader(http.StatusCreated) // empty body
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[
-				{"id":"si-a","macAddress":"00:50:56:ab:cd:ef","source":"custom"},
-				{"id":"si-b","macAddress":"00:50:56:ab:cd:ef","source":"custom"}
-			]`))
-		})
-		if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err == nil {
-			t.Fatal("two custom IPs sharing the MAC must be an ambiguity error, not a silent pick")
-		}
-	})
+	}
 
 	t.Run("a non-201 status is an error", func(t *testing.T) {
 		for _, code := range []int{http.StatusOK, http.StatusBadRequest, http.StatusForbidden, http.StatusInternalServerError} {
@@ -201,9 +179,166 @@ func TestVPCStaticIPCreate(t *testing.T) {
 				w.WriteHeader(code)
 				_, _ = w.Write([]byte(`{"static_ip_id":"si-x"}`))
 			})
-			if _, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{MacAddress: "00:50:56:ab:cd:ef"}); err == nil {
+			if _, _, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+				MacAddress:          "00:50:56:ab:cd:ef",
+				ResourceDescription: "web",
+			}); err == nil {
 				t.Fatalf("status %d must be rejected (only 201 is a successful create)", code)
 			}
+		}
+	})
+
+	t.Run("an EXPECTED create activity is not rejected by ErrorOnUnexpectedActivity", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", "act-create")
+			w.WriteHeader(http.StatusCreated)
+		})
+		// internal/client/tests sets this guard suite-wide to catch sync endpoints that
+		// unexpectedly go async. CreateStart EXPECTS an activity, so — like the sibling
+		// async methods Update/Delete — it must NOT trip the guard. Mutation-proof: route
+		// CreateStart back through doRequest/doRequestOnce and this goes red with
+		// "an unexpected Location header has been found".
+		c.config.ErrorOnUnexpectedActivity = true
+		activityID, syncID, err := c.VPC().StaticIP().CreateStart(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		})
+		if err != nil {
+			t.Fatalf("CreateStart expects an activity and must bypass ErrorOnUnexpectedActivity; got error: %v", err)
+		}
+		if activityID != "act-create" || syncID != "" {
+			t.Fatalf("expected activityID=act-create syncID=%q; got activityID=%q syncID=%q", "", activityID, syncID)
+		}
+	})
+}
+
+// TestVPCStaticIPWaitCreate pins the activity-resolution contract: the new id is
+// the completed activity's single state Result; an EMPTY Result fails closed
+// (R-M1) — a created id we cannot read must be an error, never an empty id that
+// would orphan the resource via SetId(""). options is nil here (the WaiterOptions
+// methods are nil-safe), since these tests pin resolution, not poll logging.
+func TestVPCStaticIPWaitCreate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a completed activity yields the id from its single state Result", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/activity/v1/activities/act-create" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(completedActivityBody("si-new")))
+		})
+		id, err := c.VPC().StaticIP().WaitCreate(ctx, "act-create", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != "si-new" {
+			t.Fatalf("the id must come from the activity Result, got %q", id)
+		}
+	})
+
+	t.Run("a completed activity with an EMPTY Result fails closed (R-M1)", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(completedActivityBody("")))
+		})
+		if _, err := c.VPC().StaticIP().WaitCreate(ctx, "act-create", nil); err == nil {
+			t.Fatal("an empty activity Result must fail closed, never return an empty id with a nil error")
+		}
+	})
+}
+
+// TestVPCStaticIPCreate pins the composed async create (CreateStart + WaitCreate):
+// it POSTs the create, waits on the Location activity, resolves the id from that
+// activity's Result, and — crucially — performs NO listing GET (the old
+// orphan-prone MAC-resolution path is gone, R-M2). A wait failure yields an error
+// carrying the activityID (R-Q2: the provider must fail closed and not SetId), and
+// a sync body id short-circuits the wait entirely.
+func TestVPCStaticIPCreate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("async happy path resolves the id from the activity and never lists the network", func(t *testing.T) {
+		var sawListing bool
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/vpc/v1/private_networks/pn-1/static_ips":
+				w.Header().Set("Location", "act-create")
+				w.WriteHeader(http.StatusCreated) // empty body, live contract
+			case r.Method == http.MethodGet && r.URL.Path == "/activity/v1/activities/act-create":
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(completedActivityBody("si-new")))
+			case r.Method == http.MethodGet && r.URL.Path == "/vpc/v1/private_networks/pn-1/static_ips":
+				// The async create must NEVER resolve the id by listing the network.
+				sawListing = true
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		})
+		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != "si-new" {
+			t.Fatalf("id must resolve from the activity Result, got %q", id)
+		}
+		if sawListing {
+			t.Fatal("the async create happy path must NOT list the network (the orphan-prone resolution path is removed)")
+		}
+	})
+
+	t.Run("a wait failure yields an error carrying the activityID, never a usable id", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost:
+				w.Header().Set("Location", "act-create")
+				w.WriteHeader(http.StatusCreated)
+			case r.Method == http.MethodGet && r.URL.Path == "/activity/v1/activities/act-create":
+				// Completed but EMPTY Result → WaitCreate fails closed (R-M1).
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(completedActivityBody("")))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		})
+		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		}, nil)
+		if err == nil {
+			t.Fatal("a wait failure must surface as an error, never a usable id")
+		}
+		if id != "" {
+			t.Fatalf("a failed create must return an empty id, got %q", id)
+		}
+		// The wrap must carry the activityID so a postmortem can name the orphan window.
+		if !strings.Contains(err.Error(), "act-create") {
+			t.Fatalf("the wait-failure error must carry the activityID for correlation, got %v", err)
+		}
+	})
+
+	t.Run("the sync path returns the body id directly without polling or listing", func(t *testing.T) {
+		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("the sync path must POST only (no activity poll, no listing), got %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"static_ip_id":"si-sync"}`))
+		})
+		id, err := c.VPC().StaticIP().Create(ctx, "pn-1", &CreateStaticIPRequest{
+			MacAddress:          "00:50:56:ab:cd:ef",
+			ResourceDescription: "web",
+		}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != "si-sync" {
+			t.Fatalf("the sync path must return the body id, got %q", id)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Fixes the create contract behind #348: the deployed `/vpc/v1` API acknowledges a static IP create **asynchronously** (201 + `Location` header, empty body), verified against a live environment. The previous client assumed a synchronous body and never resolved the created id.
- The create is split into `CreateStart` (POST; returns the create activity, or a defensive synchronous id) and `WaitCreate` (polls the activity to completion), composed by `Create`. `WaitCreate` fails closed on an empty activity Result — an unresolved id is never treated as success.
- This is the first chunk (C1) of the VPC v1.9.0 rebuild and is **client-only**: it restores no user-facing datasource or resource (those are later chunks), and the ct-validate VPC cycle stays quarantined (excluded from `-cycles all`) until the end-to-end write cycle is proven.

## Key changes
- `internal/client/vpc_static_ip.go`: async create. `CreateStart` bypasses the `ErrorOnUnexpectedActivity` guard the same way the sibling async `Update`/`Delete` do, because the create `Location` is expected here. `resourceDescription` is required by the deployed API (no `omitempty`); an empty value is rejected as a precondition error before the POST.
- `cmd/ct-validate`: the VPC SDK banner is updated to "under active rebuild (v1.9.0)" while the cycle stays quarantined as an operational blast-radius backstop; the static IP teardown records a 403-as-absent proof only inside the breaker-gated delete closure (never drop, never orphan; destructive only on strict positive evidence); quarantine-mechanism comments aligned with the rebuild doctrine.
- Tests: mutation-proof unit tests for the async create, the guard bypass, the `resourceDescription` struct tag, and the proof-only teardown; a human-gated live probe that documents the async contract and fails loudly rather than orphan a created resource it cannot address.

## Independent review
- Pre-commit review: GO-WITH-FIXES. All flagged items applied — live-probe orphan-on-empty-Result hardening, a mutation-proof marshal assertion, and the create-activity guard bypass with its test.
- Committed-diff review: GO. 0 blocking, 0 complacent tests, quarantine coherent.

## Merge preconditions (not yet met)
- [ ] Full `all` validation gate green, run with live credentials (the offline build/vet/unit gate is green).
- [ ] Explicit human GO to merge into `rc/v1.9.0`.

## Test plan
- [x] `go build ./...`, `go vet`, and unit tests for `cmd/ct-validate` and `internal/client` pass (Go 1.24).
- [x] New tests are mutation-proven (revert the fix and the test goes red; restore and it goes green).
- [x] Live gate (`internal/client/tests` and `ct-validate -cycles all`) — pending a human run with credentials.