### PR TITLE
feat(#374): cloudtemple_compute_iaas_opensource_network_adapter ip_address (VPC static IP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ NEW FEATURES :
   * Added resource `cloudtemple_vpc_floating_ip` to provision and manage a floating (public) IP. Provisioning is asynchronous and the billable IP is never silently orphaned; destroying the resource deprovisions the IP only once a strict read proves it unbound and a positive absence check confirms its removal — destroying a floating IP that is still bound to a static IP is refused with an actionable error. Binding to a static IP is read-only on this resource.
   * Added resource `cloudtemple_vpc_floating_ip_binding` to bind/unbind a floating (public) IP to a static IP — the day-to-day "expose a VM publicly" action. The binding is reversible by construction (the floating IP is provisioned separately and is left intact on destroy); creating it refuses to clobber a floating IP already bound elsewhere, and both create and destroy confirm the outcome by a strict by-id read that tells an omitted association apart from a genuine one — so the binding is never silently clobbered, orphaned, or dropped on inconclusive evidence.
 
+ENHANCEMENTS :
+
+  * Added `ip_address` to resource `cloudtemple_compute_iaas_opensource_network_adapter`. When the adapter's `network_id` is a VPC-backed network, this assigns the adapter's VPC static IP to a chosen address (and relocates it in place on change); if omitted the platform auto-assigns one. The assigned address is read back into the state — resolved by MAC, as the platform does not echo it on the adapter object — so the plan converges, and destroying the adapter releases the static IP. Setting it while `network_id` is not VPC-backed is rejected.
+
 # 1.8.0 (Unreleased)
 
 SECURITY :

--- a/docs/resources/compute_iaas_opensource_network_adapter.md
+++ b/docs/resources/compute_iaas_opensource_network_adapter.md
@@ -51,6 +51,7 @@ resource "cloudtemple_compute_iaas_opensource_network_adapter" "VIF-1" {
 ### Optional
 
 - `attached` (Boolean) Whether the network adapter is attached.
+- `ip_address` (String) The VPC static IP to assign to this adapter. Requires `network_id` to reference a VPC-backed private network: when set, the adapter is given this address on the VPC; if omitted, the platform auto-assigns one (reflected here after apply). Mutable: changing it relocates the static IP. Setting it while `network_id` is not VPC-backed is rejected.
 - `mac_address` (String) The MAC address of the network adapter. If not specified, a random MAC address will be generated.
 - `tx_checksumming` (Boolean) Whether TX checksumming is enabled on the network adapter.
 

--- a/docs/resources/compute_iaas_opensource_network_adapter.md
+++ b/docs/resources/compute_iaas_opensource_network_adapter.md
@@ -7,6 +7,7 @@ description: |-
     - compute_iaas_opensource_management
     - compute_iaas_opensource_read
     - activity_read
+    - vpc_read
 ---
 
 # cloudtemple_compute_iaas_opensource_network_adapter (Resource)
@@ -15,6 +16,7 @@ To manage this resource you will need the following roles:
   - `compute_iaas_opensource_management`
   - `compute_iaas_opensource_read`
   - `activity_read`
+  - `vpc_read`
 
 ## Example Usage
 

--- a/internal/client/compute_iaas_opensource_network.go
+++ b/internal/client/compute_iaas_opensource_network.go
@@ -20,6 +20,12 @@ type OpenIaaSNetwork struct {
 	NetworkAdapters            []string
 	NetworkBlockDevice         bool
 	InsecureNetworkBlockDevice bool
+	// VPC is the network's VPC association (swagger.comput.yml openIaasNetwork
+	// `vpc`). It is a POINTER: the API emits the `vpc` object only for a
+	// VPC-backed network, so a plain network decodes it to nil. The provider
+	// uses VPC != nil to tell a VPC-backed network apart from a plain one
+	// before assigning a static IP (#1854).
+	VPC *OpenIaaSNetworkAdapterVPC `json:"vpc"`
 }
 
 type OpenIaaSNetworkFilter struct {

--- a/internal/client/compute_iaas_opensource_network_adapter.go
+++ b/internal/client/compute_iaas_opensource_network_adapter.go
@@ -50,6 +50,11 @@ type CreateOpenIaasNetworkAdapterRequest struct {
 	VirtualMachineID string `json:"virtualMachineId"`
 	NetworkID        string `json:"networkId"`
 	MAC              string `json:"mac,omitempty"`
+	// IPAddress is the VPC static IP to assign when the target network is
+	// VPC-backed (compute API #1854). When set, the create registers a static
+	// IP at this address on the private network for the adapter's MAC; when
+	// omitted the platform auto-assigns one. Ignored on a non-VPC network.
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 func (v *OpenIaaSNetworkAdapterClient) Create(ctx context.Context, req *CreateOpenIaasNetworkAdapterRequest) (string, error) {
@@ -137,6 +142,10 @@ type UpdateOpenIaasNetworkAdapterRequest struct {
 	// Pointer so that an explicit `false` is serialized: with a plain bool
 	// and omitempty, disabling TX checksumming could never be sent (#246).
 	TxChecksumming *bool `json:"txChecksumming,omitempty"`
+	// IPAddress relocates the VPC static IP of a VPC-backed adapter to this
+	// address (compute API #1854). The API requires networkId alongside
+	// ipAddress, so callers set NetworkID when they set IPAddress.
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 func (v *OpenIaaSNetworkAdapterClient) Update(ctx context.Context, id string, req *UpdateOpenIaasNetworkAdapterRequest) (string, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -197,7 +197,7 @@ func New(version string) func() *schema.Provider {
 				// Compute - Open IaaS
 				"cloudtemple_compute_iaas_opensource_virtual_machine":    documentResource(resourceOpenIaasVirtualMachine(), "compute_iaas_opensource_management", "compute_iaas_opensource_read", "compute_iaas_opensource_virtual_machine_power", "backup_iaas_opensource_read", "backup_iaas_opensource_write", "activity_read", "tag_read", "tag_write"),
 				"cloudtemple_compute_iaas_opensource_virtual_disk":       documentResource(resourceOpenIaasVirtualDisk(), "compute_iaas_opensource_management", "compute_iaas_opensource_read", "activity_read"),
-				"cloudtemple_compute_iaas_opensource_network_adapter":    documentResource(resourceOpenIaasNetworkAdapter(), "compute_iaas_opensource_management", "compute_iaas_opensource_read", "activity_read"),
+				"cloudtemple_compute_iaas_opensource_network_adapter":    documentResource(resourceOpenIaasNetworkAdapter(), "compute_iaas_opensource_management", "compute_iaas_opensource_read", "activity_read", "vpc_read"),
 				"cloudtemple_compute_iaas_opensource_replication_policy": documentResource(resourceOpenIaasReplicationPolicy(), "compute_iaas_opensource_management", "compute_iaas_opensource_read", "activity_read"),
 
 				// Object Storage

--- a/internal/provider/resource_compute_iaas_opensource_network_adapter.go
+++ b/internal/provider/resource_compute_iaas_opensource_network_adapter.go
@@ -367,7 +367,10 @@ func openIaasNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, m
 	//     attempt, so resolving the live IP INSIDE the builder makes a retry after
 	//     a transient failure recognise an already-applied relocation (converged
 	//     => nil patch) instead of relocating the static IP to itself.
-	if d.HasChange("ip_address") || d.HasChange("network_id") {
+	// mac_address is in the trigger because the VPC static IP is keyed BY MAC: a
+	// MAC change re-targets the registration, so a configured ip_address must be
+	// re-applied to the new MAC in the same apply (not just on ip/network change).
+	if d.HasChange("ip_address") || d.HasChange("network_id") || d.HasChange("mac_address") {
 		ipConfigured := false
 		if raw := d.GetRawConfig(); !raw.IsNull() {
 			if v := raw.GetAttr("ip_address"); !v.IsNull() {

--- a/internal/provider/resource_compute_iaas_opensource_network_adapter.go
+++ b/internal/provider/resource_compute_iaas_opensource_network_adapter.go
@@ -57,6 +57,13 @@ func resourceOpenIaasNetworkAdapter() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"ip_address": {
+				Type:         schema.TypeString,
+				Description:  "The VPC static IP to assign to this adapter. Requires `network_id` to reference a VPC-backed private network: when set, the adapter is given this address on the VPC; if omitted, the platform auto-assigns one (reflected here after apply). Mutable: changing it relocates the static IP. Setting it while `network_id` is not VPC-backed is rejected.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
 
 			// Out
 			"id": {
@@ -127,6 +134,11 @@ func openIaasNetworkAdapterCreate(ctx context.Context, d *schema.ResourceData, m
 	c := getClient(meta)
 	vmID := d.Get("virtual_machine_id").(string)
 
+	// Reject ip_address on a non-VPC network BEFORE creating anything.
+	if diags := ensureVPCForIPAddress(ctx, c, d); diags != nil {
+		return diags
+	}
+
 	var activity *client.Activity
 	var err error
 	for attempt := 1; attempt <= maxTransientVIFAttempts; attempt++ {
@@ -138,6 +150,7 @@ func openIaasNetworkAdapterCreate(ctx context.Context, d *schema.ResourceData, m
 			VirtualMachineID: vmID,
 			NetworkID:        d.Get("network_id").(string),
 			MAC:              d.Get("mac_address").(string),
+			IPAddress:        d.Get("ip_address").(string),
 		})
 		if err != nil {
 			return diag.Errorf("the network adapter could not be created: %s", err)
@@ -257,11 +270,37 @@ func openIaasNetworkAdapterRead(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
+	// Resolve the VPC static IP assigned to this adapter so a configured
+	// `ip_address` converges. The adapter read does NOT echo it: the nested
+	// vpc.staticIpAddress reflects the live guest IP and is absent when the VM
+	// has no live address (e.g. powered off), whereas the platform-registered
+	// static IP is addressable only via GET /vpc/v1/static_ips/mac/{mac}. We
+	// only query for a VPC-backed adapter (VPC != nil); a plain-network adapter
+	// has no static IP, so ip_address is empty. Fail closed on a read error
+	// rather than blanking ip_address (which would show a spurious diff).
+	ipAddress := ""
+	onVPC := networkAdapter.VPC != nil
+	if onVPC && networkAdapter.MacAddress != "" {
+		staticIP, err := c.VPC().StaticIP().ReadByMAC(ctx, networkAdapter.MacAddress)
+		if err != nil {
+			return diag.Errorf("failed to read the VPC static IP of network adapter %s: %s", d.Id(), err)
+		}
+		ipAddress = adapterVPCStaticIP(onVPC, staticIP)
+	}
+	if err := d.Set("ip_address", ipAddress); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return diags
 }
 
 func openIaasNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := getClient(meta)
+
+	// Reject ip_address on a non-VPC network BEFORE moving the adapter.
+	if diags := ensureVPCForIPAddress(ctx, c, d); diags != nil {
+		return diags
+	}
 
 	if d.HasChange("network_id") || d.HasChange("mac_address") || d.HasChange("tx_checksumming") {
 		// At create time every HasChange is true while the Create request
@@ -317,6 +356,76 @@ func openIaasNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
+	// VPC static IP (ip_address) is reconciled AFTER the network/mac patch above,
+	// against a FRESH read, for two reasons (both real):
+	//   - moving onto a VPC-backed network and setting ip_address in the SAME
+	//     apply: only the post-patch read shows the adapter on the VPC, so gating
+	//     on the pre-patch attachment would skip the assignment and let the
+	//     platform auto-assign instead of using the configured address;
+	//   - the assigned IP lives only on the VPC side (addressable by MAC), not on
+	//     the adapter object (#1854). runVIFUpdateWithRetry re-reads before every
+	//     attempt, so resolving the live IP INSIDE the builder makes a retry after
+	//     a transient failure recognise an already-applied relocation (converged
+	//     => nil patch) instead of relocating the static IP to itself.
+	if d.HasChange("ip_address") || d.HasChange("network_id") {
+		ipConfigured := false
+		if raw := d.GetRawConfig(); !raw.IsNull() {
+			if v := raw.GetAttr("ip_address"); !v.IsNull() {
+				ipConfigured = true
+			}
+		}
+		configuredIP := d.Get("ip_address").(string)
+		if ipConfigured && configuredIP != "" {
+			fresh, err := c.Compute().OpenIaaS().NetworkAdapter().Read(ctx, d.Id())
+			if err != nil {
+				return diag.Errorf("failed to read network adapter %s before VPC IP reconciliation: %s", d.Id(), err)
+			}
+			if fresh == nil {
+				return diag.Errorf("network adapter %s not found", d.Id())
+			}
+			// Reconcile only on a VPC-backed network. ensureVPCForIPAddress already
+			// rejected a non-VPC target up front, so a non-VPC `fresh` here means a
+			// rare mid-apply drift: skip rather than error after the network patch
+			// already ran. The live static IP is resolved by MAC INSIDE the builder
+			// (runVIFUpdateWithRetry re-reads before every attempt) so a retry after
+			// a transient failure recognises an already-applied relocation
+			// (converged => nil) instead of relocating the static IP to itself.
+			if fresh.VPC != nil {
+				var ipReadErr error
+				relocatePatch := func(actual *client.OpenIaaSNetworkAdapter) *client.UpdateOpenIaasNetworkAdapterRequest {
+					if actual.VPC == nil {
+						return nil
+					}
+					staticIP, err := c.VPC().StaticIP().ReadByMAC(ctx, actual.MacAddress)
+					if err != nil {
+						ipReadErr = err
+						return nil
+					}
+					liveIP := adapterVPCStaticIP(true, staticIP)
+					if ip := vpcStaticIPToPush(true, configuredIP, liveIP, true); ip != "" {
+						// The API requires networkId alongside ipAddress; re-sending
+						// the same networkId WITH a real ipAddress change is accepted
+						// (not the redundant-patch self-conflict of #246, verified live).
+						return &client.UpdateOpenIaasNetworkAdapterRequest{
+							NetworkID: actual.Network.ID,
+							IPAddress: ip,
+						}
+					}
+					return nil
+				}
+				if relocatePatch(fresh) != nil {
+					// Bounded retry on transient platform failures (#251 / #315).
+					if err := runVIFUpdateWithRetry(ctx, d.Id(), clientVIFUpdateFuncs(c, d.Id(), getWaiterOptions(ctx)), relocatePatch); err != nil {
+						return diag.Errorf("the VPC static IP of network adapter %s could not be set: %s", d.Id(), err)
+					}
+				}
+				if ipReadErr != nil {
+					return diag.Errorf("failed to read the current VPC static IP of network adapter %s: %s", d.Id(), ipReadErr)
+				}
+			}
+		}
+	}
+
 	if d.HasChange("attached") && !d.IsNewResource() {
 		switch d.Get("attached").(bool) {
 		case true:
@@ -352,6 +461,67 @@ func openIaasNetworkAdapterDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("failed to delete network adapter, %s", err)
 	}
 	return nil
+}
+
+// ensureVPCForIPAddress fails closed BEFORE any side effect when ip_address is
+// explicitly configured but the target network_id is not a VPC-backed private
+// network. ip_address only has meaning on a VPC network (it assigns the
+// adapter's static IP there); on a plain network the platform ignores it, so
+// the value could never be applied nor recorded and the plan would never
+// converge. Validating the target network up front makes apply reject the bad
+// config instead of creating/moving the adapter and only then failing.
+func ensureVPCForIPAddress(ctx context.Context, c *client.Client, d *schema.ResourceData) diag.Diagnostics {
+	raw := d.GetRawConfig()
+	if raw.IsNull() {
+		return nil
+	}
+	if v := raw.GetAttr("ip_address"); v.IsNull() {
+		return nil
+	}
+	ip := d.Get("ip_address").(string)
+	if ip == "" {
+		return nil
+	}
+	networkID := d.Get("network_id").(string)
+	network, err := c.Compute().OpenIaaS().Network().Read(ctx, networkID)
+	if err != nil {
+		return diag.Errorf("failed to read network %s to validate ip_address: %s", networkID, err)
+	}
+	if network == nil {
+		return diag.Errorf("network %s not found while validating ip_address", networkID)
+	}
+	if network.VPC == nil {
+		return diag.Errorf("ip_address %q is set but network %s is not a VPC-backed private network: ip_address requires network_id to reference a VPC private network — remove ip_address or use a VPC network", ip, networkID)
+	}
+	return nil
+}
+
+// vpcStaticIPToPush decides the VPC static IP to send on an OpenIaaS adapter
+// update; it returns the address to push, or "" to leave the static IP
+// untouched. It pushes ONLY when ip_address is explicitly configured, non-empty,
+// the adapter is on a VPC-backed network, and the configured address diverges
+// from the live one: re-sending an unchanged address would relocate the static
+// IP to itself on every apply (a perpetual no-op activity), and ip_address has
+// no meaning on a non-VPC network. The live static IP is resolved by MAC by the
+// caller, because the platform does not echo it on the adapter object (#1854).
+func vpcStaticIPToPush(ipConfigured bool, configuredIP, liveIP string, onVPC bool) string {
+	if !ipConfigured || configuredIP == "" || !onVPC {
+		return ""
+	}
+	if configuredIP == liveIP {
+		return ""
+	}
+	return configuredIP
+}
+
+// adapterVPCStaticIP maps a by-MAC static IP read to the ip_address state value.
+// A non-VPC adapter has no static IP; a VPC adapter with none registered yet
+// (sip == nil — including the 403/absent the client maps to nil) also yields "".
+func adapterVPCStaticIP(onVPC bool, sip *client.StaticIP) string {
+	if !onVPC || sip == nil {
+		return ""
+	}
+	return sip.IPAddress
 }
 
 // vifCleanupTargets partitions the adapter ids referenced by the failed

--- a/internal/provider/resource_compute_iaas_opensource_network_adapter_unit_test.go
+++ b/internal/provider/resource_compute_iaas_opensource_network_adapter_unit_test.go
@@ -65,3 +65,47 @@ func TestClassifyMissingDevice(t *testing.T) {
 		t.Fatalf("present tenant-wide only is drift (detached/moved), never a deletion, got %v", got)
 	}
 }
+
+// TestVPCStaticIPToPush pins the update decision for the VPC static IP
+// (ip_address, #374). The subtle rules: never push when unconfigured/empty/off-VPC,
+// never re-push an unchanged address (it would relocate the static IP to itself
+// on every apply), push on a genuine divergence or a first set.
+func TestVPCStaticIPToPush(t *testing.T) {
+	cases := []struct {
+		name                 string
+		ipConfigured         bool
+		configuredIP, liveIP string
+		onVPC                bool
+		want                 string
+	}{
+		{"not configured -> never push", false, "", "", true, ""},
+		{"configured but empty -> never push", true, "", "", true, ""},
+		{"configured non-empty but not on a VPC network -> never push", true, "192.168.0.10", "", false, ""},
+		{"configured, on VPC, no live IP yet -> push (first set)", true, "192.168.0.10", "", true, "192.168.0.10"},
+		{"configured equals live -> no redundant relocate-to-self", true, "192.168.0.10", "192.168.0.10", true, ""},
+		{"configured diverges from live -> relocate", true, "192.168.0.11", "192.168.0.10", true, "192.168.0.11"},
+		{"a stale configured value with ipConfigured=false (field cleared) -> never push", false, "192.168.0.11", "192.168.0.10", true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := vpcStaticIPToPush(c.ipConfigured, c.configuredIP, c.liveIP, c.onVPC); got != c.want {
+				t.Fatalf("vpcStaticIPToPush(%v,%q,%q,%v) = %q, want %q", c.ipConfigured, c.configuredIP, c.liveIP, c.onVPC, got, c.want)
+			}
+		})
+	}
+}
+
+// TestAdapterVPCStaticIP pins the read mapping for ip_address (#374): a non-VPC
+// adapter and a VPC adapter without a registered static IP both yield empty; a
+// VPC adapter reflects the by-MAC static IP address.
+func TestAdapterVPCStaticIP(t *testing.T) {
+	if got := adapterVPCStaticIP(false, &client.StaticIP{IPAddress: "1.2.3.4"}); got != "" {
+		t.Fatalf("a non-VPC adapter has no static IP; want empty, got %q", got)
+	}
+	if got := adapterVPCStaticIP(true, nil); got != "" {
+		t.Fatalf("a VPC adapter with no registered static IP (nil) must yield empty, got %q", got)
+	}
+	if got := adapterVPCStaticIP(true, &client.StaticIP{IPAddress: "192.168.0.10"}); got != "192.168.0.10" {
+		t.Fatalf("a VPC adapter must reflect the by-MAC static IP; want 192.168.0.10, got %q", got)
+	}
+}

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -52,6 +52,13 @@
           "computed": true,
           "elem_kind": "nil"
         },
+        "ip_address": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
         "ipv4_address": {
           "type": "TypeString",
           "computed": true,


### PR DESCRIPTION
Refs #374

Adds `ip_address` to `cloudtemple_compute_iaas_opensource_network_adapter` so a VM network adapter can be attached to a VPC private network with a controlled static IP (compute API `feat(#1854)`). Mandatory for v1.9.0: the VPC surface exists to address VMs on VPC networks, and without this the provider can only let the platform auto-assign.

## What

- **client**: `IPAddress` on the create/update requests; `VPC` on the `OpenIaaSNetwork` model (to detect a VPC-backed network up front).
- **resource** `cloudtemple_compute_iaas_opensource_network_adapter`: `ip_address` (Optional+Computed, IPv4, mutable — relocation is in-place). Create plumbs it; the VPC static IP is reconciled **after** the network patch against a fresh read (so a same-apply move onto a VPC network uses the configured address) and resolved **by MAC per retry** (the platform does not echo the assigned IP on the adapter); Read converges `ip_address` by MAC, fail-closed; `ip_address` on a non-VPC network is **rejected before any side effect**.
- non-complacent unit tests (push-decision matrix + read mapping); docs, additive golden snapshot, CHANGELOG.

## Doctrine

`ip_address` on the adapter is the canonical VPC-addressing path (registers a `source=xoa` static IP); `cloudtemple_vpc_static_ip` stays for `source=custom` off-adapter allocations.

## Validation

- `gofmt`, `go vet`, coverage ratchet (above floors), `go generate` deterministic — all green.
- Codex adversarial review: 3 rounds, 3 P2 findings fixed, final review clean.
- **End-to-end live** on an OpenIaaS test tenant: create lands the chosen IP, plan converges (no perpetual diff), relocation is in-place, destroy releases the static IP (0 orphan).

Per the RC flow this targets `rc/v1.9.0` and uses `Refs #374`; the `Closes #374` keyword is carried by the `rc/v1.9.0 → main` PR.
