### PR TITLE
feat(#375): cloudtemple_compute_network_adapter ip_address (VMware VPC static IP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ NEW FEATURES :
   * Added resource `cloudtemple_vpc_floating_ip` to provision and manage a floating (public) IP. Provisioning is asynchronous and the billable IP is never silently orphaned; destroying the resource deprovisions the IP only once a strict read proves it unbound and a positive absence check confirms its removal — destroying a floating IP that is still bound to a static IP is refused with an actionable error. Binding to a static IP is read-only on this resource.
   * Added resource `cloudtemple_vpc_floating_ip_binding` to bind/unbind a floating (public) IP to a static IP — the day-to-day "expose a VM publicly" action. The binding is reversible by construction (the floating IP is provisioned separately and is left intact on destroy); creating it refuses to clobber a floating IP already bound elsewhere, and both create and destroy confirm the outcome by a strict by-id read that tells an omitted association apart from a genuine one — so the binding is never silently clobbered, orphaned, or dropped on inconclusive evidence.
 
+ENHANCEMENTS :
+
+  * Added `ip_address` to resource `cloudtemple_compute_network_adapter` (VMware). When the adapter's `network_id` is a VPC-backed network, this assigns the adapter's VPC static IP to a chosen address (and relocates it in place on change); if omitted the platform auto-assigns one. The assigned address is read back into the state — resolved by MAC, as the platform does not echo it on the adapter object — so the plan converges, and destroying the adapter releases the static IP. Setting it while `network_id` is not VPC-backed is rejected.
+
 # 1.8.0 (Unreleased)
 
 SECURITY :

--- a/docs/resources/compute_network_adapter.md
+++ b/docs/resources/compute_network_adapter.md
@@ -8,6 +8,7 @@ description: |-
     - compute_iaas_vmware_management
     - compute_iaas_vmware_read
     - activity_read
+    - vpc_read
 ---
 
 # cloudtemple_compute_network_adapter (Resource)
@@ -18,6 +19,7 @@ To manage this resource you will need the following roles:
   - `compute_iaas_vmware_management`
   - `compute_iaas_vmware_read`
   - `activity_read`
+  - `vpc_read`
 
 ## Example Usage
 
@@ -68,6 +70,7 @@ resource "cloudtemple_compute_network_adapter" "foo" {
 
 - `auto_connect` (Boolean) Whether the network adapter should connect to the network automatically when the virtual machine is powered on.
 - `connected` (Boolean) Whether the network adapter should be connected to the network. Defaults to true.
+- `ip_address` (String) The VPC static IP to assign to this adapter. Requires `network_id` to reference a VPC-backed network: when set, the adapter is given this address on the VPC; if omitted, the platform auto-assigns one (reflected here after apply). Mutable: changing it relocates the static IP. Setting it while `network_id` is not VPC-backed is rejected.
 - `mac_address` (String) The MAC address of the network adapter. If not provided, a MAC address will be generated automatically.
 
 ### Read-Only

--- a/internal/client/compute_network.go
+++ b/internal/client/compute_network.go
@@ -30,6 +30,11 @@ type Network struct {
 	VirtualMachinesNumber int
 	HostNumber            int
 	HostNames             []string
+	// VPC is the network's VPC association. POINTER: the API emits the `vpc`
+	// object only for a VPC-backed (vStack/VPC) portgroup, so a plain network
+	// decodes it to nil. Used to reject ip_address on a non-VPC network before
+	// any side effect (#375, confirmed live: the listing exposes `vpc`).
+	VPC *OpenIaaSNetworkAdapterVPC `json:"vpc"`
 }
 
 func (n *NetworkClient) List(

--- a/internal/client/compute_network_adapter.go
+++ b/internal/client/compute_network_adapter.go
@@ -20,6 +20,11 @@ type NetworkAdapter struct {
 	MacAddress       string
 	Connected        bool
 	AutoConnect      bool
+	// VPC carries the VPC association of the adapter (vpcDetails, shared with the
+	// OpenIaaS shape). POINTER: the API emits the `vpc` object only when the
+	// adapter is on a VPC-backed network; a plain-network adapter decodes it to
+	// nil (#375, confirmed live on the recette vCenter).
+	VPC *OpenIaaSNetworkAdapterVPC `json:"vpc"`
 }
 
 type NetworkAdapterFilter struct {
@@ -77,6 +82,9 @@ type CreateNetworkAdapterRequest struct {
 	NetworkId        string `json:"networkId"`
 	Type             string `json:"type"`
 	MacAddress       string `json:"macAddress,omitempty"`
+	// IPAddress is the VPC static IP to assign when the target network is
+	// VPC-backed (compute API #1854, source=vmware). Ignored on a plain network.
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 func (n *NetworkAdapterClient) Create(ctx context.Context, req *CreateNetworkAdapterRequest) (string, error) {
@@ -110,6 +118,10 @@ type UpdateNetworkAdapterRequest struct {
 	NewNetworkId string `json:"newNetworkId"`
 	AutoConnect  bool   `json:"autoConnect"`
 	MacAddress   string `json:"macAddress,omitempty"`
+	// IPAddress relocates the VPC static IP of a VPC-backed adapter to this
+	// address (compute API #1854, source=vmware). Sent only by the VPC IP
+	// reconciliation step, on a genuine divergence.
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 func (n *NetworkAdapterClient) Update(ctx context.Context, req *UpdateNetworkAdapterRequest) (string, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,7 +188,7 @@ func New(version string) func() *schema.Provider {
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				// Compute - IaaS VMWare
-				"cloudtemple_compute_network_adapter":    documentResource(resourceNetworkAdapter(), "compute_iaas_vmware_management", "compute_iaas_vmware_read", "activity_read"),
+				"cloudtemple_compute_network_adapter":    documentResource(resourceNetworkAdapter(), "compute_iaas_vmware_management", "compute_iaas_vmware_read", "activity_read", "vpc_read"),
 				"cloudtemple_compute_virtual_controller": documentResource(resourceVirtualController(), "compute_iaas_vmware_management", "compute_iaas_vmware_read", "activity_read"),
 				"cloudtemple_compute_virtual_disk":       documentResource(resourceVirtualDisk(), "compute_iaas_vmware_management", "compute_iaas_vmware_read", "activity_read"),
 				"cloudtemple_compute_virtual_machine":    documentResource(resourceVirtualMachine(), "compute_iaas_vmware_infrastructure_read", "compute_iaas_vmware_infrastructure_write", "compute_iaas_vmware_management", "compute_iaas_vmware_read", "compute_iaas_vmware_virtual_machine_power", "backup_iaas_spp_read", "backup_iaas_spp_write", "activity_read", "tag_read", "tag_write"),

--- a/internal/provider/resource_compute_network_adapter.go
+++ b/internal/provider/resource_compute_network_adapter.go
@@ -62,6 +62,13 @@ func resourceNetworkAdapter() *schema.Resource {
 				Optional:    true,
 				Description: "Whether the network adapter should be connected to the network. Defaults to true. ",
 			},
+			"ip_address": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPv4Address,
+				Description:  "The VPC static IP to assign to this adapter. Requires `network_id` to reference a VPC-backed network: when set, the adapter is given this address on the VPC; if omitted, the platform auto-assigns one (reflected here after apply). Mutable: changing it relocates the static IP. Setting it while `network_id` is not VPC-backed is rejected.",
+			},
 
 			// Out
 			"name": {
@@ -81,11 +88,17 @@ func resourceNetworkAdapter() *schema.Resource {
 func computeNetworkAdapterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
 
+	// Reject ip_address on a non-VPC network BEFORE creating anything.
+	if diags := ensureVMwareVPCForIPAddress(ctx, c, d); diags != nil {
+		return diags
+	}
+
 	activityId, err := c.Compute().NetworkAdapter().Create(ctx, &client.CreateNetworkAdapterRequest{
 		VirtualMachineId: d.Get("virtual_machine_id").(string),
 		MacAddress:       d.Get("mac_address").(string),
 		NetworkId:        d.Get("network_id").(string),
 		Type:             d.Get("type").(string),
+		IPAddress:        d.Get("ip_address").(string),
 	})
 	if err != nil {
 		return diag.Errorf("the network adapter could not be created: %s", err)
@@ -140,11 +153,34 @@ func computeNetworkAdapterRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	// Converge ip_address: the assigned VPC static IP is addressable only by MAC
+	// (GET /vpc/v1/static_ips/mac/{mac}), not echoed on the adapter object
+	// (#375 / #1854). Only a VPC-backed adapter has one; fail closed on a read
+	// error rather than blanking ip_address (which would show a spurious diff).
+	ipAddress := ""
+	onVPC := networkAdapter.VPC != nil
+	if onVPC && networkAdapter.MacAddress != "" {
+		staticIP, err := c.VPC().StaticIP().ReadByMAC(ctx, networkAdapter.MacAddress)
+		if err != nil {
+			return diag.Errorf("failed to read the VPC static IP of network adapter %s: %s", d.Id(), err)
+		}
+		ipAddress = vmwareAdapterVPCStaticIP(onVPC, staticIP)
+	}
+	if err := d.Set("ip_address", ipAddress); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return diags
 }
 
 func computeNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
+
+	// Reject ip_address on a non-VPC network BEFORE mutating the adapter.
+	if diags := ensureVMwareVPCForIPAddress(ctx, c, d); diags != nil {
+		return diags
+	}
+
 	activityId, err := c.Compute().NetworkAdapter().Update(ctx, &client.UpdateNetworkAdapterRequest{
 		ID:           d.Id(),
 		NewNetworkId: d.Get("network_id").(string),
@@ -189,6 +225,57 @@ func computeNetworkAdapterUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	// VPC static IP reconciliation, AFTER the network/mac patch and against a
+	// FRESH read: a same-apply move onto a VPC-backed network then shows the
+	// adapter on the VPC, and the assigned IP is resolved by MAC (the platform
+	// does not echo it on the adapter, #1854). Push only on a genuine divergence
+	// so a no-op apply never relocates the static IP to itself.
+	// mac_address is in the trigger because the VPC static IP is keyed BY MAC:
+	// a MAC change re-targets the registration, so a configured ip_address must
+	// be re-applied to the new MAC in the same apply (not just on ip/network change).
+	if d.HasChange("ip_address") || d.HasChange("network_id") || d.HasChange("mac_address") {
+		ipConfigured := false
+		if raw := d.GetRawConfig(); !raw.IsNull() {
+			if v := raw.GetAttr("ip_address"); !v.IsNull() {
+				ipConfigured = true
+			}
+		}
+		configuredIP := d.Get("ip_address").(string)
+		if ipConfigured && configuredIP != "" {
+			fresh, err := c.Compute().NetworkAdapter().Read(ctx, d.Id())
+			if err != nil {
+				return diag.Errorf("failed to read network adapter %s before VPC IP reconciliation: %s", d.Id(), err)
+			}
+			if fresh == nil {
+				return diag.Errorf("network adapter %s not found", d.Id())
+			}
+			// A non-VPC target was already rejected up front; skip rather than
+			// error here (rare mid-apply drift) since the patch already ran.
+			if fresh.VPC != nil {
+				staticIP, err := c.VPC().StaticIP().ReadByMAC(ctx, fresh.MacAddress)
+				if err != nil {
+					return diag.Errorf("failed to read the current VPC static IP of network adapter %s: %s", d.Id(), err)
+				}
+				liveIP := vmwareAdapterVPCStaticIP(true, staticIP)
+				if ip := vmwareVPCStaticIPToPush(true, configuredIP, liveIP, true); ip != "" {
+					relocateActivity, err := c.Compute().NetworkAdapter().Update(ctx, &client.UpdateNetworkAdapterRequest{
+						ID:           d.Id(),
+						NewNetworkId: fresh.Network.ID,
+						AutoConnect:  d.Get("auto_connect").(bool),
+						MacAddress:   fresh.MacAddress,
+						IPAddress:    ip,
+					})
+					if err != nil {
+						return diag.Errorf("the VPC static IP of network adapter %s could not be set: %s", d.Id(), err)
+					}
+					if _, err := c.Activity().WaitForCompletion(ctx, relocateActivity, getWaiterOptions(ctx)); err != nil {
+						return diag.Errorf("the VPC static IP of network adapter %s could not be set: %s", d.Id(), err)
+					}
+				}
+			}
+		}
+	}
+
 	return computeNetworkAdapterRead(ctx, d, meta)
 }
 
@@ -203,4 +290,60 @@ func computeNetworkAdapterDelete(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("failed to delete network adapter, %s", err)
 	}
 	return nil
+}
+
+// ensureVMwareVPCForIPAddress fails closed BEFORE any side effect when ip_address
+// is explicitly configured but the target network_id is not a VPC-backed network.
+// ip_address only has meaning on a VPC network (it assigns the adapter's static IP
+// there); on a plain vCenter portgroup the platform ignores it, so the value could
+// never be applied nor recorded and the plan would never converge. (Mirrors the
+// OpenIaaS ensureVPCForIPAddress (#374); to be unified once both land.)
+func ensureVMwareVPCForIPAddress(ctx context.Context, c *client.Client, d *schema.ResourceData) diag.Diagnostics {
+	raw := d.GetRawConfig()
+	if raw.IsNull() {
+		return nil
+	}
+	if v := raw.GetAttr("ip_address"); v.IsNull() {
+		return nil
+	}
+	ip := d.Get("ip_address").(string)
+	if ip == "" {
+		return nil
+	}
+	networkID := d.Get("network_id").(string)
+	network, err := c.Compute().Network().Read(ctx, networkID)
+	if err != nil {
+		return diag.Errorf("failed to read network %s to validate ip_address: %s", networkID, err)
+	}
+	if network == nil {
+		return diag.Errorf("network %s not found while validating ip_address", networkID)
+	}
+	if network.VPC == nil {
+		return diag.Errorf("ip_address %q is set but network %s is not a VPC-backed network: ip_address requires network_id to reference a VPC private network — remove ip_address or use a VPC network", ip, networkID)
+	}
+	return nil
+}
+
+// vmwareVPCStaticIPToPush mirrors the OpenIaaS vpcStaticIPToPush (#374): returns the
+// VPC static IP to push, or "" to leave it untouched — push ONLY when ip_address is
+// configured, non-empty, on a VPC network, and diverges from the live address
+// (re-sending an unchanged address would relocate the static IP to itself).
+func vmwareVPCStaticIPToPush(ipConfigured bool, configuredIP, liveIP string, onVPC bool) string {
+	if !ipConfigured || configuredIP == "" || !onVPC {
+		return ""
+	}
+	if configuredIP == liveIP {
+		return ""
+	}
+	return configuredIP
+}
+
+// vmwareAdapterVPCStaticIP mirrors the OpenIaaS adapterVPCStaticIP (#374): maps a
+// by-MAC static IP read to the ip_address state value (empty off a VPC, or when no
+// static IP is registered yet — including the 403/absent the client maps to nil).
+func vmwareAdapterVPCStaticIP(onVPC bool, sip *client.StaticIP) string {
+	if !onVPC || sip == nil {
+		return ""
+	}
+	return sip.IPAddress
 }

--- a/internal/provider/resource_compute_network_adapter_unit_test.go
+++ b/internal/provider/resource_compute_network_adapter_unit_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestVMwareVPCStaticIPToPush pins the VMware update decision for the VPC static
+// IP (ip_address, #375): never push when unconfigured/empty/off-VPC, never
+// re-push an unchanged address (it would relocate the static IP to itself on
+// every apply), push on a genuine divergence or a first set.
+func TestVMwareVPCStaticIPToPush(t *testing.T) {
+	cases := []struct {
+		name                 string
+		ipConfigured         bool
+		configuredIP, liveIP string
+		onVPC                bool
+		want                 string
+	}{
+		{"not configured -> never push", false, "", "", true, ""},
+		{"configured but empty -> never push", true, "", "", true, ""},
+		{"configured non-empty but not on a VPC network -> never push", true, "10.0.2.10", "", false, ""},
+		{"configured, on VPC, no live IP yet -> push (first set)", true, "10.0.2.10", "", true, "10.0.2.10"},
+		{"configured equals live -> no redundant relocate-to-self", true, "10.0.2.10", "10.0.2.10", true, ""},
+		{"configured diverges from live -> relocate", true, "10.0.2.11", "10.0.2.10", true, "10.0.2.11"},
+		{"stale configured value with ipConfigured=false (field cleared) -> never push", false, "10.0.2.11", "10.0.2.10", true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := vmwareVPCStaticIPToPush(c.ipConfigured, c.configuredIP, c.liveIP, c.onVPC); got != c.want {
+				t.Fatalf("vmwareVPCStaticIPToPush(%v,%q,%q,%v) = %q, want %q", c.ipConfigured, c.configuredIP, c.liveIP, c.onVPC, got, c.want)
+			}
+		})
+	}
+}
+
+// TestVMwareAdapterVPCStaticIP pins the read mapping for ip_address (#375): a
+// non-VPC adapter and a VPC adapter without a registered static IP both yield
+// empty; a VPC adapter reflects the by-MAC static IP address.
+func TestVMwareAdapterVPCStaticIP(t *testing.T) {
+	if got := vmwareAdapterVPCStaticIP(false, &client.StaticIP{IPAddress: "1.2.3.4"}); got != "" {
+		t.Fatalf("a non-VPC adapter has no static IP; want empty, got %q", got)
+	}
+	if got := vmwareAdapterVPCStaticIP(true, nil); got != "" {
+		t.Fatalf("a VPC adapter with no registered static IP (nil) must yield empty, got %q", got)
+	}
+	if got := vmwareAdapterVPCStaticIP(true, &client.StaticIP{IPAddress: "10.0.2.10"}); got != "10.0.2.10" {
+		t.Fatalf("a VPC adapter must reflect the by-MAC static IP; want 10.0.2.10, got %q", got)
+	}
+}

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -683,6 +683,13 @@
           "optional": true,
           "elem_kind": "nil"
         },
+        "ip_address": {
+          "type": "TypeString",
+          "optional": true,
+          "computed": true,
+          "has_validate_func": true,
+          "elem_kind": "nil"
+        },
         "mac_address": {
           "type": "TypeString",
           "optional": true,


### PR DESCRIPTION
Refs #375

Adds `ip_address` to `cloudtemple_compute_network_adapter` (VMware) so a VM network adapter can be attached to a VPC private network with a controlled static IP (compute API `feat(#1854)`, `source=vmware`). VMware counterpart of #374; closes the VMware side of the #238 "VPC ↔ VM association" goal — which had never been validated live until now.

## What

- **client**: `IPAddress` on the create/update requests; `VPC` on the `Network` and `NetworkAdapter` models (detect a VPC-backed network up front; the assigned IP is not echoed on the adapter and is resolved by MAC).
- **resource** `cloudtemple_compute_network_adapter`: `ip_address` (Optional+Computed, IPv4, mutable — relocation is in-place). Create plumbs it; the VPC static IP is reconciled **after** the network/mac patch against a fresh read, resolved **by MAC**, and the reconciliation **also triggers on a `mac_address` change** (the static IP is keyed by MAC); Read converges `ip_address` by MAC, fail-closed; `ip_address` on a non-VPC network is **rejected before any side effect**. `vpc_read` added to the resource's documented roles (it now reads the VPC static-IP API).
- non-complacent unit tests; docs, additive golden snapshot, CHANGELOG.

## Validation

- `gofmt`, `go vet`, coverage ratchet (above floors), `go generate` deterministic — all green.
- Codex adversarial review: 3 rounds, 3 P2 findings fixed (same-apply move onto VPC, stale-IP-on-retry, mac-keyed reconciliation + `vpc_read`), final review clean.
- **End-to-end live** on a VPC-enabled vCenter tenant (`fsn-02` / `fsn-02-pn-01`): create lands the chosen IP (`source=vmware`), the plan converges, relocation is in-place, destroy releases the static IP (0 orphan).

Per the RC flow this targets `rc/v1.9.0` and uses `Refs #375`; the `Closes #375` keyword is carried by the `rc/v1.9.0 → main` PR.

Note: two of the findings above also apply to #374 (PR #377) and are being ported there.
