### PR TITLE
fix(#382): guard datasource reads against nil to avoid a provider panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ ENHANCEMENTS :
   * Added `ip_address` to resource `cloudtemple_compute_iaas_opensource_network_adapter`. When the adapter's `network_id` is a VPC-backed network, this assigns the adapter's VPC static IP to a chosen address (and relocates it in place on change); if omitted the platform auto-assigns one. The assigned address is read back into the state — resolved by MAC, as the platform does not echo it on the adapter object — so the plan converges, and destroying the adapter releases the static IP. Setting it while `network_id` is not VPC-backed is rejected.
   * Added `ip_address` to resource `cloudtemple_compute_network_adapter` (VMware). When the adapter's `network_id` is a VPC-backed network, this assigns the adapter's VPC static IP to a chosen address (and relocates it in place on change); if omitted the platform auto-assigns one. The assigned address is read back into the state — resolved by MAC, as the platform does not echo it on the adapter object — so the plan converges, and destroying the adapter releases the static IP. Setting it while `network_id` is not VPC-backed is rejected.
 
+BUG FIXES :
+
+  * Fixed a possible provider crash (nil-pointer panic) when reading the `cloudtemple_object_storage_bucket`, `cloudtemple_object_storage_storage_account` or `cloudtemple_backup_metrics` datasource for a target that does not exist or that the token is not allowed to read. The underlying client maps such an HTTP 404/403 response to an empty result, which the datasources dereferenced without a guard; they now return an actionable error instead of panicking.
+
 # 1.8.0 (Unreleased)
 
 SECURITY :

--- a/internal/provider/data_source_backup_metrics.go
+++ b/internal/provider/data_source_backup_metrics.go
@@ -235,6 +235,13 @@ func backupMetricsRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	// History maps an HTTP 404/403 to a (nil, nil) result (requireNotFoundOrOK).
+	// A nil here means the metrics are unavailable (absent or access denied), so
+	// fail with an actionable diagnostic instead of dereferencing nil in
+	// FlattenBackupMetricsHistory below (#382).
+	if history == nil {
+		return diag.Errorf("backup metrics history is unavailable (the API returned no content; the token may lack the required backup permission)")
+	}
 	platform, err := c.Backup().Metrics().Platform(ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -242,6 +249,11 @@ func backupMetricsRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	platformCPU, err := c.Backup().Metrics().PlatformCPU(ctx)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	// Same (nil, nil)-on-404/403 contract as History above: guard before
+	// FlattenBackupMetricsPlatformCPU dereferences it (#382).
+	if platformCPU == nil {
+		return diag.Errorf("backup metrics platform CPU is unavailable (the API returned no content; the token may lack the required backup permission)")
 	}
 	policies, err := c.Backup().Metrics().Policies(ctx)
 	if err != nil {

--- a/internal/provider/data_source_object_storage_bucket.go
+++ b/internal/provider/data_source_object_storage_bucket.go
@@ -110,6 +110,12 @@ func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading bucket with name %s: %s", bucketName, err))
 	}
+	// Read maps an HTTP 404/403 to a (nil, nil) result (requireNotFoundOrOK), so
+	// a nil bucket means it does not exist or access is denied. Fail with an
+	// actionable diagnostic instead of dereferencing nil at d.SetId below (#382).
+	if bucket == nil {
+		return diag.Errorf("object storage bucket %q could not be read (it does not exist or access is denied)", bucketName)
+	}
 
 	// Définir l'ID de la datasource
 	d.SetId(bucket.ID)

--- a/internal/provider/data_source_object_storage_storage_account.go
+++ b/internal/provider/data_source_object_storage_storage_account.go
@@ -84,6 +84,12 @@ func dataSourceStorageAccountRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading storage account with name %s: %s", accountName, err))
 	}
+	// Read maps an HTTP 404/403 to a (nil, nil) result (requireNotFoundOrOK), so
+	// a nil account means it does not exist or access is denied. Fail with an
+	// actionable diagnostic instead of dereferencing nil at d.SetId below (#382).
+	if account == nil {
+		return diag.Errorf("object storage storage account %q could not be read (it does not exist or access is denied)", accountName)
+	}
 
 	// Définir l'ID de la datasource
 	d.SetId(account.ID)

--- a/internal/provider/datasource_nil_read_unit_test.go
+++ b/internal/provider/datasource_nil_read_unit_test.go
@@ -66,7 +66,7 @@ func TestDataSourceStorageAccountReadNilDoesNotPanic(t *testing.T) {
 func TestDataSourceBucketReadSuccess(t *testing.T) {
 	c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id":"bucket-123","name":"my-bucket"}`))
+		_, _ = w.Write([]byte(`{"id":"bucket-123","name":"my-bucket","endpoint":"https://s3.example"}`))
 	})
 	d := dataSourceBucket().TestResourceData()
 	_ = d.Set("name", "my-bucket")
@@ -78,12 +78,17 @@ func TestDataSourceBucketReadSuccess(t *testing.T) {
 	if d.Id() != "bucket-123" {
 		t.Fatalf("expected id %q, got %q", "bucket-123", d.Id())
 	}
+	// A computed field (not the input "name") must be flattened from the response,
+	// proving the success read populates state, not just the id.
+	if got := d.Get("endpoint").(string); got != "https://s3.example" {
+		t.Fatalf("expected endpoint flattened from the response, got %q", got)
+	}
 }
 
 func TestDataSourceStorageAccountReadSuccess(t *testing.T) {
 	c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id":"acc-1","name":"my-account"}`))
+		_, _ = w.Write([]byte(`{"id":"acc-1","name":"my-account","arn":"arn:ct:acc-1"}`))
 	})
 	d := dataSourceStorageAccount().TestResourceData()
 	_ = d.Set("name", "my-account")
@@ -94,6 +99,10 @@ func TestDataSourceStorageAccountReadSuccess(t *testing.T) {
 	}
 	if d.Id() != "acc-1" {
 		t.Fatalf("expected id %q, got %q", "acc-1", d.Id())
+	}
+	// A computed field (not the input "name") must be flattened from the response.
+	if got := d.Get("arn").(string); got != "arn:ct:acc-1" {
+		t.Fatalf("expected arn flattened from the response, got %q", got)
 	}
 }
 

--- a/internal/provider/datasource_nil_read_unit_test.go
+++ b/internal/provider/datasource_nil_read_unit_test.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// These unit tests pin the #382 fix: a datasource read whose client method maps
+// an HTTP 404/403 to a (nil, nil) result must surface an actionable diagnostic,
+// never a nil-pointer panic. Each test drives the real datasource read function
+// against a stub HTTP server (newAssignTestClient) and asserts a clean error.
+//
+// Mutation proof: removing the corresponding `if x == nil` guard makes the test
+// go RED via a nil-pointer dereference (d.SetId / Flatten* on a nil pointer).
+
+// TestDataSourceBucketReadNilDoesNotPanic: a 404 (absent) or 403 (forbidden) read
+// of a bucket by name must return a diagnostic, not panic at d.SetId(bucket.ID).
+func TestDataSourceBucketReadNilDoesNotPanic(t *testing.T) {
+	for _, code := range []int{http.StatusNotFound, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			})
+			d := dataSourceBucket().TestResourceData()
+			_ = d.Set("name", "missing-bucket")
+
+			diags := dataSourceBucketRead(context.Background(), d, c)
+			if !diags.HasError() {
+				t.Fatalf("a %d bucket read must return an error diagnostic, got none", code)
+			}
+			diagsContain(t, diags, "could not be read")
+		})
+	}
+}
+
+// TestDataSourceStorageAccountReadNilDoesNotPanic: same contract for the storage
+// account datasource (d.SetId(account.ID)).
+func TestDataSourceStorageAccountReadNilDoesNotPanic(t *testing.T) {
+	for _, code := range []int{http.StatusNotFound, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			})
+			d := dataSourceStorageAccount().TestResourceData()
+			_ = d.Set("name", "missing-account")
+
+			diags := dataSourceStorageAccountRead(context.Background(), d, c)
+			if !diags.HasError() {
+				t.Fatalf("a %d storage account read must return an error diagnostic, got none", code)
+			}
+			diagsContain(t, diags, "could not be read")
+		})
+	}
+}
+
+// backupMetricsHandler serves a valid 200 body for every backup-metrics endpoint
+// EXCEPT the one whose path is in `down`, which returns `downCode`. Returning a
+// valid 200 for every other endpoint is what makes the mutation proof real: if a
+// guard is removed, the read must reach the Flatten*(nil) call rather than
+// failing early on an unrelated read (the read order is Coverage, History,
+// Platform, PlatformCPU, Policies, VirtualMachines).
+func backupMetricsHandler(t *testing.T, downPath string, downCode int) http.HandlerFunc {
+	t.Helper()
+	// "{}" decodes into the metric structs (zero values, non-nil pointer); the
+	// policies endpoint returns a JSON array.
+	bodies := map[string]string{
+		"/backup/v1/spp/metrics/coverage":       "{}",
+		"/backup/v1/spp/metrics/backup/history": "{}",
+		"/backup/v1/spp/metrics/plateform":      "{}",
+		"/backup/v1/spp/metrics/plateform/cpu":  "{}",
+		"/backup/v1/spp/metrics/policies":       "[]",
+		"/backup/v1/spp/metrics/vm":             "{}",
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if p == downPath {
+			w.WriteHeader(downCode)
+			return
+		}
+		body, ok := bodies[p]
+		if !ok {
+			t.Errorf("unexpected backup-metrics request path: %s", p)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// TestBackupMetricsReadNilHistoryDoesNotPanic: the History endpoint returns 404
+// (mapped to (nil,nil)) while every other endpoint returns a valid 200. The read
+// must surface a diagnostic instead of panicking in FlattenBackupMetricsHistory.
+func TestBackupMetricsReadNilHistoryDoesNotPanic(t *testing.T) {
+	c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/backup/history", http.StatusNotFound))
+	d := dataSourceBackupMetrics().TestResourceData()
+	_ = d.Set("range", 7)
+
+	diags := backupMetricsRead(context.Background(), d, c)
+	if !diags.HasError() {
+		t.Fatal("a nil history read must return an error diagnostic, got none")
+	}
+	diagsContain(t, diags, "history is unavailable")
+}
+
+// TestBackupMetricsReadNilPlatformCPUDoesNotPanic: the PlatformCPU endpoint
+// returns 403 (mapped to (nil,nil)) while every other endpoint returns a valid
+// 200. The read must surface a diagnostic instead of panicking in
+// FlattenBackupMetricsPlatformCPU.
+func TestBackupMetricsReadNilPlatformCPUDoesNotPanic(t *testing.T) {
+	c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/plateform/cpu", http.StatusForbidden))
+	d := dataSourceBackupMetrics().TestResourceData()
+	_ = d.Set("range", 7)
+
+	diags := backupMetricsRead(context.Background(), d, c)
+	if !diags.HasError() {
+		t.Fatal("a nil platform CPU read must return an error diagnostic, got none")
+	}
+	diagsContain(t, diags, "platform CPU is unavailable")
+}

--- a/internal/provider/datasource_nil_read_unit_test.go
+++ b/internal/provider/datasource_nil_read_unit_test.go
@@ -9,16 +9,24 @@ import (
 
 // These unit tests pin the #382 fix: a datasource read whose client method maps
 // an HTTP 404/403 to a (nil, nil) result must surface an actionable diagnostic,
-// never a nil-pointer panic. Each test drives the real datasource read function
-// against a stub HTTP server (newAssignTestClient) and asserts a clean error.
+// never a nil-pointer panic — AND a normal 200 read must keep working unchanged.
 //
-// Mutation proof: removing the corresponding `if x == nil` guard makes the test
-// go RED via a nil-pointer dereference (d.SetId / Flatten* on a nil pointer).
+// Both the OLD not-found contract (absent -> 403) and the NEW one (absent -> 404)
+// reach the client helper requireNotFoundOrOK(resp, 403), which folds 404 AND 403
+// to (nil, nil); so each nil-read test is run under BOTH status codes to prove the
+// guard behaves identically before and after the API change.
+//
+// Mutation proof (recorded): removing a guard makes the matching nil-read test go
+// RED via a nil-pointer dereference (d.SetId / Flatten* on a nil pointer).
 
-// TestDataSourceBucketReadNilDoesNotPanic: a 404 (absent) or 403 (forbidden) read
-// of a bucket by name must return a diagnostic, not panic at d.SetId(bucket.ID).
+// absentCodes are the two HTTP statuses the client maps to (nil, nil): the new
+// not-found (404) and the old not-found / current forbidden (403).
+var absentCodes = []int{http.StatusNotFound, http.StatusForbidden}
+
+// --- object storage: nil read must error (both 403 and 404), never panic ---
+
 func TestDataSourceBucketReadNilDoesNotPanic(t *testing.T) {
-	for _, code := range []int{http.StatusNotFound, http.StatusForbidden} {
+	for _, code := range absentCodes {
 		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
 			c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(code)
@@ -35,10 +43,8 @@ func TestDataSourceBucketReadNilDoesNotPanic(t *testing.T) {
 	}
 }
 
-// TestDataSourceStorageAccountReadNilDoesNotPanic: same contract for the storage
-// account datasource (d.SetId(account.ID)).
 func TestDataSourceStorageAccountReadNilDoesNotPanic(t *testing.T) {
-	for _, code := range []int{http.StatusNotFound, http.StatusForbidden} {
+	for _, code := range absentCodes {
 		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
 			c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(code)
@@ -55,12 +61,48 @@ func TestDataSourceStorageAccountReadNilDoesNotPanic(t *testing.T) {
 	}
 }
 
+// --- object storage: a normal 200 read must still succeed unchanged ---
+
+func TestDataSourceBucketReadSuccess(t *testing.T) {
+	c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"bucket-123","name":"my-bucket"}`))
+	})
+	d := dataSourceBucket().TestResourceData()
+	_ = d.Set("name", "my-bucket")
+
+	diags := dataSourceBucketRead(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("a valid 200 bucket read must succeed, got: %v", diags)
+	}
+	if d.Id() != "bucket-123" {
+		t.Fatalf("expected id %q, got %q", "bucket-123", d.Id())
+	}
+}
+
+func TestDataSourceStorageAccountReadSuccess(t *testing.T) {
+	c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"acc-1","name":"my-account"}`))
+	})
+	d := dataSourceStorageAccount().TestResourceData()
+	_ = d.Set("name", "my-account")
+
+	diags := dataSourceStorageAccountRead(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("a valid 200 storage account read must succeed, got: %v", diags)
+	}
+	if d.Id() != "acc-1" {
+		t.Fatalf("expected id %q, got %q", "acc-1", d.Id())
+	}
+}
+
 // backupMetricsHandler serves a valid 200 body for every backup-metrics endpoint
-// EXCEPT the one whose path is in `down`, which returns `downCode`. Returning a
+// EXCEPT the one whose path is `downPath`, which returns `downCode`. Returning a
 // valid 200 for every other endpoint is what makes the mutation proof real: if a
-// guard is removed, the read must reach the Flatten*(nil) call rather than
-// failing early on an unrelated read (the read order is Coverage, History,
-// Platform, PlatformCPU, Policies, VirtualMachines).
+// guard is removed, the read must reach the Flatten*(nil) call rather than failing
+// early on an unrelated read (read order: Coverage, History, Platform, PlatformCPU,
+// Policies, VirtualMachines).
 func backupMetricsHandler(t *testing.T, downPath string, downCode int) http.HandlerFunc {
 	t.Helper()
 	// "{}" decodes into the metric structs (zero values, non-nil pointer); the
@@ -90,33 +132,84 @@ func backupMetricsHandler(t *testing.T, downPath string, downCode int) http.Hand
 	}
 }
 
-// TestBackupMetricsReadNilHistoryDoesNotPanic: the History endpoint returns 404
-// (mapped to (nil,nil)) while every other endpoint returns a valid 200. The read
-// must surface a diagnostic instead of panicking in FlattenBackupMetricsHistory.
-func TestBackupMetricsReadNilHistoryDoesNotPanic(t *testing.T) {
-	c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/backup/history", http.StatusNotFound))
-	d := dataSourceBackupMetrics().TestResourceData()
-	_ = d.Set("range", 7)
+// --- backup metrics: a nil History / PlatformCPU read must error (both 403 and
+// 404), never panic ---
 
-	diags := backupMetricsRead(context.Background(), d, c)
-	if !diags.HasError() {
-		t.Fatal("a nil history read must return an error diagnostic, got none")
+func TestBackupMetricsReadNilHistoryDoesNotPanic(t *testing.T) {
+	for _, code := range absentCodes {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/backup/history", code))
+			d := dataSourceBackupMetrics().TestResourceData()
+			_ = d.Set("range", 7)
+
+			diags := backupMetricsRead(context.Background(), d, c)
+			if !diags.HasError() {
+				t.Fatalf("a %d history read must return an error diagnostic, got none", code)
+			}
+			diagsContain(t, diags, "history is unavailable")
+		})
 	}
-	diagsContain(t, diags, "history is unavailable")
 }
 
-// TestBackupMetricsReadNilPlatformCPUDoesNotPanic: the PlatformCPU endpoint
-// returns 403 (mapped to (nil,nil)) while every other endpoint returns a valid
-// 200. The read must surface a diagnostic instead of panicking in
-// FlattenBackupMetricsPlatformCPU.
 func TestBackupMetricsReadNilPlatformCPUDoesNotPanic(t *testing.T) {
-	c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/plateform/cpu", http.StatusForbidden))
+	for _, code := range absentCodes {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/plateform/cpu", code))
+			d := dataSourceBackupMetrics().TestResourceData()
+			_ = d.Set("range", 7)
+
+			diags := backupMetricsRead(context.Background(), d, c)
+			if !diags.HasError() {
+				t.Fatalf("a %d platform CPU read must return an error diagnostic, got none", code)
+			}
+			diagsContain(t, diags, "platform CPU is unavailable")
+		})
+	}
+}
+
+// TestBackupMetricsReadSuccessPopulatesState proves the success path is unchanged
+// AND that a legitimate ZERO value is NOT mistaken for a nil/absent read: every
+// endpoint returns a valid 200, History carries a non-zero value (total_runs=10)
+// and PlatformCPU carries an explicit zero (cpu_util=0). The read must succeed,
+// set the id, flow the History value through, and keep the zero-valued
+// platform_cpu block (non-nil), not drop or error on it.
+func TestBackupMetricsReadSuccessPopulatesState(t *testing.T) {
+	bodies := map[string]string{
+		"/backup/v1/spp/metrics/coverage":       `{}`,
+		"/backup/v1/spp/metrics/backup/history": `{"totalRuns":10,"success":8}`,
+		"/backup/v1/spp/metrics/plateform":      `{}`,
+		"/backup/v1/spp/metrics/plateform/cpu":  `{"cpuUtil":0}`,
+		"/backup/v1/spp/metrics/policies":       `[]`,
+		"/backup/v1/spp/metrics/vm":             `{}`,
+	}
+	c := newAssignTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, ok := bodies[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected backup-metrics request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	})
 	d := dataSourceBackupMetrics().TestResourceData()
 	_ = d.Set("range", 7)
 
 	diags := backupMetricsRead(context.Background(), d, c)
-	if !diags.HasError() {
-		t.Fatal("a nil platform CPU read must return an error diagnostic, got none")
+	if diags.HasError() {
+		t.Fatalf("a full valid 200 metrics read must succeed, got: %v", diags)
 	}
-	diagsContain(t, diags, "platform CPU is unavailable")
+	if d.Id() != "job_sessions" {
+		t.Fatalf("expected id %q, got %q", "job_sessions", d.Id())
+	}
+	// The non-zero History value must flow through unchanged (the guard did not
+	// swallow real data).
+	if got := d.Get("history.0.total_runs").(int); got != 10 {
+		t.Fatalf("expected history.0.total_runs == 10, got %d", got)
+	}
+	// The zero-valued PlatformCPU is present (a valid 200 {} / cpu_util:0 decodes
+	// to a NON-nil struct, so the guard must NOT fire): the block exists.
+	if cpu, ok := d.Get("platform_cpu").([]interface{}); !ok || len(cpu) != 1 {
+		t.Fatalf("expected one platform_cpu block (zero value must not be dropped), got %v", d.Get("platform_cpu"))
+	}
 }


### PR DESCRIPTION
Refs #382

## What

Three datasource read functions dereferenced a pointer returned by a client read
method without a nil check. The client read maps an HTTP 404/403 response to a
`(nil, nil)` result via `requireNotFoundOrOK(resp, 403)`, so reading a target
that is absent — or that the token is not allowed to read — caused a nil-pointer
**panic** instead of a clean error.

Fixed sites (a nil guard returning an actionable diagnostic, before any
`d.SetId` / `Flatten*`):

- `internal/provider/data_source_object_storage_bucket.go` (`d.SetId(bucket.ID)`)
- `internal/provider/data_source_object_storage_storage_account.go` (`d.SetId(account.ID)`)
- `internal/provider/data_source_backup_metrics.go` — `History` and `PlatformCPU`
  (before `FlattenBackupMetricsHistory` / `FlattenBackupMetricsPlatformCPU`)

This is a pre-existing defect, independent of the API's `403 → 404` not-found
change (it panics identically whether the absent signal arrives as 403 or 404).
The 403/404 client-mapping alignment is tracked separately in #384. No client
status-mapping was changed here.

## Tests (mutation-proven)

New unit tests in package `provider` (`internal/provider/datasource_nil_read_unit_test.go`),
driving each real datasource read against an httptest stub:

- bucket and storage account: 404 and 403 each return a clean error (substring
  `"could not be read"`), no panic;
- metrics: the stub returns a valid 200 for every metrics endpoint except the one
  under test (404/403), so the read reaches the flatten path; asserts
  `"history is unavailable"` / `"platform CPU is unavailable"`.

Mutation proof: removing each of the four guards makes the corresponding test go
RED with `panic: runtime error: invalid memory address or nil pointer
dereference`; with the guard it is GREEN.

## Verification

- `go install` (no args) builds; `go vet ./internal/provider ./internal/client`
  clean; `gofmt -l` clean; `go test ./internal/provider ./internal/client` green.
- `staticcheck` could not be run locally (installed binary built with go1.23.2,
  module requires go1.24); enforced by CI.

## Review

Independent adversarial review by Codex (read-only): PLAN review returned NO-GO
with two required changes — both addressed here (added the third
`storage_account` site; hardened the metrics tests). Committed-diff review:
**GO for #382 as scoped**.

Per the RC flow this PR uses `Refs #382` (no closing keyword); the issue is
closed by the RC → `main` PR.
