### PR TITLE
fix(#386): guard VMware virtual_machine ops against a nil read to avoid a panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ ENHANCEMENTS :
 BUG FIXES :
 
   * Fixed a possible provider crash (nil-pointer panic) when reading the `cloudtemple_object_storage_bucket`, `cloudtemple_object_storage_storage_account` or `cloudtemple_backup_metrics` datasource for a target that does not exist or that the token is not allowed to read. The underlying client maps such an HTTP 404/403 response to an empty result, which the datasources dereferenced without a guard; they now return an actionable error instead of panicking.
+  * Fixed a possible provider crash (nil-pointer panic) on `cloudtemple_compute_virtual_machine` update and destroy when the virtual machine could not be read (it no longer exists or the token is not allowed to read it). The operation now fails closed with an actionable error instead of panicking.
 
 # 1.8.0 (Unreleased)
 

--- a/internal/provider/resource_compute_virtual_machine.go
+++ b/internal/provider/resource_compute_virtual_machine.go
@@ -1345,9 +1345,9 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 	}
 
 	if d.HasChange("customize") && !customizing {
-		vm, err := c.Compute().VirtualMachine().Read(ctx, d.Id())
-		if err != nil {
-			return diag.Errorf("failed to read virtual machine: %s", err)
+		vm, vmDiags := readVirtualMachineForOp(ctx, c, d.Id(), "update")
+		if vmDiags.HasError() {
+			return vmDiags
 		}
 		if vm.PowerState == "running" {
 			activityId, err := c.Compute().VirtualMachine().Power(ctx, &client.PowerRequest{
@@ -1554,9 +1554,9 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 	if updatePower {
 		powerState := d.Get("power_state").(string)
 
-		vm, err := c.Compute().VirtualMachine().Read(ctx, d.Id())
-		if err != nil {
-			return diag.Errorf("failed to read virtual machine: %s", err)
+		vm, vmDiags := readVirtualMachineForOp(ctx, c, d.Id(), "power")
+		if vmDiags.HasError() {
+			return vmDiags
 		}
 
 		recommendation, err := helpers.GetPowerRecommendation(vm, powerState, ctx, c)
@@ -1582,12 +1582,28 @@ func updateVirtualMachine(ctx context.Context, d *schema.ResourceData, meta any,
 	return computeVirtualMachineRead(ctx, d, meta)
 }
 
+// readVirtualMachineForOp reads a VM by id for a CRUD operation and converts an
+// absent/forbidden (nil, nil) read into an actionable diagnostic instead of a
+// nil-pointer panic (#386). VirtualMachine().Read maps HTTP 404/403 to a nil
+// read (requireNotFoundOrOK), so an operation on a VM that no longer exists or
+// that the token cannot read must fail closed here rather than dereference nil.
+func readVirtualMachineForOp(ctx context.Context, c *client.Client, id, action string) (*client.VirtualMachine, diag.Diagnostics) {
+	vm, err := c.Compute().VirtualMachine().Read(ctx, id)
+	if err != nil {
+		return nil, diag.Errorf("cannot %s virtual machine %s: %s", action, id, err)
+	}
+	if vm == nil {
+		return nil, diag.Errorf("cannot %s virtual machine %s: it could not be read (it no longer exists or your access may have changed). If it was deleted outside Terraform, remove it from the state with `terraform state rm`.", action, id)
+	}
+	return vm, nil
+}
+
 func computeVirtualMachineDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
 
-	vm, err := c.Compute().VirtualMachine().Read(ctx, d.Id())
-	if err != nil {
-		return diag.Errorf("failed to read virtual effect: %s", err)
+	vm, vmDiags := readVirtualMachineForOp(ctx, c, d.Id(), "delete")
+	if vmDiags.HasError() {
+		return vmDiags
 	}
 
 	if vm.PowerState == "running" {

--- a/internal/provider/resource_compute_virtual_machine_nil_unit_test.go
+++ b/internal/provider/resource_compute_virtual_machine_nil_unit_test.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// These unit tests pin the #386 fix: a VM CRUD operation that reads the virtual
+// machine before acting must not panic when the client read returns (nil, nil).
+// VirtualMachine().Read maps an HTTP 404 (absent) OR 403 (forbidden) to (nil,nil)
+// via requireNotFoundOrOK(resp,403); the shared readVirtualMachineForOp guard
+// converts that into an actionable diagnostic. Both status codes are exercised so
+// the guard is proven identical before and after the API's 403->404 change.
+//
+// Mutation proof: removing the `if vm == nil` line in readVirtualMachineForOp
+// makes TestReadVirtualMachineForOp's 404/403 cases return no diagnostic (RED) and
+// makes TestComputeVirtualMachineDeleteNilReadDoesNotPanic panic at vm.PowerState
+// (RED).
+
+// TestReadVirtualMachineForOp covers the shared guard used by the three VM
+// operation sites (update-customize, update-power, delete). The customize and
+// power branches are gated (d.HasChange / the updatePower parameter) behind the
+// full VM-update pipeline, so the guard logic is proven here directly rather than
+// by driving those branches end-to-end.
+func TestReadVirtualMachineForOp(t *testing.T) {
+	t.Run("404 -> diagnostic, nil vm", func(t *testing.T) {
+		c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) })
+		vm, diags := readVirtualMachineForOp(context.Background(), c, "vm-1", "delete")
+		if vm != nil {
+			t.Fatalf("expected nil vm on a 404 read, got %+v", vm)
+		}
+		if !diags.HasError() {
+			t.Fatal("expected an error diagnostic on a 404 read, got none")
+		}
+		diagsContain(t, diags, "could not be read")
+	})
+	t.Run("403 -> diagnostic, nil vm", func(t *testing.T) {
+		c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		vm, diags := readVirtualMachineForOp(context.Background(), c, "vm-1", "update")
+		if vm != nil {
+			t.Fatalf("expected nil vm on a 403 read, got %+v", vm)
+		}
+		if !diags.HasError() {
+			t.Fatal("expected an error diagnostic on a 403 read, got none")
+		}
+		diagsContain(t, diags, "could not be read")
+	})
+	t.Run("500 -> diagnostic (read error)", func(t *testing.T) {
+		c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) })
+		vm, diags := readVirtualMachineForOp(context.Background(), c, "vm-1", "power")
+		if vm != nil {
+			t.Fatalf("expected nil vm on a 500 read, got %+v", vm)
+		}
+		if !diags.HasError() {
+			t.Fatal("expected an error diagnostic on a 500 read, got none")
+		}
+	})
+	t.Run("200 -> vm, no diagnostic", func(t *testing.T) {
+		c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"vm-1"}`))
+		})
+		vm, diags := readVirtualMachineForOp(context.Background(), c, "vm-1", "update")
+		if diags.HasError() {
+			t.Fatalf("a valid 200 read must not error, got: %v", diags)
+		}
+		if vm == nil || vm.ID != "vm-1" {
+			t.Fatalf("expected a non-nil vm with id %q, got %+v", "vm-1", vm)
+		}
+	})
+}
+
+// TestComputeVirtualMachineDeleteNilReadDoesNotPanic: destroy reads the VM first
+// (unconditionally) to power it off before deleting. An absent/forbidden (nil,nil)
+// read must fail closed with a diagnostic, never panic at vm.PowerState. Fail
+// closed (not idempotent): nil is ambiguous between 404 and 403, so concluding
+// "already deleted" needs a definitive 404 — that distinction is #384.
+func TestComputeVirtualMachineDeleteNilReadDoesNotPanic(t *testing.T) {
+	for _, code := range []int{http.StatusNotFound, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			c := newAssignTestClient(t, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(code) })
+			d := resourceVirtualMachine().TestResourceData()
+			d.SetId("vm-1")
+
+			diags := computeVirtualMachineDelete(context.Background(), d, c)
+			if !diags.HasError() {
+				t.Fatalf("a %d read on delete must return a diagnostic, got none", code)
+			}
+			diagsContain(t, diags, "could not be read")
+		})
+	}
+}


### PR DESCRIPTION
Refs #386

## What

The `cloudtemple_compute_virtual_machine` resource dereferenced the result of
`Compute().VirtualMachine().Read` without a nil guard in three operation paths —
`updateVirtualMachine`'s customize branch and power branch, and Delete. The
client maps an HTTP 404 (absent) or 403 (forbidden) read to `(nil, nil)` via
`requireNotFoundOrOK(resp, 403)`, so operating on a VM that no longer exists or
that the token cannot read **panicked** (nil-pointer dereference) at
`vm.PowerState` / `vm.Datacenter.ID` / `GetPowerRecommendation(vm)`.

All three sites now go through a shared `readVirtualMachineForOp` helper that
returns an actionable diagnostic on a nil/error read instead of dereferencing
nil. Delete **fails closed** (it does not assume "already deleted" on a nil read):
the client cannot tell 404 from 403, so an idempotent-on-404 destroy needs the
client-side distinction tracked in #384. No client status mapping is changed
here, and the refresh-read path (already guarded via `confirmVMwareDeviceOrKeep`)
is untouched.

This is the same defect class as #382 (datasource nil-deref), here in the
resource operation paths.

## Scope (repo-wide sweep)

A parallel audit + adversarial-verify sweep over every provider subsystem
confirmed these are the **only** unguarded `(nil,nil)`-then-dereference sites in
the provider; 106 other dereference sites are guarded (explicit nil checks,
fail-closed helpers, ResolveByID/ResolveBinding oracles, and the #382 guards).

## Tests (mutation-proven)

New unit tests in package `provider` (httptest stub):

- `readVirtualMachineForOp` for 404, 403, 500 and a valid 200;
- `computeVirtualMachineDelete` end-to-end for 404 and 403 (clean error, no panic).

Both the old (403) and new (404) absent codes are covered. Removing the nil guard
makes the 404/403 helper cases return no diagnostic and makes the Delete test
panic at `vm.PowerState` (RED); with the guard they are GREEN.

The two update branches (customize / power) are gated (`d.HasChange` / the
`updatePower` parameter) behind the full VM-update pipeline; they call the same
helper with the same pattern, so the helper test is the practical, non-complacent
proof for them.

## Verification

`go install` (no args), `go vet`, `gofmt`, `go test ./internal/provider ./internal/client`
all green (go1.24). `staticcheck` is enforced by CI.

## Review

Independent adversarial review by Codex (read-only): PLAN review GO, committed-diff
review GO (no blocking issues).

Per the RC flow this PR uses `Refs #386` (no closing keyword).
