### PR TITLE
feat(#384): read-only absence-contract probe in ct-validate

### DIFF
--- a/cmd/ct-validate/cycle_probe_absence.go
+++ b/cmd/ct-validate/cycle_probe_absence.go
@@ -23,10 +23,13 @@ type probeAbsenceEndpoint struct {
 // UUID shape for id routes, valid object-storage names, a valid MAC for ReadByMAC,
 // and a real marketplace provider target for the /items/%s/%s/info route.
 const (
-	probeBogusID     = "00000000-0000-0000-0000-000000000000"
-	probeBogusID2    = "11111111-1111-1111-1111-111111111111"
+	// Random-looking valid UUIDs (NOT the nil/all-ones UUID: a stricter route
+	// validator may special-case those and answer 405/400 instead of running the
+	// absence lookup).
+	probeBogusID     = "7f3e9a2b-1c4d-4e5f-8a6b-9c0d1e2f3a4b"
+	probeBogusID2    = "b2c3d4e5-6f70-4a1b-9c2d-3e4f5a6b7c8d"
 	probeBogusName   = "ctvalidateprobeabsent"
-	probeBogusMAC    = "00:00:00:00:00:00"
+	probeBogusMAC    = "02:00:5e:10:00:01"
 	probeMarketplace = "vmware"
 )
 

--- a/cmd/ct-validate/cycle_probe_absence.go
+++ b/cmd/ct-validate/cycle_probe_absence.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// probeAbsenceEndpoint is one by-id / parent-scoped read endpoint to probe with a
+// deliberately-nonexistent id, to observe whether the API returns 404 (the new
+// "absent -> 404" contract — safe to flip its notFoundCode from 403 to 404) or
+// 403 (still 403-for-absent — do NOT flip). See issue #384.
+type probeAbsenceEndpoint struct {
+	name string        // stable report label, e.g. "compute.vmware.virtual_machine"
+	path string        // newRequest path template, with one %s per bogus arg
+	args []interface{} // bogus, well-formed-but-nonexistent argument(s)
+}
+
+// Well-formed but nonexistent identifiers. They must be syntactically VALID so the
+// API performs an absence lookup (404/403) rather than route/format validation
+// (which could answer 400 and tell us nothing about the absence contract): a valid
+// UUID shape for id routes, valid object-storage names, a valid MAC for ReadByMAC,
+// and a real marketplace provider target for the /items/%s/%s/info route.
+const (
+	probeBogusID     = "00000000-0000-0000-0000-000000000000"
+	probeBogusID2    = "11111111-1111-1111-1111-111111111111"
+	probeBogusName   = "ctvalidateprobeabsent"
+	probeBogusMAC    = "00:00:00:00:00:00"
+	probeMarketplace = "vmware"
+)
+
+// absenceProbeEndpoints is every by-id / parent-scoped read that currently uses
+// requireNotFoundOrOK(resp, 403) (i.e. its GET path contains a %s). The exact
+// coverage test (cycle_probe_absence_test.go) asserts this set matches a scan of
+// the client package, so a new such endpoint cannot be added without a probe
+// entry. Collection/aggregate endpoints (no %s) are intentionally excluded: a list
+// has no "absent id" — a 403 there is a forbidden, not a missing resource — so
+// #384 treats those as inherently safe to flip without a probe.
+var absenceProbeEndpoints = []probeAbsenceEndpoint{
+	// VMware compute
+	{"compute.vmware.content_library", "/compute/v1/vcenters/content_libraries/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.content_library.items", "/compute/v1/vcenters/content_libraries/%s/items", []interface{}{probeBogusID}},
+	{"compute.vmware.content_library.item", "/compute/v1/vcenters/content_libraries/%s/items/%s", []interface{}{probeBogusID, probeBogusID2}},
+	{"compute.vmware.datastore", "/compute/v1/vcenters/datastores/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.datastore_cluster", "/compute/v1/vcenters/datastore_clusters/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.folder", "/compute/v1/vcenters/folders/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.host", "/compute/v1/vcenters/hosts/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.host_cluster", "/compute/v1/vcenters/host_clusters/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.network", "/compute/v1/vcenters/networks/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.network_adapter", "/compute/v1/vcenters/network_adapters/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.resource_pool", "/compute/v1/vcenters/resource_pools/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.virtual_controller", "/compute/v1/vcenters/virtual_controllers/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.virtual_datacenter", "/compute/v1/vcenters/virtual_datacenters/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.virtual_disk", "/compute/v1/vcenters/virtual_disks/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.virtual_machine", "/compute/v1/vcenters/virtual_machines/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.virtual_switch", "/compute/v1/vcenters/virtual_switchs/%s", []interface{}{probeBogusID}},
+	{"compute.vmware.worker", "/compute/v1/vcenters/%s", []interface{}{probeBogusID}},
+
+	// OpenIaaS compute
+	{"compute.openiaas.host", "/compute/v1/open_iaas/hosts/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.machine_manager", "/compute/v1/open_iaas/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.network", "/compute/v1/open_iaas/networks/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.network_adapter", "/compute/v1/open_iaas/network_adapters/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.pool", "/compute/v1/open_iaas/pools/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.replication_policy", "/compute/v1/open_iaas/replication/configurations/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.replication_virtual_machine", "/compute/v1/open_iaas/replication/virtual_machines/%s/configurations", []interface{}{probeBogusID}},
+	{"compute.openiaas.snapshot", "/compute/v1/open_iaas/snapshots/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.storage_repository", "/compute/v1/open_iaas/storage_repositories/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.template", "/compute/v1/open_iaas/templates/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.virtual_disk", "/compute/v1/open_iaas/virtual_disks/%s", []interface{}{probeBogusID}},
+	{"compute.openiaas.virtual_machine", "/compute/v1/open_iaas/virtual_machines/%s", []interface{}{probeBogusID}},
+
+	// Backup
+	{"backup.sla_policy", "/backup/v1/spp/policies/%s", []interface{}{probeBogusID}},
+	{"backup.spp_server", "/backup/v1/spp/servers/%s", []interface{}{probeBogusID}},
+	{"backup.openiaas.backup", "/backup/v1/open_iaas/backups/%s", []interface{}{probeBogusID}},
+	{"backup.openiaas.policy", "/backup/v1/open_iaas/policies/%s", []interface{}{probeBogusID}},
+
+	// Object storage
+	{"object_storage.bucket", "/storage/object/v1/buckets/%s", []interface{}{probeBogusName}},
+	{"object_storage.storage_account", "/storage/object/v1/storage_accounts/%s", []interface{}{probeBogusName}},
+
+	// Marketplace
+	{"marketplace.item", "/marketplace/v1/items/%s", []interface{}{probeBogusID}},
+	{"marketplace.item.info", "/marketplace/v1/items/%s/%s/info", []interface{}{probeBogusID, probeMarketplace}},
+
+	// VPC (404 already proven on dev 2026-06-26; included to RE-CONFIRM on the
+	// actual recette tenant).
+	{"vpc.floating_ip", "/vpc/v1/floating_ips/%s", []interface{}{probeBogusID}},
+	{"vpc.private_network", "/vpc/v1/private_networks/%s", []interface{}{probeBogusID}},
+	{"vpc.static_ip", "/vpc/v1/static_ips/%s", []interface{}{probeBogusID}},
+	{"vpc.static_ip.by_mac", "/vpc/v1/static_ips/mac/%s", []interface{}{probeBogusMAC}},
+	{"vpc.vpc", "/vpc/v1/vpc/%s", []interface{}{probeBogusID}},
+}
+
+// probeAbsenceCycle is a READ-ONLY diagnostic that GETs every by-id read endpoint
+// with a deliberately-nonexistent id and records the observed HTTP status, to map
+// — per endpoint, on a real tenant — whether the "absent -> 404" contract is
+// deployed (#384). It is QUARANTINED (opt-in: it runs only when named explicitly
+// via `-cycles probe_absence`, never under `-cycles all`), because it deliberately
+// hits bogus ids and is a diagnostic, not a normal validation sweep.
+//
+// OPERATIONAL CAVEAT: a 403 is an unambiguous "NOT migrated" signal only when the
+// probe token HAS read permission on that resource type. With an under-privileged
+// token a 403 could be a genuine permission denial. Run with a broadly
+// read-entitled recette token, and prefer `-runs 1 -concurrency 1` so a distressed
+// endpoint does not exhaust the read-retry budget before the breaker reacts.
+type probeAbsenceCycle struct{}
+
+func (probeAbsenceCycle) Name() string { return "probe_absence" }
+func (probeAbsenceCycle) Kind() Kind   { return KindRead }
+
+// Quarantined keeps the bogus-id probe out of the `-cycles all` sweep; it runs
+// only when named explicitly.
+func (probeAbsenceCycle) Quarantined() bool { return true }
+
+func (pc probeAbsenceCycle) Run(ctx context.Context, c *client.Client, r *Run) error {
+	for _, ep := range absenceProbeEndpoints {
+		ep := ep
+		_ = r.op(pc, "probe."+ep.name, func() error {
+			status, err := c.ProbeStatus(ctx, ep.path, ep.args...)
+			if err != nil {
+				// Transport / auth / request failure before a status: surface it
+				// (categorize treats it as distress, which fails safe).
+				return err
+			}
+			return probeAbsenceOutcome(status)
+		})
+	}
+	return nil
+}
+
+// probeAbsenceOutcome maps an observed HTTP status to the value r.op records:
+//   - 404            -> nil (OK): the desired "migrated" outcome (safe to flip).
+//   - 429 / 5xx      -> a distress StatusError so the breaker trips on real API
+//     distress and stops the sweep (same safety as every other cycle).
+//   - everything else (403 "not migrated", or any other deterministic non-404) ->
+//     a 4xx-categorised StatusError that NEVER trips the breaker, carrying the REAL
+//     status in its body so the report shows it without masking the rest of the
+//     map. A 2xx/3xx on a bogus id is an anomaly: it is surfaced via the body but
+//     clamped to a 4xx code so it stays non-distress.
+func probeAbsenceOutcome(status int) error {
+	switch {
+	case status == 404:
+		return nil
+	case status == 429 || (status >= 500 && status <= 599):
+		return client.StatusError{Code: status, Body: fmt.Sprintf("absence probe: HTTP %d", status)}
+	default:
+		code := status
+		if code < 400 || code > 499 {
+			// Anomalous non-4xx (e.g. a 200/3xx on a bogus id): keep it non-distress
+			// (HTTP4xx) so it does not trip the breaker; the real status is in the body.
+			code = 400
+		}
+		return client.StatusError{Code: code, Body: fmt.Sprintf("absence probe: HTTP %d (expected 404)", status)}
+	}
+}

--- a/cmd/ct-validate/cycle_probe_absence_test.go
+++ b/cmd/ct-validate/cycle_probe_absence_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestProbeAbsenceOutcome pins the status -> recorded-outcome mapping: 404 is the
+// migrated success; 403 and other deterministic non-404 statuses are 4xx failures
+// that NEVER trip the breaker; only genuine distress (5xx/429) trips it. A 2xx/3xx
+// on a bogus id is clamped to a non-distress 4xx (its real status kept in Detail).
+//
+// Mutation proof: make 404 return an error, or stop clamping the 2xx/3xx anomaly
+// (so it falls to CategoryOther -> distress), or make 403 distress, and a row here
+// goes RED.
+func TestProbeAbsenceOutcome(t *testing.T) {
+	cases := []struct {
+		status       int
+		wantCat      Category
+		wantDistress bool
+	}{
+		{404, CategoryOK, false},         // migrated
+		{403, CategoryHTTP4xx, false},    // NOT migrated (or no permission)
+		{409, CategoryHTTP4xx, false},    // other deterministic 4xx
+		{200, CategoryHTTP4xx, false},    // anomaly, clamped non-distress
+		{301, CategoryHTTP4xx, false},    // anomaly, clamped non-distress
+		{500, CategoryHTTP5xx, true},     // distress
+		{503, CategoryHTTP5xx, true},     // distress
+		{429, CategoryRateLimited, true}, // distress (back off)
+	}
+	for _, tc := range cases {
+		err := probeAbsenceOutcome(tc.status)
+		cat := categorize(err)
+		if cat != tc.wantCat {
+			t.Errorf("status %d: category = %s, want %s", tc.status, cat, tc.wantCat)
+		}
+		if cat.isDistress() != tc.wantDistress {
+			t.Errorf("status %d: distress = %v, want %v", tc.status, cat.isDistress(), tc.wantDistress)
+		}
+		if tc.status != 404 && !strings.Contains(err.Error(), "absence probe") {
+			t.Errorf("status %d: error should mention the absence probe, got %q", tc.status, err.Error())
+		}
+	}
+}
+
+// TestProbeAbsenceCycleRecords drives the cycle against a stub returning a fixed
+// status for every endpoint, and asserts the recording and breaker behavior.
+func TestProbeAbsenceCycleRecords(t *testing.T) {
+	t.Run("all 404 -> every probe OK", func(t *testing.T) {
+		c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		r := &Run{Recorder: NewRecorder(), Breaker: NewBreaker(1000, 0.99, 1000), Cleanup: NewCleanup()}
+		_ = probeAbsenceCycle{}.Run(context.Background(), c, r)
+
+		ops := r.Recorder.Ops()
+		if len(ops) != len(absenceProbeEndpoints) {
+			t.Fatalf("expected %d recorded ops, got %d", len(absenceProbeEndpoints), len(ops))
+		}
+		for _, o := range ops {
+			if !o.OK || o.Category != CategoryOK {
+				t.Errorf("%s: a 404 must record OK (migrated), got %+v", o.Endpoint, o)
+			}
+		}
+	})
+
+	t.Run("all 403 -> 4xx not-migrated, breaker never trips", func(t *testing.T) {
+		c := newReadonlyTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		b := NewBreaker(1000, 0.99, 1000)
+		r := &Run{Recorder: NewRecorder(), Breaker: b, Cleanup: NewCleanup()}
+		_ = probeAbsenceCycle{}.Run(context.Background(), c, r)
+
+		for _, o := range r.Recorder.Ops() {
+			if o.OK || o.Category != CategoryHTTP4xx {
+				t.Errorf("%s: a 403 must record a 4xx not-migrated failure, got %+v", o.Endpoint, o)
+			}
+			if !strings.Contains(o.Detail, "403") {
+				t.Errorf("%s: detail must surface HTTP 403, got %q", o.Endpoint, o.Detail)
+			}
+		}
+		if !b.Allow() {
+			t.Fatal("the breaker must NOT trip on deterministic 403s (not distress)")
+		}
+	})
+}
+
+// TestProbeAbsenceRegistryCoverage is the anti-drift guard: it scans the client
+// package for every requireNotFoundOrOK(resp, 403) read whose GET path contains a
+// %s, and asserts the probe registry covers EXACTLY that set — so a newly added
+// by-id read with the old 403 contract cannot ship without a probe entry, and a
+// stale entry cannot linger.
+func TestProbeAbsenceRegistryCoverage(t *testing.T) {
+	expected := scanClient403PathsWithArg(t)
+
+	got := map[string]bool{}
+	for _, ep := range absenceProbeEndpoints {
+		if got[ep.path] {
+			t.Errorf("duplicate registry entry for path %s", ep.path)
+		}
+		got[ep.path] = true
+	}
+
+	for p := range expected {
+		if !got[p] {
+			t.Errorf("MISSING probe entry: client has a requireNotFoundOrOK(resp,403) read on %q with no absenceProbeEndpoints entry", p)
+		}
+	}
+	for p := range got {
+		if !expected[p] {
+			t.Errorf("STALE probe entry: absenceProbeEndpoints has %q but no client requireNotFoundOrOK(resp,403) read uses it", p)
+		}
+	}
+}
+
+// scanClient403PathsWithArg returns the set of GET path templates (containing a
+// %s) that are read by a method using requireNotFoundOrOK(resp, 403). It mirrors,
+// in the test, the inventory the probe registry must match. Within a method the
+// GET newRequest always precedes its requireNotFoundOrOK, so tracking the most
+// recent GET path correctly attributes it.
+func scanClient403PathsWithArg(t *testing.T) map[string]bool {
+	t.Helper()
+	dir := filepath.Join("..", "..", "internal", "client")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read client dir %s: %v", dir, err)
+	}
+	getRe := regexp.MustCompile(`newRequest\("GET",\s*"([^"]+)"`)
+	nfRe := regexp.MustCompile(`requireNotFoundOrOK\(resp,\s*403\)`)
+
+	out := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+		curPath := ""
+		for sc.Scan() {
+			line := sc.Text()
+			if m := getRe.FindStringSubmatch(line); m != nil {
+				curPath = m[1]
+			}
+			if nfRe.MatchString(line) && strings.Contains(curPath, "%s") {
+				out[curPath] = true
+			}
+		}
+		_ = f.Close()
+	}
+	if len(out) == 0 {
+		t.Fatal("scan found no requireNotFoundOrOK(resp,403) by-id paths — the scanner or the client layout changed")
+	}
+	return out
+}
+
+// TestProbeAbsenceQuarantinedButRunnable pins that the probe cycle is registered,
+// EXCLUDED from the `all` sweep (quarantined: it hits bogus ids), and runnable
+// when named explicitly. It is KindRead, so it is not write-gated.
+func TestProbeAbsenceQuarantinedButRunnable(t *testing.T) {
+	reg := buildRegistry()
+
+	registered := false
+	for _, n := range reg.Names() {
+		if n == "probe_absence" {
+			registered = true
+		}
+	}
+	if !registered {
+		t.Fatal("probe_absence must be registered in buildRegistry()")
+	}
+
+	all, _, err := reg.Select("all", true)
+	if err != nil {
+		t.Fatalf("Select(all): %v", err)
+	}
+	for _, c := range all {
+		if c.Name() == "probe_absence" {
+			t.Fatal("probe_absence must be EXCLUDED from `all` (quarantined diagnostic)")
+		}
+	}
+
+	sel, _, err := reg.Select("probe_absence", false)
+	if err != nil {
+		t.Fatalf("Select(probe_absence): %v", err)
+	}
+	if len(sel) != 1 || sel[0].Name() != "probe_absence" {
+		t.Fatalf("probe_absence must run when named explicitly (KindRead, not write-gated), got %+v", sel)
+	}
+}

--- a/cmd/ct-validate/main.go
+++ b/cmd/ct-validate/main.go
@@ -42,6 +42,7 @@ func buildRegistry() *Registry {
 		vpcCycle{},
 		objectStorageCycle{},
 		iamPATCycle{},
+		probeAbsenceCycle{},
 	)
 }
 

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -601,6 +601,24 @@ func requireNotFoundOrOK(resp *http.Response, notFoundCode int) (bool, error) {
 	}
 }
 
+// ProbeStatus issues a GET to path (with args) using the client's auth and base
+// URL and returns the RAW HTTP status code, WITHOUT the not-found/forbidden
+// folding that requireNotFoundOrOK applies in the resource read methods (which
+// collapse both 404 and 403 to a nil read). It is a read-only diagnostic helper
+// — it discards the body and never mutates — used by the ct-validate
+// absence-contract probe to observe whether an absent id yields 404 (the new
+// "absent -> 404" contract) or 403 (still 403-for-absent). A returned (0, err) is
+// a transport, auth or request failure that occurred before a status was observed.
+func (c *Client) ProbeStatus(ctx context.Context, path string, args ...interface{}) (int, error) {
+	r := c.newRequest("GET", path, args...)
+	resp, err := c.doRequest(ctx, r)
+	if err != nil {
+		return 0, err
+	}
+	defer closeResponseBody(resp)
+	return resp.StatusCode, nil
+}
+
 type StatusError struct {
 	Code int
 	Body string

--- a/internal/client/api_probe_test.go
+++ b/internal/client/api_probe_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestProbeStatus pins that ProbeStatus returns the RAW HTTP status for a GET,
+// without the not-found/forbidden folding the resource read methods apply. The
+// distinction between 404 (migrated) and 403 (forbidden) is exactly what the
+// absence-contract probe needs and what requireNotFoundOrOK would have erased.
+//
+// Only non-retried statuses are exercised here (2xx/4xx): a 5xx would trigger the
+// client's transient-retry path; the probe's handling of 5xx is covered by the
+// ct-validate probeAbsenceOutcome unit test.
+func TestProbeStatus(t *testing.T) {
+	for _, code := range []int{http.StatusOK, http.StatusForbidden, http.StatusNotFound, http.StatusConflict} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			c := newVPCTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			})
+			got, err := c.ProbeStatus(context.Background(), "/compute/v1/vcenters/virtual_machines/%s", "bogus-id")
+			if err != nil {
+				t.Fatalf("ProbeStatus returned an unexpected error for HTTP %d: %v", code, err)
+			}
+			if got != code {
+				t.Fatalf("ProbeStatus: expected raw status %d, got %d", code, got)
+			}
+		})
+	}
+}

--- a/scripts/ct-test.sh
+++ b/scripts/ct-test.sh
@@ -43,6 +43,7 @@ scenarios() {
   cat <<'EOF'
 readonly|readonly|0|1|Read every service (no create/destroy). The safest scenario, validates the tool.
 machine-managers|machine_managers|0|1|OpenIaaS: just run_identity + machine_managers.list, repeatable, to characterize the #315 5xx flakiness. Read-only.
+probe-absence|probe_absence|0|1|GET every by-id read with a bogus id to map the 404-vs-403 absence contract per endpoint (#384). Read-only; needs a read-entitled token (a 403 is "not migrated" only if the token may read the type).
 vpc|vpc|1|0|QUARANTINED: /vpc/v1 is deprecated and frozen pending the rebuild (no cloudtemple_vpc_* provider surface ships in v1.8.0). The opt-in `ct-validate -cycles vpc -write` still runs it manually.
 storage|object_storage|1|1|Create an object-storage bucket + account + ACL, verify, then destroy.
 vm|compute_lifecycle|1|1|OpenIaaS: create a VM from a template, add a disk, connect the network, then destroy.


### PR DESCRIPTION
Refs #384

## What

Step 1 of #384: a **read-only** probe to confirm, per endpoint on a real tenant,
whether the API's new "absent → 404, 403 = forbidden only" contract is deployed —
**before** flipping any `requireNotFoundOrOK(resp, 403)` site to `404`. The flip
itself is deliberately **not** in this PR.

- `client.ProbeStatus(ctx, path, args...)` — a read-only helper that GETs `path`
  with the client's auth/base URL and returns the **raw** HTTP status, without the
  404/403 folding the resource reads apply (which would erase the very distinction
  we need). Discards the body; never mutates.
- ct-validate `probe_absence` cycle (`KindRead`, **quarantined** so it never runs
  under `-cycles all`). It GETs every by-id / parent-scoped read endpoint (the 42
  whose path has a `%s`) with a well-formed-but-nonexistent id and records the
  status: **404 → OK (migrated, safe to flip)**; **403 / other non-404 → a 4xx
  failure** (the real status in the report detail, breaker **not** tripped);
  **5xx/429 → distress** (breaker). Collection/aggregate endpoints (no `%s`) are
  excluded — a list has no "absent id".

## How to run (on recette)

```
go install ./cmd/ct-validate
ct-validate -cycles probe_absence -runs 1 -concurrency 1   # with recette creds in env
```

Reading the report: a **green/OK** probe = the endpoint returned **404** for an
absent id → safe to flip that site to `notFoundCode=404`. A **4xx** probe whose
detail shows **`HTTP 403`** = **not migrated** → do **not** flip it.

**Operational caveat:** a 403 is an unambiguous "not migrated" signal only with a
token that **has read permission** on that resource type (otherwise a 403 could be
a genuine permission denial). Run with a broadly read-entitled recette token.

## Tests (mutation-proven)

- `client`: `ProbeStatus` returns the raw status (200/403/404/409).
- `ct-validate`: the status→outcome mapping (404=OK, 403/anomalies=non-distress
  4xx, 5xx/429=distress); the cycle records correctly and the breaker never trips
  on 403s; an **exact registry-coverage** test scans the client and fails if a
  `403`-by-id endpoint has no probe entry (or a stale entry lingers); and the cycle
  is quarantined yet runnable when named.
- Mutation-proven: a 404→error makes the mapping test RED; dropping a registry
  entry makes the coverage test RED.

## Review

Independent adversarial review by Codex (read-only): PLAN review GO (with 3
refinements, all applied), committed-diff review GO (no blocking findings).

Internal test-harness tooling (`cmd/ct-validate`), not a provider-user-facing
change → no CHANGELOG entry. `Refs #384` (no closing keyword, RC flow).
