### PR TITLE
feat(#384) PR-A: surface a genuine 403 as access-denied on Backup/Marketplace/VPC reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ ENHANCEMENTS :
 
 BUG FIXES :
 
-  * Fixed a possible provider crash (nil-pointer panic) when reading the `cloudtemple_object_storage_bucket`, `cloudtemple_object_storage_storage_account` or `cloudtemple_backup_metrics` datasource for a target that does not exist or that the token is not allowed to read. The underlying client maps such an HTTP 404/403 response to an empty result, which the datasources dereferenced without a guard; they now return an actionable error instead of panicking.
+  * Fixed a possible provider crash (nil-pointer panic) when reading the `cloudtemple_object_storage_bucket`, `cloudtemple_object_storage_storage_account` or `cloudtemple_backup_metrics` datasource for a target that does not exist or that the token is not allowed to read. The underlying client returned an empty result for such a not-found read, which the datasources dereferenced without a guard; they now return an actionable error instead of panicking.
   * Fixed a possible provider crash (nil-pointer panic) on `cloudtemple_compute_virtual_machine` update and destroy when the virtual machine could not be read (it no longer exists or the token is not allowed to read it). The operation now fails closed with an actionable error instead of panicking.
+  * Backup, Marketplace and VPC reads now surface a genuine HTTP 403 as an explicit "access denied" error instead of silently treating it as "not found". This relies on the API's not-found contract for these services (an absent resource returns 404, and 403 means access denied), so a forbidden read can no longer be mistaken for an absent resource and risk a wrong state drop. Compute is not affected by this change yet.
 
 # 1.8.0 (Unreleased)
 

--- a/internal/client/backup_iaas_opensource_backup.go
+++ b/internal/client/backup_iaas_opensource_backup.go
@@ -28,7 +28,7 @@ func (v *BackupOpenIaasBackupClient) Read(ctx context.Context, id string) (*Back
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (v *BackupOpenIaasBackupClient) List(ctx context.Context, filter *OpenIaasB
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/backup_iaas_opensource_policy.go
+++ b/internal/client/backup_iaas_opensource_policy.go
@@ -33,7 +33,7 @@ func (v *BackupOpenIaasPolicyClient) Read(ctx context.Context, id string) (*Back
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (v *BackupOpenIaasPolicyClient) List(ctx context.Context, filter *BackupOpe
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/backup_metrics.go
+++ b/internal/client/backup_metrics.go
@@ -30,7 +30,7 @@ func (c *BackupMetricsClient) History(ctx context.Context, rang int) (*BackupMet
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (c *BackupMetricsClient) PlatformCPU(ctx context.Context) (*BackupMetricsPl
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/backup_sla_policy.go
+++ b/internal/client/backup_sla_policy.go
@@ -74,7 +74,7 @@ func (c *BackupSLAPolicyClient) Read(ctx context.Context, id string) (*BackupSLA
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/backup_spp_server.go
+++ b/internal/client/backup_spp_server.go
@@ -47,7 +47,7 @@ func (c *BackupSPPServerClient) Read(ctx context.Context, id string) (*BackupSPP
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/flip_404_test.go
+++ b/internal/client/flip_404_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestNotFound404Flip pins the #384 PR-A flip on the Backup and Marketplace reads:
+// they now use requireNotFoundOrOK(resp, 404), so a 404 (absent) yields (nil, nil)
+// while a 403 (forbidden) is surfaced as an "access denied" error instead of being
+// masked as not-found. (VPC.Read has the same assertions in vpc_unit_test.go.)
+//
+// Mutation proof: reverting either site to notFoundCode=403 makes its 403 subtest
+// RED (a 403 would again return (nil, nil) instead of an error).
+func TestNotFound404Flip(t *testing.T) {
+	notFound := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) }
+	forbidden := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusForbidden) }
+	ctx := context.Background()
+
+	t.Run("backup SLAPolicy.Read 404 -> (nil,nil)", func(t *testing.T) {
+		c := newVPCTestClient(t, notFound)
+		p, err := c.Backup().SLAPolicy().Read(ctx, "absent")
+		if err != nil || p != nil {
+			t.Fatalf("404 must yield (nil,nil); got policy=%+v err=%v", p, err)
+		}
+	})
+	t.Run("backup SLAPolicy.Read 403 -> access-denied error", func(t *testing.T) {
+		c := newVPCTestClient(t, forbidden)
+		p, err := c.Backup().SLAPolicy().Read(ctx, "forbidden")
+		if err == nil || p != nil {
+			t.Fatalf("403 must yield an access-denied error and nil; got policy=%+v err=%v", p, err)
+		}
+	})
+	t.Run("marketplace Item.Read 404 -> (nil,nil)", func(t *testing.T) {
+		c := newVPCTestClient(t, notFound)
+		it, err := c.Marketplace().Item().Read(ctx, "absent")
+		if err != nil || it != nil {
+			t.Fatalf("404 must yield (nil,nil); got item=%+v err=%v", it, err)
+		}
+	})
+	t.Run("marketplace Item.Read 403 -> access-denied error", func(t *testing.T) {
+		c := newVPCTestClient(t, forbidden)
+		it, err := c.Marketplace().Item().Read(ctx, "forbidden")
+		if err == nil || it != nil {
+			t.Fatalf("403 must yield an access-denied error and nil; got item=%+v err=%v", it, err)
+		}
+	})
+}

--- a/internal/client/marketplace_item.go
+++ b/internal/client/marketplace_item.go
@@ -123,7 +123,7 @@ func (v *MarketplaceItemClient) Read(ctx context.Context, id string) (*Marketpla
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (v *MarketplaceItemClient) ReadInfo(ctx context.Context, id string, target 
 		return nil, nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, nil, err
 	}

--- a/internal/client/vpc_floating_ip.go
+++ b/internal/client/vpc_floating_ip.go
@@ -69,12 +69,11 @@ func (f *VPCFloatingIPClient) List(ctx context.Context, filter *FloatingIPFilter
 }
 
 // Read retrieves a single floating IP by ID, for DATASOURCE use. It returns
-// (nil, nil) when the floating IP is not found. Per the live contract a genuinely
-// absent floating IP answers 404; requireNotFoundOrOK ADDITIONALLY folds 403 into
-// not-found — a deliberate DATASOURCE tolerance (#303: a datasource treats a
-// forbidden floating IP as "absent"), NOT a claim that the API returns 403 for
-// absence. The RESOURCE must not use this: it reads via ResolveByID, which treats
-// 403 as a fail-closed error and ONLY an authoritative 404 as absence.
+// (nil, nil) when the floating IP is absent (404). Since #384 it uses
+// requireNotFoundOrOK(resp, 404), so a genuine 403 is surfaced as an access-denied
+// error rather than masked as not-found. The RESOURCE must not use this: it reads
+// via ResolveByID, which treats 403 as a fail-closed error and ONLY an
+// authoritative 404 as absence.
 func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP, error) {
 	r := f.c.newRequest("GET", "/vpc/v1/floating_ips/%s", id)
 	resp, err := f.c.doRequest(ctx, r)
@@ -82,7 +81,7 @@ func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP,
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -97,7 +96,8 @@ func (f *VPCFloatingIPClient) Read(ctx context.Context, id string) (*FloatingIP,
 
 // ResolveByID is the STRICT by-id read used by the floating-IP RESOURCE (create
 // read-back, refresh, delete confirmation) — distinct from Read (datasources),
-// which folds 403 into not-found. ResolveByID returns a tri-state result and uses
+// which since #384 maps 404 to not-found and surfaces 403 as an error.
+// ResolveByID returns a tri-state result and uses
 // an EXPLICIT status switch instead of requireNotFoundOrOK, because for the
 // resource only an AUTHORITATIVE 404 may drop state. The floating IP has NO
 // listing-omission drop channel (unlike static IP's per-network strict listing),

--- a/internal/client/vpc_private_network.go
+++ b/internal/client/vpc_private_network.go
@@ -49,7 +49,7 @@ func (p *VPCPrivateNetworkClient) List(ctx context.Context, filter *PrivateNetwo
 }
 
 // Read retrieves a single private network by ID. It returns (nil, nil) when the
-// private network does not exist (403; the API returns 403 for an absent resource).
+// private network does not exist (404; since #384 the VPC API returns 404 for an absent resource, 403 only for access denied).
 func (p *VPCPrivateNetworkClient) Read(ctx context.Context, id string) (*PrivateNetwork, error) {
 	r := p.c.newRequest("GET", "/vpc/v1/private_networks/%s", id)
 	resp, err := p.c.doRequest(ctx, r)
@@ -57,7 +57,7 @@ func (p *VPCPrivateNetworkClient) Read(ctx context.Context, id string) (*Private
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/vpc_static_ip.go
+++ b/internal/client/vpc_static_ip.go
@@ -126,9 +126,8 @@ func (s *VPCStaticIPClient) ListStrict(ctx context.Context, privateNetworkID str
 }
 
 // Read retrieves a single static IP by ID. It returns (nil, nil) when the static
-// IP is not found: requireNotFoundOrOK maps BOTH 404 and 403 to not-found (the VPC
-// API conflates absent/forbidden, #303), so an absent static IP — whether the API
-// answers 404 or 403 — surfaces as (nil, nil) for idempotent read handling.
+// IP is absent (404). Since #384 it uses requireNotFoundOrOK(resp, 404): a genuine
+// 403 is surfaced as an access-denied error, not masked as not-found.
 func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/%s", id)
 	resp, err := s.c.doRequest(ctx, r)
@@ -136,7 +135,7 @@ func (s *VPCStaticIPClient) Read(ctx context.Context, id string) (*StaticIP, err
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -293,8 +292,8 @@ func (s *VPCStaticIPClient) Delete(ctx context.Context, id string) (string, erro
 }
 
 // ReadByMAC retrieves a single static IP by MAC address. It returns (nil, nil)
-// when no static IP matches: requireNotFoundOrOK maps BOTH 404 and 403 to not-found
-// (the VPC API conflates absent/forbidden, #303).
+// when no static IP matches (404). Since #384 it uses requireNotFoundOrOK(resp,
+// 404): a genuine 403 is surfaced as an access-denied error, not masked as not-found.
 func (s *VPCStaticIPClient) ReadByMAC(ctx context.Context, mac string) (*StaticIP, error) {
 	r := s.c.newRequest("GET", "/vpc/v1/static_ips/mac/%s", mac)
 	resp, err := s.c.doRequest(ctx, r)
@@ -302,7 +301,7 @@ func (s *VPCStaticIPClient) ReadByMAC(ctx context.Context, mac string) (*StaticI
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/client/vpc_unit_test.go
+++ b/internal/client/vpc_unit_test.go
@@ -91,20 +91,18 @@ func TestVPCVPCListAndRead(t *testing.T) {
 		}
 	})
 
-	t.Run("Read treats 403 as not-found (the live VPC API returns 403 for an absent resource)", func(t *testing.T) {
-		// LIVE EVIDENCE (verified 2026-06-14 against a real tenant): the VPC API
-		// returns 403 Forbidden for an ABSENT resource, not 404 — despite the
-		// swagger documenting 404. So a single Read must treat 403 as not-found,
-		// like every other Cloud Temple read (the provider-wide convention). The
-		// trade-off — a genuine permission denial is indistinguishable from
-		// absence because the API conflates them — is an API-design limitation
-		// (anti-enumeration), not something the provider can resolve.
+	t.Run("Read surfaces a 403 as an access-denied error (404 is the absent signal; #384)", func(t *testing.T) {
+		// Since #384 the VPC API returns 404 for an absent resource and 403 ONLY for
+		// a permission denial (confirmed by the live absence probe). VPC.Read uses
+		// requireNotFoundOrOK(resp, 404), so a genuine 403 is surfaced as an error
+		// instead of being masked as not-found — a forbidden read can no longer be
+		// mistaken for an absence.
 		c := newVPCTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
 		})
-		vpc, err := c.VPC().VPC().Read(ctx, "absent")
-		if err != nil || vpc != nil {
-			t.Fatalf("403 must yield (nil,nil) (the API returns 403 for absent); got vpc=%+v err=%v", vpc, err)
+		vpc, err := c.VPC().VPC().Read(ctx, "forbidden")
+		if err == nil || vpc != nil {
+			t.Fatalf("403 must yield an access-denied error and a nil vpc; got vpc=%+v err=%v", vpc, err)
 		}
 	})
 }

--- a/internal/client/vpc_vpc.go
+++ b/internal/client/vpc_vpc.go
@@ -42,7 +42,7 @@ func (v *VPCVPCClient) List(ctx context.Context) ([]*VPC, error) {
 }
 
 // Read retrieves a single VPC by ID. It returns (nil, nil) when the VPC does
-// not exist (403; the API returns 403 for an absent resource) so callers can surface a precise not-found error.
+// not exist (404; since #384 the VPC API returns 404 for an absent resource, and 403 only for access denied) so callers can surface a precise not-found error.
 func (v *VPCVPCClient) Read(ctx context.Context, id string) (*VPC, error) {
 	r := v.c.newRequest("GET", "/vpc/v1/vpc/%s", id)
 	resp, err := v.c.doRequest(ctx, r)
@@ -50,7 +50,7 @@ func (v *VPCVPCClient) Read(ctx context.Context, id string) (*VPC, error) {
 		return nil, err
 	}
 	defer closeResponseBody(resp)
-	found, err := requireNotFoundOrOK(resp, 403)
+	found, err := requireNotFoundOrOK(resp, 404)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/internal/provider/data_source_backup_metrics.go
+++ b/internal/provider/data_source_backup_metrics.go
@@ -235,12 +235,13 @@ func backupMetricsRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// History maps an HTTP 404/403 to a (nil, nil) result (requireNotFoundOrOK).
-	// A nil here means the metrics are unavailable (absent or access denied), so
-	// fail with an actionable diagnostic instead of dereferencing nil in
+	// Since #384 History maps a 404 to a (nil, nil) result (requireNotFoundOrOK,
+	// resp 404); a 403 is surfaced as an access-denied error caught by the err
+	// check above. A nil here therefore means the metrics are absent, so fail with
+	// an actionable diagnostic instead of dereferencing nil in
 	// FlattenBackupMetricsHistory below (#382).
 	if history == nil {
-		return diag.Errorf("backup metrics history is unavailable (the API returned no content; the token may lack the required backup permission)")
+		return diag.Errorf("backup metrics history is unavailable (the API returned no content)")
 	}
 	platform, err := c.Backup().Metrics().Platform(ctx)
 	if err != nil {
@@ -250,10 +251,11 @@ func backupMetricsRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// Same (nil, nil)-on-404/403 contract as History above: guard before
-	// FlattenBackupMetricsPlatformCPU dereferences it (#382).
+	// Same 404-on-absent contract as History above (since #384): a 404 yields nil,
+	// a 403 errors out earlier. Guard before FlattenBackupMetricsPlatformCPU
+	// dereferences it (#382).
 	if platformCPU == nil {
-		return diag.Errorf("backup metrics platform CPU is unavailable (the API returned no content; the token may lack the required backup permission)")
+		return diag.Errorf("backup metrics platform CPU is unavailable (the API returned no content)")
 	}
 	policies, err := c.Backup().Metrics().Policies(ctx)
 	if err != nil {

--- a/internal/provider/datasource_nil_read_unit_test.go
+++ b/internal/provider/datasource_nil_read_unit_test.go
@@ -7,20 +7,22 @@ import (
 	"testing"
 )
 
-// These unit tests pin the #382 fix: a datasource read whose client method maps
-// an HTTP 404/403 to a (nil, nil) result must surface an actionable diagnostic,
-// never a nil-pointer panic — AND a normal 200 read must keep working unchanged.
+// These unit tests pin the #382 fix: a datasource read whose client method can
+// return (nil, nil) must surface an actionable diagnostic, never a nil-pointer
+// panic — AND a normal 200 read must keep working unchanged. Object storage maps
+// BOTH 404 and 403 to (nil,nil); since #384 backup metrics maps only 404 to nil
+// (a 403 surfaces as an access-denied error).
 //
-// Both the OLD not-found contract (absent -> 403) and the NEW one (absent -> 404)
-// reach the client helper requireNotFoundOrOK(resp, 403), which folds 404 AND 403
-// to (nil, nil); so each nil-read test is run under BOTH status codes to prove the
-// guard behaves identically before and after the API change.
+// Object storage reads still use requireNotFoundOrOK(resp, 403), which folds BOTH
+// 404 and 403 to (nil, nil); their nil-read tests therefore run under BOTH codes
+// (absentCodes). Backup metrics flipped to notFoundCode=404 in #384, so its tests
+// are split below: 404 -> nil-guard diagnostic, 403 -> access-denied error.
 //
 // Mutation proof (recorded): removing a guard makes the matching nil-read test go
 // RED via a nil-pointer dereference (d.SetId / Flatten* on a nil pointer).
 
-// absentCodes are the two HTTP statuses the client maps to (nil, nil): the new
-// not-found (404) and the old not-found / current forbidden (403).
+// absentCodes are the two HTTP statuses the object-storage reads map to (nil, nil)
+// via requireNotFoundOrOK(resp, 403): 404 and 403.
 var absentCodes = []int{http.StatusNotFound, http.StatusForbidden}
 
 // --- object storage: nil read must error (both 403 and 404), never panic ---
@@ -141,39 +143,59 @@ func backupMetricsHandler(t *testing.T, downPath string, downCode int) http.Hand
 	}
 }
 
-// --- backup metrics: a nil History / PlatformCPU read must error (both 403 and
-// 404), never panic ---
+// --- backup metrics: a nil/forbidden History or PlatformCPU read must error,
+// never panic. Since #384 backup_metrics uses notFoundCode=404, so the two codes
+// take different routes: a 404 (absent) returns (nil,nil) and is caught by the
+// datasource nil-guard ("is unavailable"); a 403 (forbidden) is surfaced by the
+// client as an "access denied" error BEFORE the guard. Both must error, neither
+// must panic in the Flatten* helper. ---
 
 func TestBackupMetricsReadNilHistoryDoesNotPanic(t *testing.T) {
-	for _, code := range absentCodes {
-		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
-			c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/backup/history", code))
-			d := dataSourceBackupMetrics().TestResourceData()
-			_ = d.Set("range", 7)
-
-			diags := backupMetricsRead(context.Background(), d, c)
-			if !diags.HasError() {
-				t.Fatalf("a %d history read must return an error diagnostic, got none", code)
-			}
-			diagsContain(t, diags, "history is unavailable")
-		})
-	}
+	const path = "/backup/v1/spp/metrics/backup/history"
+	t.Run("HTTP_404_guarded", func(t *testing.T) {
+		c := newAssignTestClient(t, backupMetricsHandler(t, path, http.StatusNotFound))
+		d := dataSourceBackupMetrics().TestResourceData()
+		_ = d.Set("range", 7)
+		diags := backupMetricsRead(context.Background(), d, c)
+		if !diags.HasError() {
+			t.Fatal("a 404 history read must return an error diagnostic, got none")
+		}
+		diagsContain(t, diags, "history is unavailable")
+	})
+	t.Run("HTTP_403_access_denied", func(t *testing.T) {
+		c := newAssignTestClient(t, backupMetricsHandler(t, path, http.StatusForbidden))
+		d := dataSourceBackupMetrics().TestResourceData()
+		_ = d.Set("range", 7)
+		diags := backupMetricsRead(context.Background(), d, c)
+		if !diags.HasError() {
+			t.Fatal("a 403 history read must return an access-denied error, got none")
+		}
+		diagsContain(t, diags, "access denied")
+	})
 }
 
 func TestBackupMetricsReadNilPlatformCPUDoesNotPanic(t *testing.T) {
-	for _, code := range absentCodes {
-		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
-			c := newAssignTestClient(t, backupMetricsHandler(t, "/backup/v1/spp/metrics/plateform/cpu", code))
-			d := dataSourceBackupMetrics().TestResourceData()
-			_ = d.Set("range", 7)
-
-			diags := backupMetricsRead(context.Background(), d, c)
-			if !diags.HasError() {
-				t.Fatalf("a %d platform CPU read must return an error diagnostic, got none", code)
-			}
-			diagsContain(t, diags, "platform CPU is unavailable")
-		})
-	}
+	const path = "/backup/v1/spp/metrics/plateform/cpu"
+	t.Run("HTTP_404_guarded", func(t *testing.T) {
+		c := newAssignTestClient(t, backupMetricsHandler(t, path, http.StatusNotFound))
+		d := dataSourceBackupMetrics().TestResourceData()
+		_ = d.Set("range", 7)
+		diags := backupMetricsRead(context.Background(), d, c)
+		if !diags.HasError() {
+			t.Fatal("a 404 platform CPU read must return an error diagnostic, got none")
+		}
+		diagsContain(t, diags, "platform CPU is unavailable")
+	})
+	t.Run("HTTP_403_access_denied", func(t *testing.T) {
+		c := newAssignTestClient(t, backupMetricsHandler(t, path, http.StatusForbidden))
+		d := dataSourceBackupMetrics().TestResourceData()
+		_ = d.Set("range", 7)
+		diags := backupMetricsRead(context.Background(), d, c)
+		if !diags.HasError() {
+			t.Fatal("a 403 platform CPU read must return an access-denied error, got none")
+		}
+		diagsContain(t, diags, "access denied")
+	})
 }
 
 // TestBackupMetricsReadSuccessPopulatesState proves the success path is unchanged

--- a/internal/provider/resource_vpc_floating_ip.go
+++ b/internal/provider/resource_vpc_floating_ip.go
@@ -233,7 +233,8 @@ func resourceVPCFloatingIPRead(ctx context.Context, d *schema.ResourceData, meta
 // overriding invariant: the resource is NEVER dropped on an inconclusive read.
 //
 // ResolveByID is the STRICT by-id read used ONLY by the resource: unlike Read
-// (datasources), it does NOT fold 403 into not-found. Its tri-state is therefore
+// (datasources), it returns an explicit tri-state (plus an id-consistency guard)
+// so the resource can act on each status distinctly. Its tri-state is therefore
 // unambiguous:
 //
 //   - error (403/206/transport/other) -> FAIL CLOSED: keep the resource, error. A

--- a/internal/provider/resource_vpc_static_ip.go
+++ b/internal/provider/resource_vpc_static_ip.go
@@ -142,8 +142,8 @@ func resourceVPCStaticIP() *schema.Resource {
 //     POSITIVE evidence, so an absent listing is eventual consistency, NOT a
 //     deletion -> FAIL CLOSED keeping the id (never orphan, #348).
 //
-// In BOTH modes a bare nil per-id read (404/403, the #303 absent/forbidden
-// conflation) NEVER drops on its own: only a SUCCESSFUL strict listing that omits
+// In BOTH modes a bare nil per-id read (a 404; since #384 a 403 surfaces as an
+// error before this path) NEVER drops on its own: only a SUCCESSFUL strict listing that omits
 // the id can drop, and only in readForRefresh (R-Q10).
 type staticIPReadMode int
 
@@ -241,11 +241,11 @@ type vpcStaticIPListStrictFunc func(ctx context.Context, privateNetworkID string
 // readVPCStaticIPInto holds the testable read logic. State safety is the
 // overriding invariant: the resource is NEVER dropped on an inconclusive read.
 //
-// A nil per-id read is INCONCLUSIVE, not a deletion: the VPC read client maps
-// HTTP 403 to nil (the #303 access-denied-as-not-found convention), so an
-// access-denied answer is indistinguishable from a genuine absence. We therefore
-// confirm via a strict, complete (200-only) listing of the private network
-// before concluding anything:
+// A nil per-id read is INCONCLUSIVE, not a deletion: since #384 the VPC read
+// client maps only a 404 to nil (a 403 now surfaces as an access-denied error
+// before this path), but a per-id 404 alone is still not trusted to drop a
+// tracked resource. We therefore confirm via a strict, complete (200-only)
+// listing of the private network before concluding anything:
 //
 //   - listing error (includes any non-200 rejected by ListStrict, e.g. a 206
 //     partial, a 403, or a 5xx) -> FAIL CLOSED: keep the resource, error;
@@ -401,8 +401,8 @@ func resourceVPCStaticIPUpdate(ctx context.Context, d *schema.ResourceData, meta
 // and private_network_id are ForceNew and never reach this path) is rebuilt from a
 // FRESH LIVE read, never from the state alone:
 //
-//   - a nil/ambiguous read (403/absent) or an id-inconsistent body FAILS CLOSED:
-//     never PATCH on ambiguous evidence;
+//   - a nil read (a 404 absent; since #384 a 403 errors out before this) or an
+//     id-inconsistent body FAILS CLOSED: never PATCH on ambiguous evidence;
 //   - if the live state already matches the desired config (after MAC
 //     canonicalisation) it is converged: return success WITHOUT a PATCH;
 //   - otherwise issue the async PATCH and wait for its activity.

--- a/internal/provider/resource_vpc_static_ip_update_test.go
+++ b/internal/provider/resource_vpc_static_ip_update_test.go
@@ -149,7 +149,7 @@ func TestUpdateVPCStaticIPWith(t *testing.T) {
 		d := newStaticIPState(t)
 		var updateCalls int
 		funcs := vpcStaticIPUpdateFuncs{
-			read: func(ctx context.Context, id string) (*client.StaticIP, error) { return nil, nil }, // 403/absent
+			read: func(ctx context.Context, id string) (*client.StaticIP, error) { return nil, nil }, // 404 absent (post-#384 a 403 would error)
 			update: func(ctx context.Context, id string, req *client.UpdateStaticIPRequest) (string, error) {
 				updateCalls++
 				return "act", nil

--- a/internal/provider/vpc_network_adapter_ip.go
+++ b/internal/provider/vpc_network_adapter_ip.go
@@ -40,7 +40,7 @@ func vpcStaticIPToPush(ipConfigured bool, configuredIP, liveIP string, onVPC boo
 
 // adapterVPCStaticIP maps a by-MAC static IP read to the ip_address state value.
 // A non-VPC adapter has no static IP; a VPC adapter with none registered yet
-// (sip == nil — including the 403/absent the client maps to nil) also yields "".
+// (sip == nil — a 404 absent; since #384 a 403 surfaces as an error instead) also yields "".
 func adapterVPCStaticIP(onVPC bool, sip *client.StaticIP) string {
 	if !onVPC || sip == nil {
 		return ""


### PR DESCRIPTION
Refs #384

## What

Flip 15 client reads (Backup, Marketplace, VPC) from `requireNotFoundOrOK(resp, 403)`
to `requireNotFoundOrOK(resp, 404)`. A 404 stays "not found"; a genuine **403 now
surfaces as an explicit "access denied" error** instead of being silently masked
as "not found". A forbidden read can no longer be mistaken for an absent resource
(never-drop: strictly safer).

This is **PR-A** of #384 — only the services whose `absent -> 404` contract is
**already deployed on prod**.

## Evidence

A read-only live absence probe (`ct-validate -cycles probe_absence`, run 2026-06-29
against prod and a newer env) confirmed an absent id returns **404** for Backup,
Marketplace and VPC.

## Scope

Flipped (15): backup `sla_policy`, `spp_server`, `openiaas` backup Read+List,
`openiaas` policy Read+List, metrics History+PlatformCPU; marketplace `item`
Read+ReadInfo; VPC `vpc`, `private_network`, `static_ip` Read+ReadByMAC,
`floating_ip`. Stale "403 for an absent resource" comments updated throughout.

**Out of scope (deliberately NOT changed):**
- **Compute** (VMware + OpenIaaS, 39 sites) stays at `403`: prod still returns 403
  for absent. It is a separate **PR-B** gated on a documented dependency on
  **Compute API v1.144.0** (the release carrying the 404 contract).
- **Object storage** (bucket, storage_account) stays at `403`: it returns **500**
  for an absent id (a separate API bug, tracked separately) — not a 404 contract.

## Tests (mutation-proven)

- client `flip_404_test.go` + `vpc_unit_test.go`: a flipped read returns
  `(nil,nil)` on 404 and an **access-denied error** on 403.
- provider `datasource_nil_read_unit_test.go`: backup metrics → 404 hits the #382
  nil-guard ("is unavailable"), 403 → access-denied; object storage UNCHANGED at 403.
- Reverting any flipped site to 403 makes its 403 test RED.
- `go install`, `go vet`, `gofmt`, full `go test ./internal/client ./internal/provider`
  green (go1.24); staticcheck via CI.

## Review

Independent adversarial review by Codex (read-only): PLAN review GO (full
caller-by-caller safety table, no never-drop regression); committed-diff review GO
(after a doc-accuracy fix pass). No closing keyword (RC flow); `Refs #384`.
