### PR TITLE
docs(rules): API/platform issues go to platform feedback, not the provider board

### DIFF
--- a/.clinerules/WORKFLOW_GIT_EPIC.md
+++ b/.clinerules/WORKFLOW_GIT_EPIC.md
@@ -32,6 +32,36 @@ Rules:
 - keep the piloting Project private if the tracking contains internal
   priorities, risks or trade-offs.
 
+### API / platform issues are out of provider scope — send feedback upstream
+
+A problem whose root cause AND fix live on the Cloud Temple API / platform side
+(not in the provider code) is NOT opened as an issue in the provider repository and
+is NOT tracked on the provider board. It is routed as feedback to the platform team
+through their support feedback endpoint:
+
+```
+POST https://shiva.cloud-temple.com/api/support/v1/tickets/feedback
+Authorization: Bearer <shiva token>     # never store the token in the repo/rules
+{
+  "note": <integer 1-4>,                 # severity/priority rating
+  "description": "<the issue, in factual English>"
+}
+```
+
+The provider board tracks ONLY:
+- provider-code work (bugs, features, hardening in this repository), and
+- provider-side MITIGATIONS of a platform problem — a mitigation PR *references* the
+  platform feedback (e.g. an existing platform issue id), it does not duplicate the
+  platform ticket on the provider board.
+
+Rationale: a platform ticket can never be closed by a provider PR, so recording it
+here leaves a permanently-open, unactionable item that pollutes the board and blurs
+what the provider team actually owns.
+
+Scope: this is a going-forward rule. Pre-existing API/platform issues already on the
+board are grandfathered and handled case by case — do not bulk-remove them. Never put
+a bearer token in an issue, PR, commit, log or these rules.
+
 ## Language of provider artifacts
 
 The Cloud Temple Terraform provider is a multi-client component. Any public


### PR DESCRIPTION
## Summary

Adds a scope-boundary rule to `.clinerules/WORKFLOW_GIT_EPIC.md` (under **Piloting scope**): a problem whose root cause **and** fix live on the Cloud Temple API/platform side (not in the provider code) is **not** opened as a provider issue nor tracked on the provider board — it is routed as **feedback to the platform team**.

## The rule

- **Channel:** `POST https://shiva.cloud-temple.com/api/support/v1/tickets/feedback` with `{ "note": <1-4>, "description": "<text>" }`, authenticated with a Shiva bearer token (never stored in the repo/rules).
- **The board tracks only:** provider-code work, and provider-side *mitigations* of a platform problem (a mitigation references the platform feedback rather than duplicating the platform ticket here).
- **Rationale:** a platform ticket can never be closed by a provider PR → it would sit permanently open, unactionable, polluting the board and blurring provider ownership.
- **Scope:** going-forward only. Pre-existing API/platform issues already on the board are grandfathered and handled case by case (no bulk removal).

Docs-only change; no code, no behavior impact.
