### PR TITLE
feat(#415): bound activity not-found retry budget (E0-7 anti-orphan)

### DIFF
--- a/internal/client/activity.go
+++ b/internal/client/activity.go
@@ -236,17 +236,23 @@ type activityReadFunc func(ctx context.Context) (*Activity, error)
 //   - permanent read errors (4xx, decode, context cancellation) fail
 //     immediately;
 //   - a terminal "failed" activity is never retried;
-//   - an initial not-found is tolerated once (eventual consistency),
-//     a repeated not-found is permanent.
+//   - initial not-founds are tolerated up to a bounded budget
+//     (WaiterOptions.NotFoundRetries, default 1) for eventual consistency,
+//     a not-found beyond the budget is permanent;
+//   - an activity that was seen and then vanishes is always permanent,
+//     regardless of the not-found budget.
 func waitForActivityCompletion(ctx context.Context, id string, read activityReadFunc, b retry.Backoff, options *WaiterOptions) (*Activity, error) {
 	var res *Activity
 	var consecutiveReadFailures int
-	// The one-time not-found tolerance (eventual consistency right after
-	// the activity is started) is tracked independently from the transient
-	// read budget: a 429/5xx/transport blip before the first successful
-	// read must not consume it (FF-3). The disappearance of an activity
-	// that was already seen stays permanent.
-	var notFoundTolerated bool
+	// The initial not-found tolerance (eventual consistency right after the
+	// activity is started) is tracked independently from the transient read
+	// budget: a 429/5xx/transport blip before the first successful read must
+	// not consume it (FF-3). Its size is WaiterOptions.NotFoundRetries (default
+	// 1) so a slow-to-index activity does not fail a write that keeps running
+	// platform-side (#415). The disappearance of an activity that was already
+	// seen stays permanent.
+	var notFoundReads int
+	notFoundBudget := options.notFoundBudget()
 	var activitySeen bool
 
 	err := retry.Do(ctx, b, func(ctx context.Context) error {
@@ -270,11 +276,12 @@ func waitForActivityCompletion(ctx context.Context, id string, read activityRead
 				message: fmt.Sprintf("the activity %q could not be found", id),
 			}
 			if activitySeen {
-				// An activity that was visible and vanished is permanent.
+				// An activity that was visible and vanished is permanent,
+				// regardless of the not-found budget.
 				return options.error(err)
 			}
-			if !notFoundTolerated {
-				notFoundTolerated = true
+			if notFoundReads < notFoundBudget {
+				notFoundReads++
 				return options.retryableError(err)
 			}
 			return options.error(err)

--- a/internal/client/activity_unit_test.go
+++ b/internal/client/activity_unit_test.go
@@ -325,3 +325,73 @@ func TestActivityWaitDisappearedActivityIsPermanent(t *testing.T) {
 		t.Fatalf("calls=%d, want 2 (no retry after disappearance)", calls)
 	}
 }
+
+// TestActivityWaitNotFoundBudgetIsConfigurableAndBounded pins the E0-7
+// anti-orphan extension (#415): WaiterOptions.NotFoundRetries widens the
+// initial not-found tolerance from a single read to a bounded budget, so a
+// slow-to-index activity does not fail a write that is still running
+// platform-side. The default (unset) budget stays at one, and the extension
+// never relaxes the disappearance rule.
+func TestActivityWaitNotFoundBudgetIsConfigurableAndBounded(t *testing.T) {
+	t.Run("a generous budget tolerates several initial not-founds then completes", func(t *testing.T) {
+		calls := 0
+		read := scriptedReads(&calls,
+			readOutcome{}, // three initial not-founds (eventual consistency)
+			readOutcome{},
+			readOutcome{},
+			readOutcome{activity: completedActivity()},
+		)
+		opts := &WaiterOptions{NotFoundRetries: 5}
+		activity, err := waitForActivityCompletion(context.Background(), "act-1", read, immediateBackoff(20), opts)
+		if err != nil || activity == nil {
+			t.Fatalf("a budget of 5 must tolerate 3 initial not-founds, got err=%v", err)
+		}
+		if calls != 4 {
+			t.Fatalf("calls=%d, want 4", calls)
+		}
+	})
+
+	t.Run("the budget is bounded: a not-found beyond it is permanent", func(t *testing.T) {
+		calls := 0
+		read := scriptedReads(&calls, readOutcome{}) // endless not-found
+		opts := &WaiterOptions{NotFoundRetries: 3}
+		_, err := waitForActivityCompletion(context.Background(), "act-1", read, immediateBackoff(50), opts)
+		if err == nil {
+			t.Fatal("an endless not-found must fail once the budget is exhausted")
+		}
+		// 3 tolerated retries + 1 final permanent attempt; kills the
+		// unbounded-tolerance and off-by-one mutants.
+		if calls != 4 {
+			t.Fatalf("calls=%d, want 4 (3 tolerated + 1 permanent)", calls)
+		}
+	})
+
+	t.Run("a generous budget still treats a seen-then-vanished activity as permanent", func(t *testing.T) {
+		calls := 0
+		read := scriptedReads(&calls,
+			readOutcome{activity: pendingActivity()}, // seen
+			readOutcome{},                            // vanished
+		)
+		opts := &WaiterOptions{NotFoundRetries: 10}
+		_, err := waitForActivityCompletion(context.Background(), "act-1", read, immediateBackoff(20), opts)
+		if err == nil {
+			t.Fatal("disappearance after being seen is permanent regardless of the not-found budget")
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2 (disappearance is not covered by the not-found budget)", calls)
+		}
+	})
+
+	t.Run("the default (unset) budget still tolerates exactly one initial not-found", func(t *testing.T) {
+		calls := 0
+		read := scriptedReads(&calls, readOutcome{}, readOutcome{})
+		opts := &WaiterOptions{} // NotFoundRetries unset -> historical single tolerance
+		_, err := waitForActivityCompletion(context.Background(), "act-1", read, immediateBackoff(20), opts)
+		if err == nil {
+			t.Fatal("the default budget tolerates only one initial not-found")
+		}
+		if calls != 2 {
+			t.Fatalf("calls=%d, want 2 (default budget unchanged)", calls)
+		}
+	})
+}

--- a/internal/client/api.go
+++ b/internal/client/api.go
@@ -756,12 +756,34 @@ func encodeBody(obj any) (io.Reader, error) {
 
 type WaiterOptions struct {
 	Logger func(msg string)
+
+	// NotFoundRetries bounds how many not-found reads of the activity are
+	// tolerated BEFORE it is first seen — the eventual-consistency window that
+	// opens right after a write returns its Location header and before
+	// GET /activity/v1/activities/{id} becomes readable (#415). It counts the
+	// TOTAL pre-seen not-found observations, and is deliberately NOT reset by an
+	// interleaved transient read error (that has its own independent budget,
+	// maxActivityReadRetries — FF-3). A value < 1 (the zero value / unset)
+	// preserves the historical behaviour of tolerating exactly one initial
+	// not-found. It NEVER relaxes the disappearance rule: an activity that was
+	// seen and then vanished stays permanently failed regardless of this budget.
+	NotFoundRetries int
 }
 
 func (w *WaiterOptions) log(msg string) {
 	if w != nil && w.Logger != nil {
 		w.Logger(msg)
 	}
+}
+
+// notFoundBudget returns how many consecutive initial not-found reads are
+// tolerated before the activity is first seen. Zero / unset (or a nil
+// WaiterOptions) preserves the historical single tolerance.
+func (w *WaiterOptions) notFoundBudget() int {
+	if w == nil || w.NotFoundRetries < 1 {
+		return 1
+	}
+	return w.NotFoundRetries
 }
 
 func (w *WaiterOptions) error(err error) error {


### PR DESCRIPTION
## What

First slice of the Public Cloud VM Instances resource work (E2): a **non-breaking extension of the shared activity waiter** so the forthcoming `cloudtemple_public_cloud_vm_instance` resource never orphans a VM when its write activity is slow to become readable.

`WaiterOptions` gains `NotFoundRetries int` + a nil-safe `notFoundBudget()`. The waiter's one-shot initial not-found tolerance becomes a bounded budget; a value `< 1` (the zero value / unset) **preserves the exact historical behaviour** (tolerate exactly one initial not-found), so every existing caller is unchanged. The budget never relaxes the disappearance rule: an activity that was seen and then vanished stays permanently failed.

## Why

For an async write that has just returned `Location: <activityId>`, `GET /activity/v1/activities/{id}` may 404 for several reads during the eventual-consistency indexing window. Failing after a single not-found abandons a write that keeps running platform-side, orphaning the resource outside the Terraform state (the E2 anti-orphan requirement, #415).

## Tests / gates

- `TestActivityWaitNotFoundBudgetIsConfigurableAndBounded` (4 mutation-killer sub-tests): generous budget tolerates N then completes; budget is bounded (beyond it is permanent); seen-then-vanished stays permanent regardless of budget; default (unset) budget unchanged.
- All pre-existing waiter invariant tests still pass (backward compatibility).
- gofmt / `go build ./...` / `go vet` / staticcheck (2025.1.1) clean; coverage ratchet green (internal/client 36.5% vs floor 24.8%).

Adversarial review: Codex (gpt-5.5, read-only) **GO**, 0 blocking / 0 minor / 1 nit (comment wording, fixed).

No user-facing behaviour change by default — CHANGELOG entry deferred to the user-facing VM instance resource PR.

Refs #415