### PR TITLE
feat(#424): public_cloud_vm_instance client with paginated list (E0-6, E2-1)

### DIFF
--- a/internal/client/public_cloud_vm_instance.go
+++ b/internal/client/public_cloud_vm_instance.go
@@ -1,0 +1,274 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+type PublicCloudVMInstanceClient struct {
+	c *Client
+}
+
+// Instance returns the VM instance sub-client — the core writable entity of the
+// Public Cloud VM Instances product (service /vm_instances, mount
+// /v1/virtual_machines). Every write is ASYNCHRONOUS: it returns 201 +
+// Location:<activityId>, so the write methods return the raw activityId and the
+// caller (the resource) tracks it through the shared Shiva Activities waiter,
+// extracts the VM id from the completed activity and never guesses it.
+func (v *PublicCloudVMClient) Instance() *PublicCloudVMInstanceClient {
+	return &PublicCloudVMInstanceClient{v.c}
+}
+
+// publicCloudVMInstanceListPageSize is the API's maximum page size for
+// GET /vm_instances/v1/virtual_machines (limit max = 200). List/ListStrict page
+// through with limit+offset so a tenant with more than one page of VMs is never
+// silently truncated (E0-6 / #414); the provider has no other pagination.
+const publicCloudVMInstanceListPageSize = 200
+
+// PublicCloudVMInstanceRef is the {id, name} shape used for the resolved
+// availability zone, template, instance family and backup policy references
+// returned by the API.
+type PublicCloudVMInstanceRef struct {
+	ID   string
+	Name string
+}
+
+// PublicCloudVMInstance mirrors an element of GET /vm_instances/v1/virtual_machines
+// and the GET /{id} detail. The broker camelizes responses (ramGb, disksSizeGb,
+// guestToolsInstalled, ...); Go's encoding/json matches struct fields
+// case-insensitively, so no json tags are needed on the read path. BackupPolicy
+// is nullable in the API and decodes to nil when null.
+type PublicCloudVMInstance struct {
+	ID                  string
+	Name                string
+	Status              string
+	AZ                  PublicCloudVMInstanceRef
+	Template            PublicCloudVMInstanceRef
+	InstanceFamily      PublicCloudVMInstanceRef
+	VCPU                int
+	RAMGb               int
+	DisksSizeGb         int
+	BackupPolicy        *PublicCloudVMInstanceRef
+	GuestToolsInstalled bool
+	CreatedAt           string
+	UpdatedAt           string
+}
+
+// PublicCloudVMInstanceFilter carries the server-side query filters of the list
+// endpoint. Only string fields are represented here because addFilter maps
+// string/bool/[]string tags; the int limit/offset pagination cursor is added
+// manually by the list loop. Note the query parameter for the instance family is
+// `familyId` (≠ the create body's `instanceFamilyId`).
+type PublicCloudVMInstanceFilter struct {
+	Name               string `filter:"name"`
+	Status             string `filter:"status"`
+	AvailabilityZoneID string `filter:"availabilityZoneId"`
+	FamilyID           string `filter:"familyId"`
+	OrderBy            string `filter:"orderBy"`
+	OrderDir           string `filter:"orderDir"`
+}
+
+// List returns every VM instance matching the filter, auto-paginating over the
+// full result set. Pages are accepted with requireOK (200/201/206).
+func (i *PublicCloudVMInstanceClient) List(ctx context.Context, filter *PublicCloudVMInstanceFilter) ([]*PublicCloudVMInstance, error) {
+	return i.list(ctx, filter, false)
+}
+
+// ListStrict is List with a 200-ONLY contract on every page (206/partial is
+// rejected as an error). It is the authoritative source of truth for an absence
+// decision (E0-9): a VM is only accepted as deleted when a complete, strictly
+// successful listing does not contain its id. A partial or access-denied listing
+// must fail closed (never drop state on an incomplete listing).
+func (i *PublicCloudVMInstanceClient) ListStrict(ctx context.Context, filter *PublicCloudVMInstanceFilter) ([]*PublicCloudVMInstance, error) {
+	return i.list(ctx, filter, true)
+}
+
+func (i *PublicCloudVMInstanceClient) list(ctx context.Context, filter *PublicCloudVMInstanceFilter, strict bool) ([]*PublicCloudVMInstance, error) {
+	var out []*PublicCloudVMInstance
+	seen := make(map[string]struct{})
+	for offset := 0; ; offset += publicCloudVMInstanceListPageSize {
+		req := i.c.newRequest("GET", "/vm_instances/v1/virtual_machines")
+		if filter != nil {
+			req.addFilter(filter)
+		}
+		req.params.Add("limit", strconv.Itoa(publicCloudVMInstanceListPageSize))
+		req.params.Add("offset", strconv.Itoa(offset))
+
+		page, err := i.readPage(ctx, req, strict)
+		if err != nil {
+			return nil, err
+		}
+
+		// Deduplicate across pages and count the ids this page contributes: a
+		// well-behaved server never repeats an id across offsets.
+		newInPage := 0
+		for _, vm := range page {
+			if vm == nil {
+				continue
+			}
+			if _, dup := seen[vm.ID]; dup {
+				continue
+			}
+			seen[vm.ID] = struct{}{}
+			out = append(out, vm)
+			newInPage++
+		}
+
+		// A short (or empty) page means the collection is exhausted.
+		if len(page) < publicCloudVMInstanceListPageSize {
+			break
+		}
+		// A FULL page that contributes no new id means the server is not honouring
+		// `offset` (it keeps returning the same page). Fail closed rather than loop
+		// forever (unbounded memory / spin) or silently truncate — a partial
+		// listing must never be mistaken for the complete set (E0-6 anti-truncation;
+		// E0-9 relies on a complete listing as absence evidence).
+		if newInPage == 0 {
+			return nil, fmt.Errorf("virtual machine listing made no progress at offset %d (the API may be ignoring pagination); refusing to loop or truncate", offset)
+		}
+	}
+	return out, nil
+}
+
+// readPage issues one paginated request and decodes the bare-array page,
+// applying the strict (200-only) or lenient (requireOK) success contract. It
+// isolates the per-request body close so the pagination loop cannot leak a
+// response body.
+func (i *PublicCloudVMInstanceClient) readPage(ctx context.Context, req *request, strict bool) ([]*PublicCloudVMInstance, error) {
+	resp, err := i.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+
+	if strict {
+		if err := requireHttpCodes(resp, 200); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := requireOK(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	var page []*PublicCloudVMInstance
+	if err := decodeBody(resp, &page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+// Read returns a single VM instance by UUID. A positive 404 maps to (nil, nil)
+// (absence); any other non-OK code (403, 5xx) is returned as an error so the
+// caller fails closed and never treats a permission/backend blip as a deletion.
+func (i *PublicCloudVMInstanceClient) Read(ctx context.Context, id string) (*PublicCloudVMInstance, error) {
+	req := i.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s", id)
+	resp, err := i.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	found, err := requireNotFoundOrOK(resp, 404)
+	if err != nil || !found {
+		return nil, err
+	}
+
+	var out PublicCloudVMInstance
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateVMInstanceNIC is one network interface of the create body. The whole
+// structure is immutable (ForceNew) on the resource; NIC changes go through the
+// standalone network_adapter resource.
+type CreateVMInstanceNIC struct {
+	DeviceIndex int    `json:"deviceIndex"`
+	NetworkID   string `json:"networkId"`
+	IPAddress   string `json:"ipAddress,omitempty"`
+}
+
+// CreateVMInstanceCloudInit is the optional cloud-init payload of the create body.
+type CreateVMInstanceCloudInit struct {
+	CloudConfig   string `json:"cloudConfig,omitempty"`
+	NetworkConfig string `json:"networkConfig,omitempty"`
+}
+
+// CreateVMInstanceRequest is the body of POST /vm_instances/v1/virtual_machines.
+// disks[] is deliberately NOT modelled: the resource never creates disks (the
+// template provides the system disk); data disks are the standalone disk
+// resource. PowerState is passed through so the VM boots (or stays off) from the
+// first apply; when empty the API leaves the VM stopped.
+type CreateVMInstanceRequest struct {
+	Name               string                     `json:"name"`
+	AvailabilityZoneID string                     `json:"availabilityZoneId"`
+	TemplateID         string                     `json:"templateId"`
+	InstanceFamilyID   string                     `json:"instanceFamilyId"`
+	CPU                int                        `json:"cpu"`
+	Memory             int                        `json:"memory"`
+	BackupPolicyID     string                     `json:"backupPolicyId"`
+	NetworkInterfaces  []CreateVMInstanceNIC      `json:"networkInterfaces"`
+	CloudInit          *CreateVMInstanceCloudInit `json:"cloudInit,omitempty"`
+	PowerState         string                     `json:"powerState,omitempty"`
+}
+
+// Create submits the async VM creation and returns the raw activityId from the
+// Location header. The caller waits on the activity and extracts the VM id from
+// the completed activity (result / concernedItems type "vmi").
+func (i *PublicCloudVMInstanceClient) Create(ctx context.Context, req *CreateVMInstanceRequest) (string, error) {
+	r := i.c.newRequest("POST", "/vm_instances/v1/virtual_machines")
+	r.obj = req
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// PatchVMInstanceRequest is the body of PATCH /vm_instances/v1/virtual_machines/{id}
+// (in-place metadata update). Both fields are pointers with omitempty so a
+// diff-driven update sends only the attributes that actually changed.
+type PatchVMInstanceRequest struct {
+	Name           *string `json:"name,omitempty"`
+	BackupPolicyID *string `json:"backupPolicyId,omitempty"`
+}
+
+// PatchMetadata submits the async in-place metadata update (name / backup policy)
+// and returns the activityId.
+func (i *PublicCloudVMInstanceClient) PatchMetadata(ctx context.Context, id string, req *PatchVMInstanceRequest) (string, error) {
+	r := i.c.newRequest("PATCH", "/vm_instances/v1/virtual_machines/%s", id)
+	r.obj = req
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// ResizeVMInstanceRequest is the body of POST /vm_instances/v1/virtual_machines/{id}/resize.
+// Both dimensions are optional (a resize may change only cpu or only memory).
+// The "VM must be stopped" precondition is enforced downstream (worker); a
+// violation surfaces as a failed activity.
+type ResizeVMInstanceRequest struct {
+	CPU    *int `json:"cpu,omitempty"`
+	Memory *int `json:"memory,omitempty"`
+}
+
+// Resize submits the async vCPU/RAM resize and returns the activityId.
+func (i *PublicCloudVMInstanceClient) Resize(ctx context.Context, id string, req *ResizeVMInstanceRequest) (string, error) {
+	r := i.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/resize", id)
+	r.obj = req
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Start submits the async power-on transition and returns the activityId.
+func (i *PublicCloudVMInstanceClient) Start(ctx context.Context, id string) (string, error) {
+	r := i.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/start", id)
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Stop submits the async power-off transition and returns the activityId.
+func (i *PublicCloudVMInstanceClient) Stop(ctx context.Context, id string) (string, error) {
+	r := i.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/stop", id)
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Delete submits the async VM deletion and returns the activityId.
+func (i *PublicCloudVMInstanceClient) Delete(ctx context.Context, id string) (string, error) {
+	r := i.c.newRequest("DELETE", "/vm_instances/v1/virtual_machines/%s", id)
+	return i.c.doRequestAndReturnActivity(ctx, r)
+}

--- a/internal/client/public_cloud_vm_instance_test.go
+++ b/internal/client/public_cloud_vm_instance_test.go
@@ -1,0 +1,476 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+// TestPublicCloudVMInstanceListDecode pins the decode of the bare-array,
+// camelCase GET /vm_instances/v1/virtual_machines response: nested {id,name}
+// refs (az, template, instanceFamily), int fields (vcpu, ramGb, disksSizeGb),
+// the bool guestToolsInstalled, and a nullable backupPolicy that decodes to nil.
+func TestPublicCloudVMInstanceListDecode(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vm_instances/v1/virtual_machines" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+		  {"id":"vm-1","name":"web","status":"running",
+		   "az":{"id":"az-1","name":"fr1-az01"},
+		   "template":{"id":"tpl-1","name":"rocky-9"},
+		   "instanceFamily":{"id":"fam-1","name":"general"},
+		   "vcpu":2,"ramGb":4,"disksSizeGb":40,
+		   "backupPolicy":{"id":"bp-1","name":"daily"},
+		   "guestToolsInstalled":true,
+		   "createdAt":"2026-04-14T12:50:41.881814","updatedAt":"2026-04-14T12:50:41.881814"},
+		  {"id":"vm-2","name":"db","status":"stopped",
+		   "az":{"id":"az-1","name":"fr1-az01"},
+		   "template":{"id":"tpl-1","name":"rocky-9"},
+		   "instanceFamily":{"id":"fam-1","name":"general"},
+		   "vcpu":1,"ramGb":2,"disksSizeGb":20,
+		   "backupPolicy":null,
+		   "guestToolsInstalled":false,
+		   "createdAt":"2026-04-14T12:50:41.881814","updatedAt":"2026-04-14T12:50:41.881814"}
+		]`))
+	})
+
+	vms, err := c.PublicCloudVM().Instance().List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("want 2 vms, got %d", len(vms))
+	}
+	first := vms[0]
+	if first.ID != "vm-1" || first.Name != "web" || first.Status != "running" {
+		t.Fatalf("scalar fields not decoded: %+v", first)
+	}
+	if first.AZ.ID != "az-1" || first.AZ.Name != "fr1-az01" {
+		t.Fatalf("az ref not decoded: %+v", first.AZ)
+	}
+	if first.Template.ID != "tpl-1" || first.InstanceFamily.ID != "fam-1" {
+		t.Fatalf("template/family refs not decoded: %+v", first)
+	}
+	if first.VCPU != 2 || first.RAMGb != 4 || first.DisksSizeGb != 40 {
+		t.Fatalf("int fields not decoded: vcpu=%d ramGb=%d disksSizeGb=%d", first.VCPU, first.RAMGb, first.DisksSizeGb)
+	}
+	if !first.GuestToolsInstalled {
+		t.Fatalf("guestToolsInstalled should decode to true")
+	}
+	if first.BackupPolicy == nil || first.BackupPolicy.ID != "bp-1" {
+		t.Fatalf("backupPolicy should decode to a non-nil ref: %+v", first.BackupPolicy)
+	}
+	if vms[1].BackupPolicy != nil {
+		t.Fatalf("a null backupPolicy must decode to nil, got %+v", vms[1].BackupPolicy)
+	}
+}
+
+// TestPublicCloudVMInstanceListPaginates is the E0-6 mutation-killer: the client
+// MUST page through the full result set (limit+offset), not return only the
+// first page nor loop forever. The stub serves a dataset of pageSize+extra items;
+// a correct client fetches page 0 (full) and page 1 (short) and stops.
+func TestPublicCloudVMInstanceListPaginates(t *testing.T) {
+	ctx := context.Background()
+	const total = publicCloudVMInstanceListPageSize + 3 // 203: two pages, second short
+
+	var offsetsSeen []int
+	var limitsSeen []int
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		offsetsSeen = append(offsetsSeen, offset)
+		limitsSeen = append(limitsSeen, limit)
+
+		page := []map[string]any{}
+		for n := offset; n < offset+limit && n < total; n++ {
+			page = append(page, map[string]any{"id": fmt.Sprintf("vm-%d", n), "name": fmt.Sprintf("vm%d", n)})
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(page)
+	})
+
+	vms, err := c.PublicCloudVM().Instance().List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(vms) != total {
+		t.Fatalf("pagination lost items: want %d, got %d (a non-paginating client would return %d)", total, len(vms), publicCloudVMInstanceListPageSize)
+	}
+	// Order is preserved across pages and every item is distinct.
+	if vms[0].ID != "vm-0" || vms[total-1].ID != fmt.Sprintf("vm-%d", total-1) {
+		t.Fatalf("page concatenation order wrong: first=%s last=%s", vms[0].ID, vms[total-1].ID)
+	}
+	if len(offsetsSeen) != 2 || offsetsSeen[0] != 0 || offsetsSeen[1] != publicCloudVMInstanceListPageSize {
+		t.Fatalf("offsets seen = %v, want [0 %d]", offsetsSeen, publicCloudVMInstanceListPageSize)
+	}
+	for _, l := range limitsSeen {
+		if l != publicCloudVMInstanceListPageSize {
+			t.Fatalf("every page must request limit=%d, got %v", publicCloudVMInstanceListPageSize, limitsSeen)
+		}
+	}
+}
+
+// TestPublicCloudVMInstanceListRefusesRunawayPagination is the E0-6 fail-closed
+// guard: if the server ignores `offset` and keeps returning the same full page,
+// the client must ERROR after a bounded number of requests — never loop forever
+// (unbounded memory / spin) and never silently truncate. Deleting the progress
+// guard turns this RED with an infinite loop.
+func TestPublicCloudVMInstanceListRefusesRunawayPagination(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// Ignore offset entirely: always return the SAME full page of distinct ids.
+		page := make([]map[string]any, publicCloudVMInstanceListPageSize)
+		for n := 0; n < publicCloudVMInstanceListPageSize; n++ {
+			page[n] = map[string]any{"id": fmt.Sprintf("vm-%d", n)}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(page)
+	})
+
+	_, err := c.PublicCloudVM().Instance().List(ctx, nil)
+	if err == nil {
+		t.Fatal("a server that ignores offset (repeats a full page) must fail closed, not loop or truncate")
+	}
+	if calls != 2 {
+		t.Fatalf("runaway must be caught after exactly 2 pages (first full page of new ids, second all-duplicate), got %d calls", calls)
+	}
+}
+
+// TestPublicCloudVMInstanceListStrictLaterPagePartial pins that the strict
+// 200-only contract holds across EVERY page: a 206 on a later page (after a full
+// 200-OK first page) must fail closed, not return the partial-but-first page as a
+// complete listing (which E0-9 could misread as proof of absence).
+func TestPublicCloudVMInstanceListStrictLaterPagePartial(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		if offset == 0 {
+			page := make([]map[string]any, publicCloudVMInstanceListPageSize)
+			for n := 0; n < publicCloudVMInstanceListPageSize; n++ {
+				page[n] = map[string]any{"id": fmt.Sprintf("vm-%d", n)}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(page)
+			return
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte(`[{"id":"vm-200"}]`))
+	})
+	if _, err := c.PublicCloudVM().Instance().ListStrict(ctx, nil); err == nil {
+		t.Fatal("a 206 on a later page must fail closed (strict 200-only across all pages)")
+	}
+}
+
+// TestPublicCloudVMInstanceListFilters pins the mapping of the filter struct to
+// query parameters (including familyId, whose query name differs from the create
+// body's instanceFamilyId).
+func TestPublicCloudVMInstanceListFilters(t *testing.T) {
+	ctx := context.Background()
+	var q url.Values
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		q = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	_, err := c.PublicCloudVM().Instance().List(ctx, &PublicCloudVMInstanceFilter{
+		Name:               "web",
+		Status:             "running",
+		AvailabilityZoneID: "az-1",
+		FamilyID:           "fam-1",
+		OrderBy:            "name",
+		OrderDir:           "asc",
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := map[string]string{
+		"name":               "web",
+		"status":             "running",
+		"availabilityZoneId": "az-1",
+		"familyId":           "fam-1",
+		"orderBy":            "name",
+		"orderDir":           "asc",
+	}
+	for k, v := range want {
+		if got := q.Get(k); got != v {
+			t.Fatalf("query %q = %q, want %q (full query: %v)", k, got, v, q)
+		}
+	}
+}
+
+// TestPublicCloudVMInstanceListStrict pins the E0-9 evidence channel: only a
+// complete HTTP 200 is a usable listing. A 206 is partial and MUST fail closed
+// (never accepted as a complete listing that could prove an absence); a 403 is
+// not evidence either.
+func TestPublicCloudVMInstanceListStrict(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 returns the listing", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"vm-1","name":"web"}]`))
+		})
+		vms, err := c.PublicCloudVM().Instance().ListStrict(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListStrict 200: %v", err)
+		}
+		if len(vms) != 1 || vms[0].ID != "vm-1" {
+			t.Fatalf("unexpected listing: %+v", vms)
+		}
+	})
+
+	t.Run("206 partial fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(`[{"id":"vm-1","name":"web"}]`))
+		})
+		if _, err := c.PublicCloudVM().Instance().ListStrict(ctx, nil); err == nil {
+			t.Fatal("a 206 partial listing must fail closed (it cannot prove an absence)")
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		if _, err := c.PublicCloudVM().Instance().ListStrict(ctx, nil); err == nil {
+			t.Fatal("a 403 listing must fail closed")
+		}
+	})
+}
+
+// TestPublicCloudVMInstanceRead pins the state-safety contract of Read: a
+// positive 404 is absence (nil,nil); a 403 (or any other non-OK) fails closed
+// with an error and never maps to absence.
+func TestPublicCloudVMInstanceRead(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 by id decodes", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"vm-1","name":"web","status":"running","vcpu":2,"ramGb":4}`))
+		})
+		vm, err := c.PublicCloudVM().Instance().Read(ctx, "vm-1")
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if vm == nil || vm.ID != "vm-1" || vm.VCPU != 2 {
+			t.Fatalf("bad vm: %+v", vm)
+		}
+	})
+
+	t.Run("404 is absence (nil,nil)", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		vm, err := c.PublicCloudVM().Instance().Read(ctx, "missing")
+		if err != nil {
+			t.Fatalf("404 must not error, got %v", err)
+		}
+		if vm != nil {
+			t.Fatalf("404 must return a nil vm, got %+v", vm)
+		}
+	})
+
+	t.Run("403 fails closed (error, not absence)", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		vm, err := c.PublicCloudVM().Instance().Read(ctx, "denied")
+		if err == nil {
+			t.Fatalf("403 must fail closed with an error, got vm %+v", vm)
+		}
+		if vm != nil {
+			t.Fatalf("403 must not return a vm")
+		}
+	})
+}
+
+// TestPublicCloudVMInstanceCreate pins the create body encoding and the async
+// contract: camelCase keys, powerState passed through, disks[] deliberately
+// absent (the resource never creates disks), and the activityId returned from
+// the Location header.
+func TestPublicCloudVMInstanceCreate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("encodes camelCase body, omits disks, returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Fatalf("body not JSON: %v (%s)", err, raw)
+			}
+			w.Header().Set("Location", "act-create-1")
+			w.WriteHeader(http.StatusCreated)
+		})
+
+		activityID, err := c.PublicCloudVM().Instance().Create(ctx, &CreateVMInstanceRequest{
+			Name:               "web",
+			AvailabilityZoneID: "az-1",
+			TemplateID:         "tpl-1",
+			InstanceFamilyID:   "fam-1",
+			CPU:                2,
+			Memory:             4,
+			BackupPolicyID:     "bp-1",
+			NetworkInterfaces:  []CreateVMInstanceNIC{{DeviceIndex: 0, NetworkID: "net-1"}},
+			PowerState:         "on",
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if activityID != "act-create-1" {
+			t.Fatalf("Create must return the Location activityId, got %q", activityID)
+		}
+		for _, k := range []string{"name", "availabilityZoneId", "templateId", "instanceFamilyId", "cpu", "memory", "backupPolicyId", "networkInterfaces", "powerState"} {
+			if _, ok := body[k]; !ok {
+				t.Fatalf("create body missing camelCase key %q (body: %v)", k, body)
+			}
+		}
+		if _, ok := body["disks"]; ok {
+			t.Fatalf("create body must NOT contain disks[]: the resource never creates disks (body: %v)", body)
+		}
+		nics, ok := body["networkInterfaces"].([]any)
+		if !ok || len(nics) != 1 {
+			t.Fatalf("networkInterfaces not encoded as a 1-element array: %v", body["networkInterfaces"])
+		}
+		nic := nics[0].(map[string]any)
+		if _, ok := nic["deviceIndex"]; !ok {
+			t.Fatalf("nic must encode deviceIndex (camelCase): %v", nic)
+		}
+		if nic["networkId"] != "net-1" {
+			t.Fatalf("nic networkId = %v, want net-1", nic["networkId"])
+		}
+		// ip_address unset and cloud_init nil must be omitted.
+		if _, ok := nic["ipAddress"]; ok {
+			t.Fatalf("an unset ipAddress must be omitted, got %v", nic["ipAddress"])
+		}
+		if _, ok := body["cloudInit"]; ok {
+			t.Fatalf("a nil cloudInit must be omitted, got %v", body["cloudInit"])
+		}
+	})
+
+	t.Run("empty Location fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			// 201 without a Location header: the write was accepted but we cannot
+			// track it -> must error, never return ("", nil).
+			w.WriteHeader(http.StatusCreated)
+		})
+		if _, err := c.PublicCloudVM().Instance().Create(ctx, &CreateVMInstanceRequest{Name: "web"}); err == nil {
+			t.Fatal("a 201 without a Location must fail (untrackable write)")
+		}
+	})
+}
+
+// TestPublicCloudVMInstanceDiffDrivenBodies pins that PATCH and resize send ONLY
+// the changed dimensions (pointer + omitempty), so an update never clobbers an
+// attribute the user did not touch.
+func TestPublicCloudVMInstanceDiffDrivenBodies(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("PatchMetadata with only name omits backupPolicyId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-patch-1")
+			w.WriteHeader(http.StatusCreated)
+		})
+		name := "web2"
+		activityID, err := c.PublicCloudVM().Instance().PatchMetadata(ctx, "vm-1", &PatchVMInstanceRequest{Name: &name})
+		if err != nil {
+			t.Fatalf("PatchMetadata: %v", err)
+		}
+		if activityID != "act-patch-1" {
+			t.Fatalf("want activityId act-patch-1, got %q", activityID)
+		}
+		if body["name"] != "web2" {
+			t.Fatalf("name not sent: %v", body)
+		}
+		if _, ok := body["backupPolicyId"]; ok {
+			t.Fatalf("an unchanged backupPolicyId must be omitted, got %v", body["backupPolicyId"])
+		}
+	})
+
+	t.Run("Resize with only cpu omits memory", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/resize" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-resize-1")
+			w.WriteHeader(http.StatusCreated)
+		})
+		cpu := 4
+		activityID, err := c.PublicCloudVM().Instance().Resize(ctx, "vm-1", &ResizeVMInstanceRequest{CPU: &cpu})
+		if err != nil {
+			t.Fatalf("Resize: %v", err)
+		}
+		if activityID != "act-resize-1" {
+			t.Fatalf("want activityId act-resize-1, got %q", activityID)
+		}
+		if body["cpu"] != float64(4) {
+			t.Fatalf("cpu not sent: %v", body)
+		}
+		if _, ok := body["memory"]; ok {
+			t.Fatalf("an unchanged memory must be omitted, got %v", body["memory"])
+		}
+	})
+}
+
+// TestPublicCloudVMInstancePowerAndDelete pins the method+path of the bodyless
+// power transitions and the delete, and that each returns the Location activityId.
+func TestPublicCloudVMInstancePowerAndDelete(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		call       func(c *Client) (string, error)
+		wantMethod string
+		wantPath   string
+		activityID string
+	}{
+		{"start", func(c *Client) (string, error) { return c.PublicCloudVM().Instance().Start(ctx, "vm-1") }, http.MethodPost, "/vm_instances/v1/virtual_machines/vm-1/start", "act-start"},
+		{"stop", func(c *Client) (string, error) { return c.PublicCloudVM().Instance().Stop(ctx, "vm-1") }, http.MethodPost, "/vm_instances/v1/virtual_machines/vm-1/stop", "act-stop"},
+		{"delete", func(c *Client) (string, error) { return c.PublicCloudVM().Instance().Delete(ctx, "vm-1") }, http.MethodDelete, "/vm_instances/v1/virtual_machines/vm-1", "act-delete"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tc.wantMethod || r.URL.Path != tc.wantPath {
+					t.Errorf("unexpected request: %s %s (want %s %s)", r.Method, r.URL.Path, tc.wantMethod, tc.wantPath)
+				}
+				w.Header().Set("Location", tc.activityID)
+				w.WriteHeader(http.StatusCreated)
+			})
+			got, err := tc.call(c)
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if got != tc.activityID {
+				t.Fatalf("%s activityId = %q, want %q", tc.name, got, tc.activityID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The client layer for the Public Cloud VM Instances resource: `PublicCloudVM().Instance()` — the core writable entity (service `/vm_instances`, mount `/v1/virtual_machines`).

- Reads (`Read`, `List`) reuse the existing HTTP/auth machinery unchanged.
- Writes (`Create`, `PatchMetadata`, `Resize`, `Start`, `Stop`, `Delete`) return the raw `activityId` from the `Location` header via `doRequestAndReturnActivity` — the wait, activity-based id extraction and state-safety orchestration stay in the resource (a later PR).
- `List`/`ListStrict` auto-paginate over `limit`+`offset` (page size 200, the API max) so a tenant with more than one page of VMs is never silently truncated (**E0-6**, #414). A progress guard fails **closed** if the server ignores `offset` (a full page that adds no new id) — never loops, never truncates.
- `ListStrict` applies a 200-only contract on **every** page, so it can serve as the authoritative absence evidence for the resource's Read (**E0-9** foundation): a 206/partial/403 listing fails closed and can never prove a deletion.
- The create body deliberately omits `disks[]`: the resource never creates disks (the template provides the system disk); data disks are the standalone disk resource. PATCH/resize bodies use pointer+omitempty so a diff-driven update sends only the changed dimensions.

## Tests / gates

Unit tests (httptest) pin: bare-array camelCase decode (nested refs, nullable backupPolicy, int/bool); pagination across a full+short page (offsets `[0,200]`); **runaway guard** (ignored-offset server → error after exactly 2 calls, no loop/truncation); filter→query mapping (incl. `familyId`); `ListStrict` 200-only fail-closed on first- **and** later-page 206 and on 403; Read 404=absence / 403=fail-closed; create body camelCase + disks omitted + empty-`Location` failure; PATCH/resize omitempty; power/delete method+path+activityId.

gofmt / `go build ./...` / `go vet` / staticcheck (2025.1.1) clean; coverage ratchet green (internal/client 37.8% vs floor 24.8%).

Adversarial review: Codex (gpt-5.5, read-only) round 1 **NO-GO** (pagination runaway) → fixed with the progress guard → round 2 **GO** (0/0/0). The 201-only and double-close findings were declined with rationale (shared async contract reused ISO; double-close is the codebase-wide idiom, no leak) and accepted by the reviewer.

No user-facing behaviour yet (no resource/datasource) — CHANGELOG deferred to the resource PR.

Refs #424 #414