### PR TITLE
feat(#431): public_cloud_vm disk + snapshot clients (E3-1)

### DIFF
--- a/internal/client/public_cloud_vm_disk.go
+++ b/internal/client/public_cloud_vm_disk.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+type PublicCloudVMDiskClient struct {
+	c *Client
+}
+
+// Disk returns the VM disk sub-client. Disks are VM-scoped
+// (/vm_instances/v1/virtual_machines/{vmID}/disks...); every write is
+// asynchronous (201 + Location:<activityId>). This resource layer manages DATA
+// disks only — the system/primary disk is provided by the template and cannot be
+// created or deleted here.
+func (v *PublicCloudVMClient) Disk() *PublicCloudVMDiskClient {
+	return &PublicCloudVMDiskClient{v.c}
+}
+
+// PublicCloudVMDisk mirrors an element of GET .../disks (camelCase, verified
+// live). Position 0 / IsPrimary true is the system disk; position >= 1 are data
+// disks. StorageType is a storage-type UUID.
+type PublicCloudVMDisk struct {
+	ID          string
+	Position    int
+	Label       string
+	SizeGb      int
+	StorageType string
+	IsPrimary   bool
+}
+
+// publicCloudVMDiskListResponse is the wrapped list shape (verified live):
+// {"vmId": "...", "disks": [...], "total": N}. Total is a pointer so a missing
+// `total` field is distinguishable from a genuine 0: a malformed/empty wrapper
+// ({} or {"disks":[]}) must NOT be accepted as authoritative absence evidence.
+type publicCloudVMDiskListResponse struct {
+	VmID  string
+	Disks []*PublicCloudVMDisk
+	Total *int
+}
+
+// List returns the VM's disks (lenient success contract).
+func (d *PublicCloudVMDiskClient) List(ctx context.Context, vmID string) ([]*PublicCloudVMDisk, error) {
+	return d.list(ctx, vmID, false)
+}
+
+// ListStrict returns the VM's disks with a 200-only contract AND a completeness
+// check (total == len(disks)): a truncated page can never serve as absence
+// evidence. It is the authoritative source for a disk deletion decision (E0-9).
+func (d *PublicCloudVMDiskClient) ListStrict(ctx context.Context, vmID string) ([]*PublicCloudVMDisk, error) {
+	return d.list(ctx, vmID, true)
+}
+
+func (d *PublicCloudVMDiskClient) list(ctx context.Context, vmID string, strict bool) ([]*PublicCloudVMDisk, error) {
+	req := d.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/disks", vmID)
+	resp, err := d.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+
+	if strict {
+		if err := requireHttpCodes(resp, 200); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := requireOK(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	var out publicCloudVMDiskListResponse
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	if strict {
+		if out.Total == nil {
+			return nil, fmt.Errorf("disk listing for virtual machine %s did not report a total; refusing to use a malformed listing as absence evidence", vmID)
+		}
+		if *out.Total != len(out.Disks) {
+			return nil, fmt.Errorf("disk listing for virtual machine %s is incomplete (total %d, %d returned); refusing to use a truncated listing as absence evidence", vmID, *out.Total, len(out.Disks))
+		}
+	}
+	return out.Disks, nil
+}
+
+// Read returns a single disk by id. A positive 404 (disk OR its VM absent) maps
+// to (nil, nil); any other non-OK code (403, 5xx) fails closed with an error.
+func (d *PublicCloudVMDiskClient) Read(ctx context.Context, vmID, diskID string) (*PublicCloudVMDisk, error) {
+	req := d.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/disks/%s", vmID, diskID)
+	resp, err := d.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	found, err := requireNotFoundOrOK(resp, 404)
+	if err != nil || !found {
+		return nil, err
+	}
+
+	var out PublicCloudVMDisk
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateVMDiskRequest is the body of POST .../disks. Only Size is required;
+// StorageType (a storage-type UUID) and Name default server-side when omitted.
+// This endpoint only ever adds a DATA disk.
+type CreateVMDiskRequest struct {
+	Size        int    `json:"size"`
+	StorageType string `json:"storageType,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
+// Create adds a data disk and returns the activityId. The completed activity's
+// result carries the new disk id.
+func (d *PublicCloudVMDiskClient) Create(ctx context.Context, vmID string, req *CreateVMDiskRequest) (string, error) {
+	r := d.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/disks", vmID)
+	r.obj = req
+	return d.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// extendVMDiskRequest is the body of the extend endpoints ({"size": N}).
+type extendVMDiskRequest struct {
+	Size int `json:"size"`
+}
+
+// ExtendById grows a specific disk (grow-only, and the VM must be stopped — both
+// enforced downstream; a violation surfaces as a failed activity). Returns the
+// activityId.
+func (d *PublicCloudVMDiskClient) ExtendById(ctx context.Context, vmID, diskID string, size int) (string, error) {
+	r := d.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/disks/%s/extend", vmID, diskID)
+	r.obj = &extendVMDiskRequest{Size: size}
+	return d.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Delete removes a data disk and returns the activityId. Deleting the primary
+// disk is refused downstream (and guarded by the resource before calling this).
+func (d *PublicCloudVMDiskClient) Delete(ctx context.Context, vmID, diskID string) (string, error) {
+	r := d.c.newRequest("DELETE", "/vm_instances/v1/virtual_machines/%s/disks/%s", vmID, diskID)
+	return d.c.doRequestAndReturnActivity(ctx, r)
+}

--- a/internal/client/public_cloud_vm_disk_test.go
+++ b/internal/client/public_cloud_vm_disk_test.go
@@ -1,0 +1,204 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestPublicCloudVMDiskList(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/disks" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"vmId":"vm-1","total":2,"disks":[
+		  {"id":"d0","position":0,"label":"system","sizeGb":38,"storageType":"st-1","isPrimary":true},
+		  {"id":"d1","position":1,"label":"data","sizeGb":10,"storageType":"st-1","isPrimary":false}
+		]}`))
+	})
+	disks, err := c.PublicCloudVM().Disk().List(ctx, "vm-1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(disks) != 2 {
+		t.Fatalf("want 2 disks, got %d", len(disks))
+	}
+	if disks[0].Position != 0 || !disks[0].IsPrimary || disks[0].SizeGb != 38 {
+		t.Fatalf("system disk not decoded: %+v", disks[0])
+	}
+	if disks[1].ID != "d1" || disks[1].Position != 1 || disks[1].IsPrimary || disks[1].StorageType != "st-1" {
+		t.Fatalf("data disk not decoded: %+v", disks[1])
+	}
+}
+
+// TestPublicCloudVMDiskListStrict pins the E0-9 completeness contract: only a
+// complete 200 listing is absence evidence. A truncated 200 (total > len), a 206
+// and a 403 all fail closed.
+func TestPublicCloudVMDiskListStrict(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("complete 200 returns the disks", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vmId":"vm-1","total":1,"disks":[{"id":"d1","position":1}]}`))
+		})
+		disks, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1")
+		if err != nil || len(disks) != 1 {
+			t.Fatalf("complete listing: err=%v disks=%d", err, len(disks))
+		}
+	})
+
+	t.Run("truncated 200 (total > len) fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vmId":"vm-1","total":5,"disks":[{"id":"d1","position":1}]}`))
+		})
+		if _, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a truncated listing (total>len) must fail closed, not be usable as absence evidence")
+		}
+	})
+
+	t.Run("missing total (malformed/empty wrapper) fails closed", func(t *testing.T) {
+		// {"disks":[]} with no `total` must NOT be read as an authoritative empty
+		// listing: a missing total decodes to 0 and len(nil)==0 would spuriously
+		// prove absence. Kills the int-Total mutant.
+		for _, bad := range []string{`{"disks":[]}`, `{}`} {
+			c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(bad))
+			})
+			if _, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1"); err == nil {
+				t.Fatalf("a listing without a total (%s) must fail closed", bad)
+			}
+		}
+	})
+
+	t.Run("genuine empty listing (total 0 present) is accepted", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vmId":"vm-1","total":0,"disks":[]}`))
+		})
+		disks, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1")
+		if err != nil || len(disks) != 0 {
+			t.Fatalf("a genuine empty listing (total 0) must be accepted, got err=%v disks=%d", err, len(disks))
+		}
+	})
+
+	t.Run("206 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(`{"vmId":"vm-1","total":1,"disks":[{"id":"d1"}]}`))
+		})
+		if _, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a 206 must fail closed")
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().Disk().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a 403 must fail closed")
+		}
+	})
+}
+
+func TestPublicCloudVMDiskRead(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 decodes", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/disks/d1" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"d1","position":1,"label":"data","sizeGb":12,"storageType":"st-1","isPrimary":false}`))
+		})
+		disk, err := c.PublicCloudVM().Disk().Read(ctx, "vm-1", "d1")
+		if err != nil || disk == nil || disk.SizeGb != 12 || disk.IsPrimary {
+			t.Fatalf("bad disk: %+v err=%v", disk, err)
+		}
+	})
+
+	t.Run("404 is absence", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusNotFound) })
+		disk, err := c.PublicCloudVM().Disk().Read(ctx, "vm-1", "missing")
+		if err != nil || disk != nil {
+			t.Fatalf("404 must be (nil,nil), got disk=%+v err=%v", disk, err)
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().Disk().Read(ctx, "vm-1", "denied"); err == nil {
+			t.Fatal("403 must fail closed")
+		}
+	})
+}
+
+func TestPublicCloudVMDiskWrites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create encodes camelCase body, omits empty storageType/name, returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/disks" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-disk")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().Disk().Create(ctx, "vm-1", &CreateVMDiskRequest{Size: 10})
+		if err != nil || id != "act-disk" {
+			t.Fatalf("Create: id=%q err=%v", id, err)
+		}
+		if body["size"] != float64(10) {
+			t.Fatalf("size not sent: %v", body)
+		}
+		if _, ok := body["storageType"]; ok {
+			t.Fatalf("empty storageType must be omitted: %v", body)
+		}
+		if _, ok := body["name"]; ok {
+			t.Fatalf("empty name must be omitted: %v", body)
+		}
+	})
+
+	t.Run("extend posts {size} to /extend and returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/disks/d1/extend" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-extend")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().Disk().ExtendById(ctx, "vm-1", "d1", 20)
+		if err != nil || id != "act-extend" {
+			t.Fatalf("ExtendById: id=%q err=%v", id, err)
+		}
+		if body["size"] != float64(20) {
+			t.Fatalf("extend size not sent: %v", body)
+		}
+	})
+
+	t.Run("delete DELETEs the disk and returns activityId", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/disks/d1" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.Header().Set("Location", "act-del")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().Disk().Delete(ctx, "vm-1", "d1")
+		if err != nil || id != "act-del" {
+			t.Fatalf("Delete: id=%q err=%v", id, err)
+		}
+	})
+}

--- a/internal/client/public_cloud_vm_snapshot.go
+++ b/internal/client/public_cloud_vm_snapshot.go
@@ -1,0 +1,123 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+type PublicCloudVMSnapshotClient struct {
+	c *Client
+}
+
+// Snapshot returns the VM snapshot sub-client. Snapshots are VM-scoped
+// (/vm_instances/v1/virtual_machines/{vmID}/snapshots...); create and delete are
+// asynchronous (201 + Location:<activityId>). Revert is intentionally not exposed.
+func (v *PublicCloudVMClient) Snapshot() *PublicCloudVMSnapshotClient {
+	return &PublicCloudVMSnapshotClient{v.c}
+}
+
+// PublicCloudVMSnapshot mirrors an element of GET .../snapshots (camelCase,
+// verified live). There is no size/description field.
+type PublicCloudVMSnapshot struct {
+	ID        string
+	VmID      string
+	TenantID  string
+	Name      string
+	Status    string
+	CreatedAt string
+}
+
+// publicCloudVMSnapshotListResponse is the wrapped list shape (verified live):
+// {"snapshots": [...], "total": N}. Total is a pointer so a missing `total` field
+// is distinguishable from a genuine 0: a malformed/empty wrapper must NOT be
+// accepted as authoritative absence evidence.
+type publicCloudVMSnapshotListResponse struct {
+	Snapshots []*PublicCloudVMSnapshot
+	Total     *int
+}
+
+// List returns the VM's snapshots (lenient success contract).
+func (s *PublicCloudVMSnapshotClient) List(ctx context.Context, vmID string) ([]*PublicCloudVMSnapshot, error) {
+	return s.list(ctx, vmID, false)
+}
+
+// ListStrict returns the VM's snapshots with a 200-only contract AND a
+// completeness check (total == len): the authoritative absence evidence (E0-9).
+func (s *PublicCloudVMSnapshotClient) ListStrict(ctx context.Context, vmID string) ([]*PublicCloudVMSnapshot, error) {
+	return s.list(ctx, vmID, true)
+}
+
+func (s *PublicCloudVMSnapshotClient) list(ctx context.Context, vmID string, strict bool) ([]*PublicCloudVMSnapshot, error) {
+	req := s.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/snapshots", vmID)
+	resp, err := s.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+
+	if strict {
+		if err := requireHttpCodes(resp, 200); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := requireOK(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	var out publicCloudVMSnapshotListResponse
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	if strict {
+		if out.Total == nil {
+			return nil, fmt.Errorf("snapshot listing for virtual machine %s did not report a total; refusing to use a malformed listing as absence evidence", vmID)
+		}
+		if *out.Total != len(out.Snapshots) {
+			return nil, fmt.Errorf("snapshot listing for virtual machine %s is incomplete (total %d, %d returned); refusing to use a truncated listing as absence evidence", vmID, *out.Total, len(out.Snapshots))
+		}
+	}
+	return out.Snapshots, nil
+}
+
+// Read returns a single snapshot by id. A positive 404 maps to (nil, nil); any
+// other non-OK code (403, 5xx) fails closed with an error.
+func (s *PublicCloudVMSnapshotClient) Read(ctx context.Context, vmID, snapshotID string) (*PublicCloudVMSnapshot, error) {
+	req := s.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/snapshots/%s", vmID, snapshotID)
+	resp, err := s.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	found, err := requireNotFoundOrOK(resp, 404)
+	if err != nil || !found {
+		return nil, err
+	}
+
+	var out PublicCloudVMSnapshot
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// createVMSnapshotRequest is the body of POST .../snapshots ({"name": "..."} —
+// the only accepted field).
+type createVMSnapshotRequest struct {
+	Name string `json:"name"`
+}
+
+// Create takes a snapshot and returns the activityId. The completed activity's
+// result / concernedItems ("snapshot") carries the new snapshot id.
+func (s *PublicCloudVMSnapshotClient) Create(ctx context.Context, vmID, name string) (string, error) {
+	r := s.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/snapshots", vmID)
+	r.obj = &createVMSnapshotRequest{Name: name}
+	return s.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Delete removes a snapshot and returns the activityId (the completed activity's
+// result is the vmId, not the snapshotId).
+func (s *PublicCloudVMSnapshotClient) Delete(ctx context.Context, vmID, snapshotID string) (string, error) {
+	r := s.c.newRequest("DELETE", "/vm_instances/v1/virtual_machines/%s/snapshots/%s", vmID, snapshotID)
+	return s.c.doRequestAndReturnActivity(ctx, r)
+}

--- a/internal/client/public_cloud_vm_snapshot_test.go
+++ b/internal/client/public_cloud_vm_snapshot_test.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestPublicCloudVMSnapshotList(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/snapshots" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total":1,"snapshots":[{"id":"s1","vmId":"vm-1","tenantId":"t1","name":"snap","status":"available","createdAt":"2026-07-01T12:00:00"}]}`))
+	})
+	snaps, err := c.PublicCloudVM().Snapshot().List(ctx, "vm-1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].ID != "s1" || snaps[0].VmID != "vm-1" || snaps[0].Name != "snap" || snaps[0].Status != "available" {
+		t.Fatalf("snapshot not decoded: %+v", snaps)
+	}
+}
+
+func TestPublicCloudVMSnapshotListStrict(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("truncated 200 (total > len) fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total":3,"snapshots":[{"id":"s1"}]}`))
+		})
+		if _, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a truncated snapshot listing must fail closed")
+		}
+	})
+
+	t.Run("206 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(`{"total":1,"snapshots":[{"id":"s1"}]}`))
+		})
+		if _, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a 206 must fail closed")
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1"); err == nil {
+			t.Fatal("a 403 must fail closed")
+		}
+	})
+
+	t.Run("missing total (malformed wrapper) fails closed", func(t *testing.T) {
+		for _, bad := range []string{`{"snapshots":[]}`, `{}`} {
+			c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(bad))
+			})
+			if _, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1"); err == nil {
+				t.Fatalf("a listing without a total (%s) must fail closed", bad)
+			}
+		}
+	})
+
+	t.Run("genuine empty listing (total 0 present) is accepted", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total":0,"snapshots":[]}`))
+		})
+		snaps, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1")
+		if err != nil || len(snaps) != 0 {
+			t.Fatalf("a genuine empty listing (total 0) must be accepted, got err=%v snaps=%d", err, len(snaps))
+		}
+	})
+
+	t.Run("complete 200 returns the snapshots", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total":1,"snapshots":[{"id":"s1"}]}`))
+		})
+		snaps, err := c.PublicCloudVM().Snapshot().ListStrict(ctx, "vm-1")
+		if err != nil || len(snaps) != 1 {
+			t.Fatalf("complete listing: err=%v snaps=%d", err, len(snaps))
+		}
+	})
+}
+
+func TestPublicCloudVMSnapshotRead(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 decodes", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/snapshots/s1" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"s1","vmId":"vm-1","name":"snap","status":"available"}`))
+		})
+		snap, err := c.PublicCloudVM().Snapshot().Read(ctx, "vm-1", "s1")
+		if err != nil || snap == nil || snap.Name != "snap" {
+			t.Fatalf("bad snapshot: %+v err=%v", snap, err)
+		}
+	})
+
+	t.Run("404 is absence", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusNotFound) })
+		snap, err := c.PublicCloudVM().Snapshot().Read(ctx, "vm-1", "missing")
+		if err != nil || snap != nil {
+			t.Fatalf("404 must be (nil,nil), got snap=%+v err=%v", snap, err)
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().Snapshot().Read(ctx, "vm-1", "denied"); err == nil {
+			t.Fatal("403 must fail closed")
+		}
+	})
+}
+
+func TestPublicCloudVMSnapshotWrites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create posts {name} and returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/snapshots" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-snap")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().Snapshot().Create(ctx, "vm-1", "snap")
+		if err != nil || id != "act-snap" {
+			t.Fatalf("Create: id=%q err=%v", id, err)
+		}
+		if body["name"] != "snap" {
+			t.Fatalf("name not sent: %v", body)
+		}
+	})
+
+	t.Run("delete DELETEs the snapshot and returns activityId", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/snapshots/s1" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.Header().Set("Location", "act-snap-del")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().Snapshot().Delete(ctx, "vm-1", "s1")
+		if err != nil || id != "act-snap-del" {
+			t.Fatalf("Delete: id=%q err=%v", id, err)
+		}
+	})
+}


### PR DESCRIPTION
## What

The VM-scoped **disk** and **snapshot** sub-clients (`PublicCloudVM().Disk()` / `.Snapshot()`) — the read+write layer for the E3 resources (which come in the next PRs).

- **Disk**: `List`/`ListStrict` (decode the live `{vmId, disks, total}` wrapper), `Read` (404=absence / 403=fail-closed), `Create` (data disk), `ExtendById` (grow; VM-stopped enforced downstream), `Delete` — writes return the `activityId`. The disk model exposes `id/position/label/sizeGb/storageType/isPrimary` (position 0 / isPrimary = the system disk).
- **Snapshot**: `List`/`ListStrict` (`{snapshots, total}`), `Read`, `Create({name})`, `Delete`. No revert (out of scope).

**`ListStrict` is the authoritative absence evidence** for the E3 resources' E0-9 rule: it is 200-only **and** checks completeness (`total == len(items)`), so a truncated page can never be mistaken for "the child is gone".

## Tests / gates

Unit tests (httptest): wrapper decode; `ListStrict` truncated (`total>len`) / 206 / 403 all fail closed; `Read` 404=absence / 403=fail-closed; create camelCase body with omitted empty `storageType`/`name`; extend `{size}` to `/extend`; delete method+path; every write returns the `Location` activityId. gofmt / vet / build / staticcheck clean; ratchet green (internal/client 39.1% vs floor 24.8%).

Live shapes verified by a DEV probe (VM→disk→extend→snapshot→cleanup, 0 orphan). Adversarial review: Codex (gpt-5.5, read-only) — running.

Refs #431