### PR TITLE
feat(#436): public_cloud_vm network + network_adapter client (E4-1)

### DIFF
--- a/internal/client/public_cloud_vm_network.go
+++ b/internal/client/public_cloud_vm_network.go
@@ -1,0 +1,87 @@
+package client
+
+import "context"
+
+type PublicCloudVMNetworkClient struct {
+	c *Client
+}
+
+// Network returns the VM network catalogue sub-client. Networks are a read-only
+// catalogue provisioned upstream (Saturne/VPC): the provider never creates or
+// deletes them, and both endpoints (GET /networks, GET /networks/{id}) are
+// synchronous — there is no activity to poll.
+func (v *PublicCloudVMClient) Network() *PublicCloudVMNetworkClient {
+	return &PublicCloudVMNetworkClient{v.c}
+}
+
+// PublicCloudVMNetwork mirrors an element of GET /networks. The live shape is a
+// bare JSON array of {"id","name"} (verified live). The spec documents an
+// optional `vpc` block, but no VPC network was observable on the live platform,
+// so modelling it is deferred rather than freezing an unverified schema shape.
+type PublicCloudVMNetwork struct {
+	ID   string
+	Name string
+}
+
+// List returns the network catalogue (bare JSON array, lenient success contract).
+func (n *PublicCloudVMNetworkClient) List(ctx context.Context) ([]*PublicCloudVMNetwork, error) {
+	return n.list(ctx, false)
+}
+
+// ListStrict returns the catalogue with a 200-only contract. The response is a
+// bare array with no `total`, so there is no completeness cross-check to run —
+// and a read-only catalogue is never the basis for a state-drop decision, so a
+// 200-only contract is sufficient.
+func (n *PublicCloudVMNetworkClient) ListStrict(ctx context.Context) ([]*PublicCloudVMNetwork, error) {
+	return n.list(ctx, true)
+}
+
+func (n *PublicCloudVMNetworkClient) list(ctx context.Context, strict bool) ([]*PublicCloudVMNetwork, error) {
+	req := n.c.newRequest("GET", "/vm_instances/v1/networks")
+	resp, err := n.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+
+	if strict {
+		if err := requireHttpCodes(resp, 200); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := requireOK(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	var out []*PublicCloudVMNetwork
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Read returns a single network by id. Absence does NOT surface as a clean 404:
+// the live platform returns 400 (well-formed unknown id) or 500 (nil UUID), so
+// any non-200 fails closed with an error. That is correct for a read-only data
+// source — it errors on a bad id rather than dropping anything from state.
+func (n *PublicCloudVMNetworkClient) Read(ctx context.Context, id string) (*PublicCloudVMNetwork, error) {
+	req := n.c.newRequest("GET", "/vm_instances/v1/networks/%s", id)
+	resp, err := n.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	// 200 only: absence on this endpoint is 400/500 (never a clean 404), and a
+	// read-only lookup has no reason to accept 201/206 — anything but 200 fails
+	// closed with an error rather than decoding a partial/unexpected body.
+	if err := requireHttpCodes(resp, 200); err != nil {
+		return nil, err
+	}
+
+	var out PublicCloudVMNetwork
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/client/public_cloud_vm_network_adapter.go
+++ b/internal/client/public_cloud_vm_network_adapter.go
@@ -1,0 +1,180 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type PublicCloudVMNetworkAdapterClient struct {
+	c *Client
+}
+
+// NetworkAdapter returns the VM network-adapter (NIC) sub-client. NICs are
+// VM-scoped (/vm_instances/v1/virtual_machines/{vmID}/network_adapters); every
+// write is asynchronous (201 + Location:<activityId>). The broker remaps the
+// worker's nic_id to `id`.
+func (v *PublicCloudVMClient) NetworkAdapter() *PublicCloudVMNetworkAdapterClient {
+	return &PublicCloudVMNetworkAdapterClient{v.c}
+}
+
+// PublicCloudVMNetworkAdapter mirrors an element of GET .../network_adapters
+// (camelCase, verified live). ipv4Address/ipv6Address arrive as JSON null until
+// the guest agent reports them, decoding to "". The spec's `vif_uuid` is NOT
+// returned by the live API (neither the list nor the single GET) and is
+// intentionally not modelled.
+type PublicCloudVMNetworkAdapter struct {
+	ID              string
+	DeviceIndex     int
+	NetworkID       string
+	NetworkName     string
+	Type            string
+	ProvisionStatus string
+	MacAddress      string
+	IPv4Address     string
+	IPv6Address     string
+}
+
+// publicCloudVMNetworkAdapterListResponse is the wrapped list shape (verified
+// live): {"vmId": "...", "networks": [...], "total": N}. Total is a pointer so a
+// missing `total` is distinguishable from a genuine 0 — a malformed wrapper ({}
+// or {"networks":[]}) must NOT count as authoritative absence evidence.
+type publicCloudVMNetworkAdapterListResponse struct {
+	VmID     string
+	Networks []*PublicCloudVMNetworkAdapter
+	Total    *int
+}
+
+// List returns the VM's NICs (lenient success contract).
+func (a *PublicCloudVMNetworkAdapterClient) List(ctx context.Context, vmID string) ([]*PublicCloudVMNetworkAdapter, error) {
+	return a.list(ctx, vmID, false)
+}
+
+// ListStrict returns the VM's NICs with a 200-only contract AND a completeness
+// check (total == len(networks)) plus structural integrity checks: a truncated
+// page, a wrapper scoped to a different vmId, or a malformed entry can never
+// serve as absence evidence. It is the authoritative source for a NIC deletion
+// decision (E0-9) — the single-GET code (400 for an unknown NIC) is never trusted
+// as absence.
+func (a *PublicCloudVMNetworkAdapterClient) ListStrict(ctx context.Context, vmID string) ([]*PublicCloudVMNetworkAdapter, error) {
+	return a.list(ctx, vmID, true)
+}
+
+func (a *PublicCloudVMNetworkAdapterClient) list(ctx context.Context, vmID string, strict bool) ([]*PublicCloudVMNetworkAdapter, error) {
+	req := a.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/network_adapters", vmID)
+	resp, err := a.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+
+	if strict {
+		if err := requireHttpCodes(resp, 200); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := requireOK(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	var out publicCloudVMNetworkAdapterListResponse
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, err
+	}
+	if strict {
+		if out.Total == nil {
+			return nil, fmt.Errorf("network adapter listing for virtual machine %s did not report a total; refusing to use a malformed listing as absence evidence", vmID)
+		}
+		if *out.Total != len(out.Networks) {
+			return nil, fmt.Errorf("network adapter listing for virtual machine %s is incomplete (total %d, %d returned); refusing to use a truncated listing as absence evidence", vmID, *out.Total, len(out.Networks))
+		}
+		// Structural integrity: a wrapper whose vmId does not match the requested
+		// VM, or a nil / empty-id entry, cannot be trusted as a complete-and-correct
+		// listing for an absence decision. Compared case-insensitively because an id
+		// written upper-case (import/config) must match the platform's lower-case id.
+		if out.VmID != "" && !strings.EqualFold(out.VmID, vmID) {
+			return nil, fmt.Errorf("network adapter listing reported vmId %q for a request scoped to virtual machine %s; refusing an inconsistent listing", out.VmID, vmID)
+		}
+		for i, nic := range out.Networks {
+			if nic == nil || nic.ID == "" {
+				return nil, fmt.Errorf("network adapter listing for virtual machine %s contains a malformed entry at index %d; refusing an untrustworthy listing", vmID, i)
+			}
+		}
+	}
+	return out.Networks, nil
+}
+
+// Read returns a single NIC by id. A positive 404 maps to (nil, nil); every other
+// non-OK code fails closed with an error. NOTE (verified live): an unknown NIC
+// returns 400, not 404 — so a caller must NEVER treat a Read error as absence.
+// The resource's Read falls back to a complete ListStrict for any drop decision.
+func (a *PublicCloudVMNetworkAdapterClient) Read(ctx context.Context, vmID, nicID string) (*PublicCloudVMNetworkAdapter, error) {
+	req := a.c.newRequest("GET", "/vm_instances/v1/virtual_machines/%s/network_adapters/%s", vmID, nicID)
+	resp, err := a.c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponseBody(resp)
+	// Explicit contract (stricter than requireNotFoundOrOK, which also accepts
+	// 206): ONLY a 200 is a found NIC, ONLY a clean 404 is absence. Everything
+	// else — notably the 400 the live API returns for an unknown NIC, and any
+	// 206 — fails closed. A caller must never read a non-404 error as absence:
+	// the resource confirms a drop via a complete ListStrict, not via this code.
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var out PublicCloudVMNetworkAdapter
+		if err := decodeBody(resp, &out); err != nil {
+			return nil, err
+		}
+		return &out, nil
+	case http.StatusNotFound:
+		return nil, nil
+	default:
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
+}
+
+// CreateVMNetworkAdapterRequest is the body of POST .../network_adapters.
+// IPAddress is only honoured for VPC networks (the worker registers a static IP
+// only when the network type is VPC); it is silently ignored on Private Backbone
+// networks, so it is omitted when empty.
+type CreateVMNetworkAdapterRequest struct {
+	NetworkID   string `json:"networkId"`
+	DeviceIndex int    `json:"deviceIndex"`
+	IPAddress   string `json:"ipAddress,omitempty"`
+}
+
+// Create attaches a NIC and returns the activityId. The completed activity's
+// result — and a concernedItem of type network_adapter — carries the new NIC id.
+func (a *PublicCloudVMNetworkAdapterClient) Create(ctx context.Context, vmID string, req *CreateVMNetworkAdapterRequest) (string, error) {
+	r := a.c.newRequest("POST", "/vm_instances/v1/virtual_machines/%s/network_adapters", vmID)
+	r.obj = req
+	return a.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// ChangeVMNetworkAdapterRequest is the body of PATCH .../{nicID} (change-network).
+// Only the target network (and an optional VPC static IP) can change; deviceIndex
+// is immutable.
+type ChangeVMNetworkAdapterRequest struct {
+	NetworkID string `json:"networkId"`
+	IPAddress string `json:"ipAddress,omitempty"`
+}
+
+// ChangeNetwork re-points a NIC to another network (async). The completed
+// activity's result is the vmId (NOT the NIC id, which is unchanged). Requires the
+// VM to be stopped — enforced by the worker; a running VM fails the activity.
+func (a *PublicCloudVMNetworkAdapterClient) ChangeNetwork(ctx context.Context, vmID, nicID string, req *ChangeVMNetworkAdapterRequest) (string, error) {
+	r := a.c.newRequest("PATCH", "/vm_instances/v1/virtual_machines/%s/network_adapters/%s", vmID, nicID)
+	r.obj = req
+	return a.c.doRequestAndReturnActivity(ctx, r)
+}
+
+// Delete detaches a NIC (async) and returns the activityId. The completed
+// activity's result is the vmId. Requires the VM to be stopped (enforced by the
+// worker; a running VM fails the activity — guarded by the resource beforehand).
+func (a *PublicCloudVMNetworkAdapterClient) Delete(ctx context.Context, vmID, nicID string) (string, error) {
+	r := a.c.newRequest("DELETE", "/vm_instances/v1/virtual_machines/%s/network_adapters/%s", vmID, nicID)
+	return a.c.doRequestAndReturnActivity(ctx, r)
+}

--- a/internal/client/public_cloud_vm_network_adapter_test.go
+++ b/internal/client/public_cloud_vm_network_adapter_test.go
@@ -1,0 +1,290 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestPublicCloudVMNetworkAdapterList(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/network_adapters" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		// Wrapper {vmId,networks,total} (verified live); ipv4/ipv6 arrive as null.
+		_, _ = w.Write([]byte(`{"vmId":"vm-1","total":1,"networks":[
+		  {"deviceIndex":0,"networkId":"net-1","networkName":"ahn-1","type":"private_backbone","provisionStatus":"provisioned","macAddress":"12:af:bf:c9:90:b0","ipv4Address":null,"ipv6Address":null,"id":"nic-1"}
+		]}`))
+	})
+	nics, err := c.PublicCloudVM().NetworkAdapter().List(ctx, "vm-1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(nics) != 1 {
+		t.Fatalf("want 1 nic, got %d", len(nics))
+	}
+	n := nics[0]
+	if n.ID != "nic-1" || n.DeviceIndex != 0 || n.NetworkID != "net-1" || n.NetworkName != "ahn-1" {
+		t.Fatalf("nic identity not decoded: %+v", n)
+	}
+	if n.Type != "private_backbone" || n.ProvisionStatus != "provisioned" || n.MacAddress != "12:af:bf:c9:90:b0" {
+		t.Fatalf("nic attrs not decoded: %+v", n)
+	}
+	// null ipv4/ipv6 must decode to the empty string, never fail the decode.
+	if n.IPv4Address != "" || n.IPv6Address != "" {
+		t.Fatalf("null ip must decode to empty string, got v4=%q v6=%q", n.IPv4Address, n.IPv6Address)
+	}
+}
+
+// TestPublicCloudVMNetworkAdapterListStrict pins the E0-9 completeness + structural
+// integrity contract: only a complete, self-consistent 200 listing is absence
+// evidence. Truncation, a missing total, a mismatched vmId, a malformed entry, a
+// 206 and a 403 all fail closed.
+func TestPublicCloudVMNetworkAdapterListStrict(t *testing.T) {
+	ctx := context.Background()
+
+	strictWith := func(body string, code int) error {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+			_, _ = w.Write([]byte(body))
+		})
+		_, err := c.PublicCloudVM().NetworkAdapter().ListStrict(ctx, "vm-1")
+		return err
+	}
+
+	t.Run("complete 200 returns the nics", func(t *testing.T) {
+		if err := strictWith(`{"vmId":"vm-1","total":1,"networks":[{"id":"nic-1","deviceIndex":0}]}`, http.StatusOK); err != nil {
+			t.Fatalf("complete listing must succeed: %v", err)
+		}
+	})
+
+	t.Run("truncated (total>len) fails closed", func(t *testing.T) {
+		if err := strictWith(`{"vmId":"vm-1","total":5,"networks":[{"id":"nic-1"}]}`, http.StatusOK); err == nil {
+			t.Fatal("a truncated listing (total>len) must fail closed")
+		}
+	})
+
+	t.Run("missing total fails closed", func(t *testing.T) {
+		for _, bad := range []string{`{"vmId":"vm-1","networks":[]}`, `{}`} {
+			if err := strictWith(bad, http.StatusOK); err == nil {
+				t.Fatalf("a listing without a total (%s) must fail closed", bad)
+			}
+		}
+	})
+
+	t.Run("genuine empty (total 0) is accepted", func(t *testing.T) {
+		if err := strictWith(`{"vmId":"vm-1","total":0,"networks":[]}`, http.StatusOK); err != nil {
+			t.Fatalf("a genuine empty listing (total 0) must be accepted: %v", err)
+		}
+	})
+
+	t.Run("vmId mismatch fails closed", func(t *testing.T) {
+		// A listing scoped to another VM cannot prove this VM's NIC absent.
+		if err := strictWith(`{"vmId":"vm-OTHER","total":0,"networks":[]}`, http.StatusOK); err == nil {
+			t.Fatal("a wrapper vmId that does not match the requested VM must fail closed")
+		}
+	})
+
+	t.Run("vmId case-insensitive match is accepted", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vmId":"VM-1","total":0,"networks":[]}`))
+		})
+		if _, err := c.PublicCloudVM().NetworkAdapter().ListStrict(ctx, "vm-1"); err != nil {
+			t.Fatalf("an upper-case vmId must still match case-insensitively: %v", err)
+		}
+	})
+
+	t.Run("malformed entry (empty id) fails closed", func(t *testing.T) {
+		if err := strictWith(`{"vmId":"vm-1","total":1,"networks":[{"id":"","deviceIndex":0}]}`, http.StatusOK); err == nil {
+			t.Fatal("a listing with an empty-id entry must fail closed")
+		}
+	})
+
+	t.Run("null entry fails closed", func(t *testing.T) {
+		// A JSON null decodes to a nil *PublicCloudVMNetworkAdapter; it must be
+		// rejected rather than panic or be silently counted toward completeness.
+		if err := strictWith(`{"vmId":"vm-1","total":1,"networks":[null]}`, http.StatusOK); err == nil {
+			t.Fatal("a listing with a null entry must fail closed")
+		}
+	})
+
+	t.Run("empty wrapper vmId is accepted", func(t *testing.T) {
+		// An absent vmId in the wrapper is allowed (we only reject a NON-empty
+		// mismatch); a complete listing must still be usable.
+		if err := strictWith(`{"total":0,"networks":[]}`, http.StatusOK); err != nil {
+			t.Fatalf("an empty wrapper vmId must be accepted: %v", err)
+		}
+	})
+
+	t.Run("206 fails closed", func(t *testing.T) {
+		if err := strictWith(`{"vmId":"vm-1","total":1,"networks":[{"id":"nic-1"}]}`, http.StatusPartialContent); err == nil {
+			t.Fatal("a 206 must fail closed")
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		if err := strictWith(``, http.StatusForbidden); err == nil {
+			t.Fatal("a 403 must fail closed")
+		}
+	})
+}
+
+// TestPublicCloudVMNetworkAdapterRead pins that a 404 is absence but a 400 (what
+// the live platform returns for an unknown NIC) is a fail-closed error, never a
+// silent absent — so the resource can never drop state on a 400.
+func TestPublicCloudVMNetworkAdapterRead(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 decodes", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/network_adapters/nic-1" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"nic-1","deviceIndex":1,"networkId":"net-1","type":"vpc"}`))
+		})
+		nic, err := c.PublicCloudVM().NetworkAdapter().Read(ctx, "vm-1", "nic-1")
+		if err != nil || nic == nil || nic.DeviceIndex != 1 || nic.Type != "vpc" {
+			t.Fatalf("bad nic: %+v err=%v", nic, err)
+		}
+	})
+
+	t.Run("404 is absence", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusNotFound) })
+		nic, err := c.PublicCloudVM().NetworkAdapter().Read(ctx, "vm-1", "missing")
+		if err != nil || nic != nil {
+			t.Fatalf("404 must be (nil,nil), got nic=%+v err=%v", nic, err)
+		}
+	})
+
+	t.Run("400 fails closed (never a silent absent)", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusBadRequest) })
+		nic, err := c.PublicCloudVM().NetworkAdapter().Read(ctx, "vm-1", "unknown")
+		if err == nil || nic != nil {
+			t.Fatalf("a 400 must fail closed with an error, got nic=%+v err=%v", nic, err)
+		}
+	})
+
+	t.Run("206 fails closed (only 200 is a found NIC)", func(t *testing.T) {
+		// A 206 must never be decoded as a found NIC (it could carry a partial
+		// body that bypasses the ListStrict integrity guards).
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(`{"id":"nic-1"}`))
+		})
+		nic, err := c.PublicCloudVM().NetworkAdapter().Read(ctx, "vm-1", "nic-1")
+		if err == nil || nic != nil {
+			t.Fatalf("a 206 must fail closed with an error, got nic=%+v err=%v", nic, err)
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().NetworkAdapter().Read(ctx, "vm-1", "denied"); err == nil {
+			t.Fatal("a 403 must fail closed")
+		}
+	})
+}
+
+func TestPublicCloudVMNetworkAdapterWrites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create posts camelCase body, omits empty ipAddress, returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/network_adapters" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-nic")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().NetworkAdapter().Create(ctx, "vm-1", &CreateVMNetworkAdapterRequest{NetworkID: "net-1", DeviceIndex: 0})
+		if err != nil || id != "act-nic" {
+			t.Fatalf("Create: id=%q err=%v", id, err)
+		}
+		if body["networkId"] != "net-1" || body["deviceIndex"] != float64(0) {
+			t.Fatalf("create body not sent camelCase: %v", body)
+		}
+		if _, ok := body["ipAddress"]; ok {
+			t.Fatalf("empty ipAddress must be omitted: %v", body)
+		}
+	})
+
+	t.Run("create includes ipAddress when set", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-nic")
+			w.WriteHeader(http.StatusCreated)
+		})
+		_, err := c.PublicCloudVM().NetworkAdapter().Create(ctx, "vm-1", &CreateVMNetworkAdapterRequest{NetworkID: "net-1", DeviceIndex: 1, IPAddress: "10.0.0.5"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if body["ipAddress"] != "10.0.0.5" || body["deviceIndex"] != float64(1) {
+			t.Fatalf("ipAddress/deviceIndex not sent: %v", body)
+		}
+	})
+
+	t.Run("change-network PATCHes the nic and returns activityId", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/network_adapters/nic-1" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-patch")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().NetworkAdapter().ChangeNetwork(ctx, "vm-1", "nic-1", &ChangeVMNetworkAdapterRequest{NetworkID: "net-2"})
+		if err != nil || id != "act-patch" {
+			t.Fatalf("ChangeNetwork: id=%q err=%v", id, err)
+		}
+		if body["networkId"] != "net-2" {
+			t.Fatalf("change-network body not sent: %v", body)
+		}
+		if _, ok := body["ipAddress"]; ok {
+			t.Fatalf("empty ipAddress must be omitted on change-network: %v", body)
+		}
+	})
+
+	t.Run("change-network includes ipAddress when set", func(t *testing.T) {
+		var body map[string]any
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			w.Header().Set("Location", "act-patch")
+			w.WriteHeader(http.StatusCreated)
+		})
+		_, err := c.PublicCloudVM().NetworkAdapter().ChangeNetwork(ctx, "vm-1", "nic-1", &ChangeVMNetworkAdapterRequest{NetworkID: "net-2", IPAddress: "10.0.0.9"})
+		if err != nil {
+			t.Fatalf("ChangeNetwork: %v", err)
+		}
+		if body["networkId"] != "net-2" || body["ipAddress"] != "10.0.0.9" {
+			t.Fatalf("change-network body with ip not sent: %v", body)
+		}
+	})
+
+	t.Run("delete DELETEs the nic and returns activityId", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete || r.URL.Path != "/vm_instances/v1/virtual_machines/vm-1/network_adapters/nic-1" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.Header().Set("Location", "act-del")
+			w.WriteHeader(http.StatusCreated)
+		})
+		id, err := c.PublicCloudVM().NetworkAdapter().Delete(ctx, "vm-1", "nic-1")
+		if err != nil || id != "act-del" {
+			t.Fatalf("Delete: id=%q err=%v", id, err)
+		}
+	})
+}

--- a/internal/client/public_cloud_vm_network_test.go
+++ b/internal/client/public_cloud_vm_network_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPublicCloudVMNetworkList(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vm_instances/v1/networks" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		// Bare array (verified live) — no wrapper, no total, no vpc block.
+		_, _ = w.Write([]byte(`[{"id":"net-1","name":"LAN01"},{"id":"net-2","name":"test222"}]`))
+	})
+	nets, err := c.PublicCloudVM().Network().List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(nets) != 2 {
+		t.Fatalf("want 2 networks, got %d", len(nets))
+	}
+	if nets[0].ID != "net-1" || nets[0].Name != "LAN01" || nets[1].ID != "net-2" {
+		t.Fatalf("networks not decoded: %+v", nets)
+	}
+}
+
+func TestPublicCloudVMNetworkListStrict(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 returns the catalogue", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"net-1","name":"LAN01"}]`))
+		})
+		nets, err := c.PublicCloudVM().Network().ListStrict(ctx)
+		if err != nil || len(nets) != 1 {
+			t.Fatalf("complete listing: err=%v nets=%d", err, len(nets))
+		}
+	})
+
+	t.Run("206 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(`[]`))
+		})
+		if _, err := c.PublicCloudVM().Network().ListStrict(ctx); err == nil {
+			t.Fatal("a 206 must fail closed for ListStrict")
+		}
+	})
+
+	t.Run("403 fails closed", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+		if _, err := c.PublicCloudVM().Network().ListStrict(ctx); err == nil {
+			t.Fatal("a 403 must fail closed")
+		}
+	})
+}
+
+// TestPublicCloudVMNetworkRead pins the read-only data source contract: absence
+// on this endpoint is NOT a clean 404 (the live platform returns 400/500), so any
+// non-200 fails closed with an error rather than a (nil,nil) "absent" signal.
+func TestPublicCloudVMNetworkRead(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("200 decodes", func(t *testing.T) {
+		c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/vm_instances/v1/networks/net-1" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"net-1","name":"LAN01"}`))
+		})
+		net, err := c.PublicCloudVM().Network().Read(ctx, "net-1")
+		if err != nil || net == nil || net.Name != "LAN01" {
+			t.Fatalf("bad network: %+v err=%v", net, err)
+		}
+	})
+
+	// 400/500 = live absence codes; 404 = not a clean absence here either; 206/201
+	// must NOT be decoded as success on a read-only single lookup.
+	for _, code := range []int{http.StatusBadRequest, http.StatusInternalServerError, http.StatusNotFound, http.StatusPartialContent, http.StatusCreated} {
+		code := code
+		t.Run(http.StatusText(code)+" fails closed", func(t *testing.T) {
+			c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
+			if _, err := c.PublicCloudVM().Network().Read(ctx, "missing"); err == nil {
+				t.Fatalf("HTTP %d must fail closed (never a silent absent) for a read-only network lookup", code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #436 — E4-1 of the Public Cloud VM networking epic (#409).

## What
Client layer only (no resources/datasources wired yet — those land in E4-2/E4-3):

- **`Network()`** — read-only network catalogue. `List`/`ListStrict` decode the live **bare array** `[{id,name}]`; `Read` is **200-only** because absence surfaces as 400/500 (never a clean 404), so a bad id fails closed instead of being read as absence.
- **`NetworkAdapter()`** — VM-scoped NIC sub-client (`/virtual_machines/{vmID}/network_adapters`). `List`/`ListStrict` decode the wrapped `{vmId, networks, total}` shape with:
  - `Total *int` so a missing `total` (`{}` / `{"networks":[]}`) is distinguishable from a genuine 0 and **fails closed**;
  - `total == len(networks)` completeness;
  - structural-integrity guards — a wrapper `vmId` that doesn't match the request (case-insensitive), or a `nil` / empty-id entry, is **rejected** so a listing can never wrongly serve as absence evidence (E0-9).
  - `Read` decodes only on **200**, maps **404 → (nil,nil)**, and **fails closed on everything else** (notably the **400** the live API returns for an unknown NIC).
  - Async `Create` / `ChangeNetwork` (PATCH) / `Delete` return the `activityId`; request bodies encode camelCase (`networkId`, `deviceIndex`, `ipAddress` omitempty).

## State-safety decisions (from live probe + Codex plan review)
- **Absence is never a clean 404** for these endpoints (verified live: unknown id → 400/500). The single-GET status is therefore never trusted as absence; the drop decision (in the E4-3 resource) will rely on the complete `ListStrict` only.
- **`vif_uuid` not modelled** — absent from the live response despite the spec (spec↔code discrepancy, tracked for E7).
- **`vpc` block deferred** — never observable on the live platform (no VPC network available); modelling it now would freeze an unverified schema.

## Tests
`httptest` unit tests: bare-array decode; `null` ipv4/ipv6 → `""`; all `ListStrict` fail-closed cases (missing total, truncated, vmId mismatch, null/empty-id entry, 206, 403) and the genuine-empty + case-insensitive-vmId + empty-vmId accepted cases; `Read` 200 / 404 / 400 / 206 / 403; write method+path+camelCase-body assertions.

Build (`go install`), `go vet`, staticcheck clean; client coverage 40.5% (floor 24.8). Reviewed by Codex (state-safety adversarial pass) — GO after tightening both `Read` paths to reject 206.