### PR TITLE
fix(#432): disk create must not persist a proven wrong-adopted id

### DIFF
--- a/internal/provider/resource_public_cloud_vm_disk.go
+++ b/internal/provider/resource_public_cloud_vm_disk.go
@@ -207,16 +207,29 @@ func createVMDiskWith(ctx context.Context, d *schema.ResourceData, funcs vmDiskC
 	}
 	d.SetId(candidate)
 
-	diags := readVMDiskInto(ctx, d, funcs, vmDiskReadAfterWrite)
-	if diags.HasError() {
-		return diags
+	// Validate the adopted id with a direct read BEFORE populating the state.
+	// The distinction matters because SDKv2 persists d.State() even on a create
+	// error: an UNREADABLE disk (error/nil) is eventual consistency — keep the id
+	// so a later refresh reconciles it — while a read-back that PROVES a wrong
+	// adoption (primary/system disk, or a size that is not the one we requested)
+	// must clear the id: a tainted wrong id would later make Terraform DELETE the
+	// wrong disk (data loss on the system disk).
+	disk, rerr := funcs.read(ctx, vmID, candidate)
+	if rerr != nil {
+		return diag.Errorf("data disk %s of VM %s was just created but could not be read back: %s; the resource is kept in the state with its id.", candidate, vmID, rerr)
 	}
-	// Hardening: the read-back disk must have the requested size; a mismatch means
-	// the adopted id is not the disk we created.
-	if got := d.Get("size").(int); got != req.Size {
-		return diag.Errorf("data disk %s on VM %s read back size %d GB, expected %d GB; refusing an inconsistent id", d.Id(), vmID, got, req.Size)
+	if disk == nil {
+		return diag.Errorf("data disk %s of VM %s was just created but is not yet readable (eventual consistency); the resource is kept in the state with its id.", candidate, vmID)
 	}
-	return diags
+	if disk.IsPrimary {
+		d.SetId("")
+		return diag.Errorf("disk %s on VM %s read back as the primary (system) disk; a wrong id was adopted. The resource was NOT recorded in the state. If a data disk was created it is ORPHANED — audit the VM's disks and import (terraform import <vmID>/<diskID>) or delete it.", candidate, vmID)
+	}
+	if disk.SizeGb != req.Size {
+		d.SetId("")
+		return diag.Errorf("data disk %s on VM %s read back size %d GB, expected %d GB; a different disk was adopted. The resource was NOT recorded in the state. If a disk was created it is ORPHANED — audit the VM's disks and import (terraform import <vmID>/<diskID>) or delete it.", candidate, vmID, disk.SizeGb, req.Size)
+	}
+	return readVMDiskInto(ctx, d, funcs, vmDiskReadAfterWrite)
 }
 
 // readVMDiskInto holds the testable read logic. The resource is NEVER dropped on

--- a/internal/provider/resource_public_cloud_vm_disk_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_disk_unit_test.go
@@ -155,6 +155,49 @@ func TestCreateVMDiskWith(t *testing.T) {
 		if diags := createVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
 			t.Fatal("a primary disk read-back must fail (data-disk resource only)")
 		}
+		if d.Id() != "" {
+			t.Fatal("a primary read-back is a proven wrong-adoption and must clear the id (never leave the system disk id in state)")
+		}
+	})
+
+	t.Run("unreadable read-back (error) keeps the fresh id", func(t *testing.T) {
+		d := newDiskRD(t, 10)
+		funcs := vmDiskCRUDFuncs{
+			create: func(ctx context.Context, vmID string, r *client.CreateVMDiskRequest) (string, error) {
+				return "act", nil
+			},
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
+				return diskActivity(diskTestDiskID), nil
+			},
+			read: func(ctx context.Context, vmID, diskID string) (*client.PublicCloudVMDisk, error) {
+				return nil, errors.New("503")
+			},
+		}
+		if diags := createVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("an unreadable read-back must fail the create")
+		}
+		if d.Id() != diskTestDiskID {
+			t.Fatalf("an unreadable read-back is eventual consistency and must keep the fresh id, got %q", d.Id())
+		}
+	})
+
+	t.Run("not-yet-readable read-back (nil) keeps the fresh id", func(t *testing.T) {
+		d := newDiskRD(t, 10)
+		funcs := vmDiskCRUDFuncs{
+			create: func(ctx context.Context, vmID string, r *client.CreateVMDiskRequest) (string, error) {
+				return "act", nil
+			},
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
+				return diskActivity(diskTestDiskID), nil
+			},
+			read: func(ctx context.Context, vmID, diskID string) (*client.PublicCloudVMDisk, error) { return nil, nil },
+		}
+		if diags := createVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("a not-yet-readable read-back must fail the create")
+		}
+		if d.Id() != diskTestDiskID {
+			t.Fatalf("a nil read-back is eventual consistency and must keep the fresh id, got %q", d.Id())
+		}
 	})
 
 	t.Run("size mismatch on readback fails", func(t *testing.T) {
@@ -172,6 +215,9 @@ func TestCreateVMDiskWith(t *testing.T) {
 		}
 		if diags := createVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
 			t.Fatal("a size mismatch on read-back must fail (inconsistent id)")
+		}
+		if d.Id() != "" {
+			t.Fatal("a proven wrong-adoption must clear the id (never leave a wrong disk in state to be destroyed later)")
 		}
 	})
 }


### PR DESCRIPTION
Refs #432 — state-safety hardening of the data-disk resource shipped in E3-2 (#460), same defect class as the one fixed for the network adapter in #466.

## The bug
`createVMDiskWith` adopted the activity's disk id (`d.SetId(candidate)`) and then returned an error on a bad read-back **without clearing the id**. SDKv2 persists `d.State()` even when Create errors, so a **proven wrong adoption** — the read-back is the primary/system disk, or a size that is not the one requested — left a tainted wrong id in the state. A later `terraform destroy` would have deleted the **wrong disk** (potential data loss on the system disk; delete's own primary guard mitigates that specific case, but the state was still corrupt).

## The fix
The create path now validates the adopted id with a **direct read before populating the state**:

| Read-back | Verdict | Action |
|---|---|---|
| error / not-yet-readable | eventual consistency | **keep** the id (a later refresh reconciles) |
| primary/system disk | proven wrong adoption | **clear** the id + orphan-audit error |
| size ≠ requested | proven wrong adoption | **clear** the id + orphan-audit error |
| consistent | ok | populate state via the usual after-write read |

## Tests
Unit tests pin the boundary: primary and size-mismatch read-backs assert `d.Id()==""`; new read-error and read-nil tests assert the id is **kept**.

Reviewed by Codex (adversarial state-safety pass): first round NO-GO — it caught that the primary read-back path still kept the id — restructured, second round **GO**.