### PR TITLE
refactor(#470): rename network_interfaces to os_network_adapter (E9-1)

### DIFF
--- a/docs/resources/public_cloud_vm_instance.md
+++ b/docs/resources/public_cloud_vm_instance.md
@@ -55,7 +55,7 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
   backup_policy_id     = data.cloudtemple_public_cloud_vm_backup_policy.policy.id
   power_state          = "on"
 
-  network_interfaces {
+  os_network_adapter {
     device_index = 0
     network_id   = var.network_id
   }
@@ -77,7 +77,7 @@ output "vm_status" {
 - `instance_family_id` (String) The ID of the instance family. Immutable.
 - `memory` (Number) The amount of RAM in GB. Mutable via resize, which requires `power_state = "off"`.
 - `name` (String) The name of the virtual machine. Mutable (issues a metadata update).
-- `network_interfaces` (Block List, Min: 1, Max: 8) The network interfaces attached at creation. Immutable here; additional adapters are managed by the dedicated network adapter resource. (see [below for nested schema](#nestedblock--network_interfaces))
+- `os_network_adapter` (Block List, Min: 1, Max: 8) The network interfaces attached at creation. Immutable here; additional adapters are managed by the dedicated network adapter resource. (see [below for nested schema](#nestedblock--os_network_adapter))
 - `template_id` (String) The ID of the OS template the VM is created from. Immutable.
 
 ### Optional
@@ -101,8 +101,8 @@ output "vm_status" {
 - `template_name` (String) The name of the OS template.
 - `updated_at` (String) The last update date of the VM (RFC3339).
 
-<a id="nestedblock--network_interfaces"></a>
-### Nested Schema for `network_interfaces`
+<a id="nestedblock--os_network_adapter"></a>
+### Nested Schema for `os_network_adapter`
 
 Required:
 
@@ -140,7 +140,7 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-# A VM instance is imported by its UUID. cloud_init and network_interfaces are
+# A VM instance is imported by its UUID. cloud_init and os_network_adapter are
 # not returned by the API and cannot be reconciled on import; power_state is
 # derived from the VM status.
 terraform import cloudtemple_public_cloud_vm_instance.web 00000000-0000-0000-0000-000000000000

--- a/examples/resources/cloudtemple_public_cloud_vm_instance/import.sh
+++ b/examples/resources/cloudtemple_public_cloud_vm_instance/import.sh
@@ -1,4 +1,4 @@
-# A VM instance is imported by its UUID. cloud_init and network_interfaces are
+# A VM instance is imported by its UUID. cloud_init and os_network_adapter are
 # not returned by the API and cannot be reconciled on import; power_state is
 # derived from the VM status.
 terraform import cloudtemple_public_cloud_vm_instance.web 00000000-0000-0000-0000-000000000000

--- a/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
@@ -31,7 +31,7 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
   backup_policy_id     = data.cloudtemple_public_cloud_vm_backup_policy.policy.id
   power_state          = "on"
 
-  network_interfaces {
+  os_network_adapter {
     device_index = 0
     network_id   = var.network_id
   }

--- a/internal/provider/resource_public_cloud_vm_instance.go
+++ b/internal/provider/resource_public_cloud_vm_instance.go
@@ -107,7 +107,7 @@ func resourcePublicCloudVMInstance() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "The ID of the instance family. Immutable.",
 			},
-			"network_interfaces": {
+			"os_network_adapter": {
 				Type:        schema.TypeList,
 				Required:    true,
 				ForceNew:    true,
@@ -489,7 +489,7 @@ func setVMInstanceOSDisk(ctx context.Context, d *schema.ResourceData, funcs vmIn
 
 // setVMInstanceState writes the API view of the VM into the resource state. The
 // immutable ids (az/template/family) are reconciled to their API values to catch
-// an out-of-band replacement; network_interfaces and cloud_init are not returned
+// an out-of-band replacement; os_network_adapter and cloud_init are not returned
 // by the API and are ForceNew, so they are left untouched (kept from config).
 func setVMInstanceState(d *schema.ResourceData, vm *client.PublicCloudVMInstance, mode vmInstanceReadMode) diag.Diagnostics {
 	sw := newStateWriter(d)
@@ -692,7 +692,7 @@ func buildCreateVMInstanceRequest(d *schema.ResourceData) (*client.CreateVMInsta
 		Memory:             d.Get("memory").(int),
 		BackupPolicyID:     d.Get("backup_policy_id").(string),
 		PowerState:         d.Get("power_state").(string),
-		NetworkInterfaces:  expandVMInstanceNICs(d.Get("network_interfaces").([]interface{})),
+		NetworkInterfaces:  expandVMInstanceNICs(d.Get("os_network_adapter").([]interface{})),
 	}
 	req.CloudInit = expandVMInstanceCloudInit(d.Get("cloud_init").(map[string]interface{}))
 	return req, nil

--- a/internal/provider/resource_public_cloud_vm_instance_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_instance_unit_test.go
@@ -191,7 +191,7 @@ func createRD(t *testing.T) *schema.ResourceData {
 		"memory":               4,
 		"backup_policy_id":     "44444444-4444-4444-4444-444444444444",
 		"power_state":          "on",
-		"network_interfaces": []interface{}{
+		"os_network_adapter": []interface{}{
 			map[string]interface{}{"device_index": 0, "network_id": "55555555-5555-5555-5555-555555555555"},
 		},
 	})

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -2052,37 +2052,6 @@
           "has_validate_func": true,
           "elem_kind": "nil"
         },
-        "network_interfaces": {
-          "type": "TypeList",
-          "required": true,
-          "force_new": true,
-          "min_items": 1,
-          "max_items": 8,
-          "elem_kind": "resource",
-          "elem_resource": {
-            "device_index": {
-              "type": "TypeInt",
-              "required": true,
-              "force_new": true,
-              "has_validate_func": true,
-              "elem_kind": "nil"
-            },
-            "ip_address": {
-              "type": "TypeString",
-              "optional": true,
-              "force_new": true,
-              "has_validate_func": true,
-              "elem_kind": "nil"
-            },
-            "network_id": {
-              "type": "TypeString",
-              "required": true,
-              "force_new": true,
-              "has_validate_func": true,
-              "elem_kind": "nil"
-            }
-          }
-        },
         "os_disk": {
           "type": "TypeList",
           "computed": true,
@@ -2121,6 +2090,37 @@
           "computed": true,
           "has_validate_func": true,
           "elem_kind": "nil"
+        },
+        "os_network_adapter": {
+          "type": "TypeList",
+          "required": true,
+          "force_new": true,
+          "min_items": 1,
+          "max_items": 8,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "device_index": {
+              "type": "TypeInt",
+              "required": true,
+              "force_new": true,
+              "has_validate_func": true,
+              "elem_kind": "nil"
+            },
+            "ip_address": {
+              "type": "TypeString",
+              "optional": true,
+              "force_new": true,
+              "has_validate_func": true,
+              "elem_kind": "nil"
+            },
+            "network_id": {
+              "type": "TypeString",
+              "required": true,
+              "force_new": true,
+              "has_validate_func": true,
+              "elem_kind": "nil"
+            }
+          }
         },
         "power_state": {
           "type": "TypeString",

--- a/internal/provider/tests/resource_public_cloud_vm_instance_test.go
+++ b/internal/provider/tests/resource_public_cloud_vm_instance_test.go
@@ -19,7 +19,7 @@ const (
 
 // TestAccResourcePublicCloudVMInstance exercises the full lifecycle live:
 // create (booted at creation via power_state = "on"), a read-back that populates
-// the computed attributes, then import. cloud_init / network_interfaces are not
+// the computed attributes, then import. cloud_init / os_network_adapter are not
 // returned by the API (and are ForceNew), and power_state is derived from the
 // status, so they are excluded from the import verification.
 func TestAccResourcePublicCloudVMInstance(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAccResourcePublicCloudVMInstance(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Not readable from the API (and ForceNew) / derived from status.
-				ImportStateVerifyIgnore: []string{"network_interfaces", "cloud_init", "power_state"},
+				ImportStateVerifyIgnore: []string{"os_network_adapter", "cloud_init", "power_state"},
 			},
 		},
 	})
@@ -69,7 +69,7 @@ resource "cloudtemple_public_cloud_vm_instance" "test" {
   backup_policy_id     = "%s"
   power_state          = "on"
 
-  network_interfaces {
+  os_network_adapter {
     device_index = 0
     network_id   = "%s"
   }


### PR DESCRIPTION
Refs #470 — E9-1, first of the pre-release feedback batch (#409).

## What
Renames the VM resource's inline NIC block **`network_interfaces` → `os_network_adapter`**, consistent with the compute resources' naming. Terraform-side only:

- schema key, create expand, `ImportStateVerifyIgnore`, unit + acceptance tests, example (`resource.tf` + `import.sh`), generated docs, schema snapshot;
- the **API wire format is untouched** (`networkInterfaces` is still what the create body sends);
- no behavioral change (block stays Required / ForceNew, min 1 / max 8 items).

Pre-release rename — v1.10.0 is not tagged, so no deprecation path is needed.

Codex reviewed: complete TF-side rename, no stale occurrence, wire intact — GO.