### PR TITLE
feat(#472): mutable size_gb inside the os_disk block (E9-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 NEW FEATURES :
 
-  * Added resource `cloudtemple_public_cloud_vm_instance` to manage a Public Cloud VM instance: create, start/stop (`power_state`), rename, change the backup policy, resize `cpu`/`memory` and grow the OS disk (`os_disk_size_gb`) — resize and OS disk growth require the VM to be stopped.
+  * Added resource `cloudtemple_public_cloud_vm_instance` to manage a Public Cloud VM instance: create, start/stop (`power_state`), rename, change the backup policy, resize `cpu`/`memory` and grow the OS disk (`os_disk.size_gb`) — resize and OS disk growth require the VM to be stopped.
   * Added resource `cloudtemple_public_cloud_vm_disk` to manage a data disk attached to a Public Cloud VM instance: create, grow-only extend and delete (extend and delete require the VM to be stopped). Import with `<virtual_machine_id>/<disk_id>`.
   * Added resource `cloudtemple_public_cloud_vm_snapshot` to manage a snapshot of a Public Cloud VM instance (`name` is immutable). Import with `<virtual_machine_id>/<snapshot_id>`.
   * Added resource `cloudtemple_public_cloud_vm_network_adapter` to manage a network adapter attached to a Public Cloud VM instance. Changing `network_id` or deleting the adapter requires the VM to be stopped; `ip_address` is only honoured on VPC networks; `device_index` is immutable. Import with `<virtual_machine_id>/<network_adapter_id>`.

--- a/docs/resources/public_cloud_vm_instance.md
+++ b/docs/resources/public_cloud_vm_instance.md
@@ -59,6 +59,12 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
     device_index = 0
     network_id   = var.network_id
   }
+
+  # The system disk comes from the template. To grow it later (grow-only),
+  # declare the block with the new size while power_state = "off":
+  # os_disk {
+  #   size_gb = 45
+  # }
 }
 
 output "vm_status" {
@@ -83,7 +89,7 @@ output "vm_status" {
 ### Optional
 
 - `cloud_init` (Map of String) The cloud-init configuration applied at creation (keys `cloud_config` and/or `network_config`). Immutable and not readable back, so it is not reconciled on refresh.
-- `os_disk_size_gb` (Number) The size of the system (primary) disk in GB. Grow-only; increasing it extends the system disk, which requires the VM to be stopped. When omitted, the template's size is kept. Data disks are managed by the separate disk resource.
+- `os_disk` (Block List, Max: 1) The system (primary) disk of the VM, provided by the template. Declare the block with `size_gb` to grow it (grow-only; requires the VM to be stopped). Not settable at creation — the template's size is used. Data disks are managed by the separate disk resource. (see [below for nested schema](#nestedblock--os_disk))
 - `power_state` (String) The desired power state (`on` or `off`, default `off`). Honoured from the first apply (passed to the create call, so an `on` VM boots at creation). Changing it later issues a start (`off`->`on`) or stop (`on`->`off`).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
@@ -96,7 +102,6 @@ output "vm_status" {
 - `guest_tools_installed` (Boolean) Whether the guest tools are installed.
 - `id` (String) The ID of this resource.
 - `instance_family_name` (String) The name of the instance family.
-- `os_disk` (List of Object) The system (primary) disk of the VM, provided by the template. (see [below for nested schema](#nestedatt--os_disk))
 - `status` (String) The current status of the VM (e.g. `running`, `stopped`).
 - `template_name` (String) The name of the OS template.
 - `updated_at` (String) The last update date of the VM (RFC3339).
@@ -114,6 +119,21 @@ Optional:
 - `ip_address` (String) The fixed IPv4 address to assign. When omitted, the platform assigns one.
 
 
+<a id="nestedblock--os_disk"></a>
+### Nested Schema for `os_disk`
+
+Optional:
+
+- `size_gb` (Number) The size of the system disk in GB. Grow-only; increasing it extends the system disk, which requires the VM to be stopped. When omitted, the current size is kept.
+
+Read-Only:
+
+- `id` (String) The unique identifier of the system disk.
+- `is_primary` (Boolean) Always true for the system disk.
+- `position` (Number) The position of the disk (0 for the system disk).
+- `storage_type` (String) The ID of the storage type.
+
+
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
@@ -122,18 +142,6 @@ Optional:
 - `create` (String)
 - `delete` (String)
 - `update` (String)
-
-
-<a id="nestedatt--os_disk"></a>
-### Nested Schema for `os_disk`
-
-Read-Only:
-
-- `id` (String)
-- `is_primary` (Boolean)
-- `position` (Number)
-- `size_gb` (Number)
-- `storage_type` (String)
 
 ## Import
 

--- a/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
@@ -35,6 +35,12 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
     device_index = 0
     network_id   = var.network_id
   }
+
+  # The system disk comes from the template. To grow it later (grow-only),
+  # declare the block with the new size while power_state = "off":
+  # os_disk {
+  #   size_gb = 45
+  # }
 }
 
 output "vm_status" {

--- a/internal/provider/resource_public_cloud_vm_instance.go
+++ b/internal/provider/resource_public_cloud_vm_instance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -198,21 +199,22 @@ func resourcePublicCloudVMInstance() *schema.Resource {
 				Computed:    true,
 				Description: "The last update date of the VM (RFC3339).",
 			},
-			"os_disk_size_gb": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "The size of the system (primary) disk in GB. Grow-only; increasing it extends the system disk, which requires the VM to be stopped. When omitted, the template's size is kept. Data disks are managed by the separate disk resource.",
-			},
 			"os_disk": {
 				Type:        schema.TypeList,
+				Optional:    true,
 				Computed:    true,
-				Description: "The system (primary) disk of the VM, provided by the template.",
+				MaxItems:    1,
+				Description: "The system (primary) disk of the VM, provided by the template. Declare the block with `size_gb` to grow it (grow-only; requires the VM to be stopped). Not settable at creation — the template's size is used. Data disks are managed by the separate disk resource.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id":           {Type: schema.TypeString, Computed: true, Description: "The unique identifier of the system disk."},
-						"size_gb":      {Type: schema.TypeInt, Computed: true, Description: "The size of the system disk in GB."},
+						"id": {Type: schema.TypeString, Computed: true, Description: "The unique identifier of the system disk."},
+						"size_gb": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+							Description:  "The size of the system disk in GB. Grow-only; increasing it extends the system disk, which requires the VM to be stopped. When omitted, the current size is kept.",
+						},
 						"storage_type": {Type: schema.TypeString, Computed: true, Description: "The ID of the storage type."},
 						"position":     {Type: schema.TypeInt, Computed: true, Description: "The position of the disk (0 for the system disk)."},
 						"is_primary":   {Type: schema.TypeBool, Computed: true, Description: "Always true for the system disk."},
@@ -229,29 +231,81 @@ func resourcePublicCloudVMInstance() *schema.Resource {
 // zero value and an `on` power_state is the legitimate boot-at-create case.
 func customizeVMInstanceDiff(ctx context.Context, d *schema.ResourceDiff, meta any) error {
 	exists := d.Id() != ""
-	// os_disk_size_gb cannot be set at CREATE: the VM is created with the
+	// os_disk.size_gb cannot be set at CREATE: the VM is created with the
 	// template's system disk size, and create never extends it — so a configured
 	// value that differs from the template would produce an inconsistent result.
-	// Grow the system disk in a subsequent apply (with power_state = "off").
+	// Detected on the RAW config (never the diff/state: the attribute is
+	// Optional+Computed, so d.Get would report a computed value as "set").
 	if !exists {
-		if raw := d.GetRawConfig(); !raw.IsNull() {
-			if osd := raw.GetAttr("os_disk_size_gb"); !osd.IsNull() {
-				return fmt.Errorf("os_disk_size_gb cannot be set when creating the VM: the template's system disk size is used at creation. Omit it, then set it in a later apply (with power_state = \"off\") to grow the system disk")
+		if osDiskSizeSetInRawConfig(d.GetRawConfig()) {
+			return fmt.Errorf("os_disk.size_gb cannot be set when creating the VM: the template's system disk size is used at creation. Omit it, then set it in a later apply (with power_state = \"off\") to grow the system disk")
+		}
+	} else if d.HasChange("os_disk.0.size_gb") {
+		// Grow-only + requires-off, validated on the LEAF only: a refresh of a
+		// Computed sibling (id, storage_type, ...) must never look like an extend.
+		o, n := d.GetChange("os_disk.0.size_gb")
+		oldSize, okOld := o.(int)
+		newSize, okNew := n.(int)
+		if okOld && okNew {
+			if err := vmInstanceOSDiskChangeCheck(oldSize, newSize, d.Get("power_state").(string)); err != nil {
+				return err
 			}
 		}
 	}
-	// The system disk is grow-only, like a data disk.
-	if d.HasChange("os_disk_size_gb") {
-		o, n := d.GetChange("os_disk_size_gb")
-		if err := vmDiskGrowOnlyCheck(o.(int), n.(int)); err != nil {
-			return err
+	return vmInstanceResizeRequiresOff(exists, d.HasChange("cpu") || d.HasChange("memory"), d.Get("power_state").(string))
+}
+
+// osDiskSizeSetInRawConfig reports whether the raw config declares an os_disk
+// block with an explicitly set size_gb (null-, absent- and unknown-safe: an
+// unknown value counts as set, since create cannot honour it either). It reads
+// the RAW config because os_disk.size_gb is Optional+Computed — the diff/state
+// view cannot tell an explicit value from a computed one.
+func osDiskSizeSetInRawConfig(raw cty.Value) bool {
+	if raw.IsNull() || !raw.Type().IsObjectType() || !raw.Type().HasAttribute("os_disk") {
+		return false
+	}
+	osd := raw.GetAttr("os_disk")
+	if osd.IsNull() {
+		return false
+	}
+	// A declared-but-unknown os_disk cannot be inspected — and create cannot
+	// honour a size that only resolves later. Reject conservatively.
+	if !osd.IsKnown() {
+		return true
+	}
+	if !osd.CanIterateElements() {
+		return false
+	}
+	for it := osd.ElementIterator(); it.Next(); {
+		_, el := it.Element()
+		if el.IsNull() || !el.Type().IsObjectType() || !el.Type().HasAttribute("size_gb") {
+			continue
 		}
-		// Extending the system disk, like a resize, requires a stopped VM.
-		if exists && d.Get("power_state").(string) != "off" {
-			return fmt.Errorf("os_disk_size_gb can only be changed while power_state = \"off\" (extending the system disk requires a stopped VM); set power_state = \"off\" in the same change, then power the VM back on in a subsequent apply")
+		if sg := el.GetAttr("size_gb"); !sg.IsNull() {
+			return true
 		}
 	}
-	return vmInstanceResizeRequiresOff(exists, d.HasChange("cpu") || d.HasChange("memory"), d.Get("power_state").(string))
+	return false
+}
+
+// vmInstanceOSDiskChangeCheck is the pure os_disk.size_gb change rule on an
+// EXISTING VM. A zero new size (block removed, value resolved by Computed) is
+// not a change to validate. A zero OLD size (no readable primary in state)
+// cannot prove a shrink — the grow-only check is skipped — but the update will
+// still issue an extend, so the stopped-VM precondition applies regardless.
+func vmInstanceOSDiskChangeCheck(oldSize, newSize int, powerState string) error {
+	if newSize == 0 || newSize == oldSize {
+		return nil
+	}
+	if oldSize != 0 {
+		if err := vmDiskGrowOnlyCheck(oldSize, newSize); err != nil {
+			return err
+		}
+	}
+	if powerState != "off" {
+		return fmt.Errorf("os_disk.size_gb can only be changed while power_state = \"off\" (extending the system disk requires a stopped VM); set power_state = \"off\" in the same change, then power the VM back on in a subsequent apply")
+	}
+	return nil
 }
 
 // vmInstanceResizeRequiresOff is the pure resize precondition: on an EXISTING VM,
@@ -450,10 +504,12 @@ func readVMInstanceInto(ctx context.Context, d *schema.ResourceData, funcs vmIns
 	return append(diags, setVMInstanceOSDisk(ctx, d, funcs, id)...)
 }
 
-// setVMInstanceOSDisk enriches the state with the VM's system (primary) disk:
-// the read-only os_disk block and the mutable os_disk_size_gb. The disk list is
-// fetched fresh; a failure fails closed (the VM itself is kept, but the read
-// errors — a forbidden/broken disk listing is surfaced, not silently ignored).
+// setVMInstanceOSDisk enriches the state with the VM's system (primary) disk —
+// the FULL os_disk block is always written from the API view, so a partially
+// declared config block (only size_gb) can never wipe the Computed siblings.
+// The disk list is fetched fresh; a failure fails closed (the VM itself is
+// kept, but the read errors — a forbidden/broken disk listing is surfaced, not
+// silently ignored).
 func setVMInstanceOSDisk(ctx context.Context, d *schema.ResourceData, funcs vmInstanceCRUDFuncs, vmID string) diag.Diagnostics {
 	disks, err := funcs.listDisks(ctx, vmID)
 	if err != nil {
@@ -468,15 +524,13 @@ func setVMInstanceOSDisk(ctx context.Context, d *schema.ResourceData, funcs vmIn
 	}
 	if primary == nil {
 		// No primary disk reported (e.g. a never-booted template edge case): clear
-		// any stale os_disk block rather than keep a previously-read primary. Leave
-		// os_disk_size_gb (Optional+Computed) as-is — there is no primary to size it.
+		// any stale os_disk block rather than keep a previously-read primary.
 		sw := newStateWriter(d)
 		sw.set("os_disk", []map[string]interface{}{})
 		return sw.diags
 	}
 
 	sw := newStateWriter(d)
-	sw.set("os_disk_size_gb", primary.SizeGb)
 	sw.set("os_disk", []map[string]interface{}{{
 		"id":           primary.ID,
 		"size_gb":      primary.SizeGb,
@@ -649,8 +703,15 @@ func updateVMInstanceWith(ctx context.Context, d *schema.ResourceData, funcs vmI
 		}
 	}
 
-	osDiskExtending := d.HasChange("os_disk_size_gb")
-	osDiskSize := d.Get("os_disk_size_gb").(int)
+	// LEAF-only detection: HasChange("os_disk") would also fire on a refresh of a
+	// Computed sibling (id, storage_type, ...) and trigger an extend the user
+	// never asked for.
+	osDiskExtending := d.HasChange("os_disk.0.size_gb")
+	osDiskSize := d.Get("os_disk.0.size_gb").(int)
+	if osDiskExtending && osDiskSize == 0 {
+		// Block removed / no concrete target size: nothing to extend to.
+		osDiskExtending = false
+	}
 
 	plan := planVMInstanceUpdate(metadataChanged, resizing, osDiskExtending, oldPS.(string), newPS.(string))
 	if err := executeVMInstanceUpdate(ctx, id, plan, funcs, patchReq, resizeReq, osDiskSize); err != nil {

--- a/internal/provider/resource_public_cloud_vm_instance_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_instance_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -516,7 +517,7 @@ func TestDeleteVMInstanceWith(t *testing.T) {
 }
 
 func TestSetVMInstanceOSDisk(t *testing.T) {
-	t.Run("populates os_disk and os_disk_size_gb from the primary disk", func(t *testing.T) {
+	t.Run("populates the full os_disk block from the primary disk", func(t *testing.T) {
 		d := createRD(t)
 		d.SetId("vm-1")
 		funcs := vmInstanceCRUDFuncs{
@@ -530,16 +531,35 @@ func TestSetVMInstanceOSDisk(t *testing.T) {
 		if diags := setVMInstanceOSDisk(context.Background(), d, funcs, "vm-1"); diags.HasError() {
 			t.Fatalf("unexpected diags: %v", diags)
 		}
-		if d.Get("os_disk_size_gb").(int) != 38 {
-			t.Fatalf("os_disk_size_gb = %d, want 38 (primary size)", d.Get("os_disk_size_gb"))
-		}
 		osd := d.Get("os_disk").([]interface{})
 		if len(osd) != 1 {
 			t.Fatalf("os_disk must have exactly the primary disk, got %d", len(osd))
 		}
 		m := osd[0].(map[string]interface{})
-		if m["id"] != "sys" || m["is_primary"] != true || m["size_gb"].(int) != 38 {
+		if m["id"] != "sys" || m["is_primary"] != true || m["size_gb"].(int) != 38 || m["storage_type"] != "st-1" {
 			t.Fatalf("os_disk primary not mapped: %v", m)
+		}
+	})
+
+	t.Run("a partially declared block is overwritten by the full API view (no sibling wipe)", func(t *testing.T) {
+		d := createRD(t)
+		d.SetId("vm-1")
+		// Simulate the state after a config that only declares size_gb: the
+		// Computed siblings must be (re)filled from the API, never left empty.
+		if err := d.Set("os_disk", []map[string]interface{}{{"size_gb": 45}}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		funcs := vmInstanceCRUDFuncs{
+			listDisks: func(ctx context.Context, id string) ([]*client.PublicCloudVMDisk, error) {
+				return []*client.PublicCloudVMDisk{{ID: "sys", Position: 0, SizeGb: 45, StorageType: "st-1", IsPrimary: true}}, nil
+			},
+		}
+		if diags := setVMInstanceOSDisk(context.Background(), d, funcs, "vm-1"); diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		m := d.Get("os_disk").([]interface{})[0].(map[string]interface{})
+		if m["id"] != "sys" || m["storage_type"] != "st-1" || m["size_gb"].(int) != 45 || m["is_primary"] != true {
+			t.Fatalf("computed siblings must be refilled from the API view: %v", m)
 		}
 	})
 
@@ -575,4 +595,74 @@ func TestSetVMInstanceOSDisk(t *testing.T) {
 			t.Fatal("os_disk must be cleared when there is no primary (no stale value)")
 		}
 	})
+}
+
+// TestOSDiskSizeSetInRawConfig pins the create-time rejection detector: it must
+// read the RAW config (Optional+Computed cannot be told apart in the diff),
+// never panic on absent/null/unknown shapes, and treat an unknown size_gb as
+// set (create cannot honour it either).
+func TestOSDiskSizeSetInRawConfig(t *testing.T) {
+	block := func(sizeGb cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"os_disk": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"size_gb": sizeGb}),
+			}),
+		})
+	}
+	cases := []struct {
+		name string
+		raw  cty.Value
+		want bool
+	}{
+		{"null raw config", cty.NullVal(cty.Object(map[string]cty.Type{"os_disk": cty.List(cty.Object(map[string]cty.Type{"size_gb": cty.Number}))})), false},
+		{"no os_disk attribute", cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("x")}), false},
+		{"null os_disk", cty.ObjectVal(map[string]cty.Value{"os_disk": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{"size_gb": cty.Number})))}), false},
+		{"empty os_disk list", cty.ObjectVal(map[string]cty.Value{"os_disk": cty.ListValEmpty(cty.Object(map[string]cty.Type{"size_gb": cty.Number}))}), false},
+		{"block without size_gb (null)", block(cty.NullVal(cty.Number)), false},
+		{"block with size_gb set", block(cty.NumberIntVal(80)), true},
+		{"block with size_gb unknown counts as set", block(cty.UnknownVal(cty.Number)), true},
+		// A declared-but-unknown os_disk cannot be inspected; create cannot honour
+		// a size that only resolves later -> conservative reject.
+		{"unknown os_disk list counts as set", cty.ObjectVal(map[string]cty.Value{"os_disk": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{"size_gb": cty.Number})))}), true},
+		// Raw config can surface blocks as a tuple; the iterator must handle it.
+		{"tuple-shaped os_disk with size_gb set", cty.ObjectVal(map[string]cty.Value{"os_disk": cty.TupleVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"size_gb": cty.NumberIntVal(80)})})}), true},
+		{"tuple-shaped os_disk without size_gb", cty.ObjectVal(map[string]cty.Value{"os_disk": cty.TupleVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"size_gb": cty.NullVal(cty.Number)})})}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := osDiskSizeSetInRawConfig(tc.raw); got != tc.want {
+				t.Fatalf("osDiskSizeSetInRawConfig = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVMInstanceOSDiskChangeCheck pins the pure grow rule on the size_gb leaf:
+// zero/no-op sizes are skipped, a shrink is rejected, a grow requires
+// power_state = "off".
+func TestVMInstanceOSDiskChangeCheck(t *testing.T) {
+	cases := []struct {
+		name       string
+		old, new   int
+		powerState string
+		wantErr    bool
+	}{
+		{"grow while off", 38, 45, "off", false},
+		{"grow while on rejected", 38, 45, "on", true},
+		{"shrink rejected even off", 45, 38, "off", true},
+		{"no change is a no-op", 38, 38, "on", false},
+		// A zero old size cannot prove a shrink, but the update WILL issue an
+		// extend — the stopped-VM precondition still applies.
+		{"zero old: extend while on still rejected", 0, 45, "on", true},
+		{"zero old: extend while off allowed", 0, 45, "off", false},
+		{"zero new (block removed) skipped", 45, 0, "on", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := vmInstanceOSDiskChangeCheck(tc.old, tc.new, tc.powerState)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("vmInstanceOSDiskChangeCheck(%d,%d,%q) err=%v wantErr=%v", tc.old, tc.new, tc.powerState, err, tc.wantErr)
+			}
+		})
+	}
 }

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -2054,7 +2054,9 @@
         },
         "os_disk": {
           "type": "TypeList",
+          "optional": true,
           "computed": true,
+          "max_items": 1,
           "elem_kind": "resource",
           "elem_resource": {
             "id": {
@@ -2074,7 +2076,9 @@
             },
             "size_gb": {
               "type": "TypeInt",
+              "optional": true,
               "computed": true,
+              "has_validate_func": true,
               "elem_kind": "nil"
             },
             "storage_type": {
@@ -2083,13 +2087,6 @@
               "elem_kind": "nil"
             }
           }
-        },
-        "os_disk_size_gb": {
-          "type": "TypeInt",
-          "optional": true,
-          "computed": true,
-          "has_validate_func": true,
-          "elem_kind": "nil"
         },
         "os_network_adapter": {
           "type": "TypeList",


### PR DESCRIPTION
Refs #472 — E9-3 of the pre-release feedback batch (#409). Replaces the scalar `os_disk_size_gb` with a mutable **`size_gb` inside the `os_disk` block**, matching the compute resources' pattern. Pre-release change, no deprecation needed.

## Behaviour (unchanged rules, relocated)
Grow-only · requires a stopped VM · not settable at creation (the template's size is used).

## State-safety specifics (per the plan-gate constraints)
- Update detection targets **only the `os_disk.0.size_gb` leaf** — a refresh of a Computed sibling can never trigger an extend the user did not ask for.
- The create-time reject inspects the **raw config** (Optional+Computed is indistinguishable in the diff); a declared-but-**unknown** block is rejected conservatively.
- A zero old size (no readable primary in state) cannot prove a shrink, but **any concrete size change still requires `power_state = "off"`**.
- `setVMInstanceOSDisk` always rewrites the **full block** from the API view — a partially declared block never wipes the Computed siblings.

## Verification
Unit: raw-config detector (null/absent/unknown/tuple shapes), pure change rule, full-block rewrite, partial-block no-wipe. **Live E2E on DEV**: grow via the block applied & read back (45→50), shrink and grow-while-on rejected at plan, declared-block idempotence (`No changes`), os_disk-at-create rejected on a fresh state, destroy 0 orphan.

Codex adversarial review: NO-GO (unknown-block bypass + zero-old requires-off gap) → fixed → **GO**.

## ⚠️ Upstream bug found during the E2E
`POST .../disks/extend` wrongly rejects a valid grow **below ~38 GB** as "disk shrink is not supported" (22→30 fails, 22→45 works; the worker seems to compare against a stale size instead of the disk's real 22 GB). Provider payload proven correct (`{"size":30}` via TF_LOG; raw curl reproduces). Reported on #443.