### PR TITLE
feat(#473): inline os_network_adapter refuses VPC networks (E9-4)

### DIFF
--- a/docs/resources/public_cloud_vm_instance.md
+++ b/docs/resources/public_cloud_vm_instance.md
@@ -83,7 +83,7 @@ output "vm_status" {
 - `instance_family_id` (String) The ID of the instance family. Immutable.
 - `memory` (Number) The amount of RAM in GB. Mutable via resize, which requires `power_state = "off"`.
 - `name` (String) The name of the virtual machine. Mutable (issues a metadata update).
-- `os_network_adapter` (Block List, Min: 1, Max: 8) The network interfaces attached at creation. Immutable here; additional adapters are managed by the dedicated network adapter resource. (see [below for nested schema](#nestedblock--os_network_adapter))
+- `os_network_adapter` (Block List, Min: 1, Max: 8) The network interfaces attached at creation (Private Backbone networks only — attach VPC networks with the dedicated network adapter resource). Immutable here; additional adapters are managed by the dedicated network adapter resource. (see [below for nested schema](#nestedblock--os_network_adapter))
 - `template_id` (String) The ID of the OS template the VM is created from. Immutable.
 
 ### Optional

--- a/internal/provider/resource_public_cloud_vm_instance.go
+++ b/internal/provider/resource_public_cloud_vm_instance.go
@@ -114,7 +114,7 @@ func resourcePublicCloudVMInstance() *schema.Resource {
 				ForceNew:    true,
 				MinItems:    1,
 				MaxItems:    8,
-				Description: "The network interfaces attached at creation. Immutable here; additional adapters are managed by the dedicated network adapter resource.",
+				Description: "The network interfaces attached at creation (Private Backbone networks only — attach VPC networks with the dedicated network adapter resource). Immutable here; additional adapters are managed by the dedicated network adapter resource.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"device_index": {
@@ -347,6 +347,7 @@ type vmInstanceCRUDFuncs struct {
 	listStrict   func(ctx context.Context) ([]*client.PublicCloudVMInstance, error)
 	listDisks    func(ctx context.Context, id string) ([]*client.PublicCloudVMDisk, error)
 	extendSystem func(ctx context.Context, id string, size int) (string, error)
+	networkRead  func(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error)
 	waitActivity func(ctx context.Context, activityID string) (*client.Activity, error)
 }
 
@@ -371,6 +372,7 @@ func vmInstanceClientFuncs(c *client.Client) vmInstanceCRUDFuncs {
 		},
 		listDisks:    c.PublicCloudVM().Disk().List,
 		extendSystem: c.PublicCloudVM().Disk().ExtendSystem,
+		networkRead:  c.PublicCloudVM().Network().Read,
 		waitActivity: func(ctx context.Context, activityID string) (*client.Activity, error) {
 			return c.Activity().WaitForCompletion(ctx, activityID, vmInstanceWaiterOptions(ctx))
 		},
@@ -410,6 +412,24 @@ func createVMInstanceWith(ctx context.Context, d *schema.ResourceData, funcs vmI
 	req, err := buildCreateVMInstanceRequest(d)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// VPC phase 1: the inline os_network_adapter block only supports Private
+	// Backbone networks — VPC attachments go through the standalone
+	// cloudtemple_public_cloud_vm_network_adapter resource. Each declared network
+	// is resolved BEFORE the create POST; a network that cannot be read fails
+	// closed (never create a VM against an unverifiable network).
+	for _, nic := range req.NetworkInterfaces {
+		network, nerr := funcs.networkRead(ctx, nic.NetworkID)
+		if nerr != nil {
+			return diag.Errorf("failed to verify network %s of os_network_adapter (device_index %d) before creating VM %q: %s. Refusing to create against an unverifiable network.", nic.NetworkID, nic.DeviceIndex, req.Name, nerr)
+		}
+		if network == nil {
+			return diag.Errorf("network %s of os_network_adapter (device_index %d) could not be found before creating VM %q; refusing to create against an unverifiable network.", nic.NetworkID, nic.DeviceIndex, req.Name)
+		}
+		if network.VPC != nil {
+			return diag.Errorf("network %s (%q) of os_network_adapter (device_index %d) is a VPC network: the inline os_network_adapter block only supports Private Backbone networks. Create the VM on a Private Backbone network and attach the VPC network with a cloudtemple_public_cloud_vm_network_adapter resource.", nic.NetworkID, network.Name, nic.DeviceIndex)
+		}
 	}
 
 	activityID, err := funcs.create(ctx, req)

--- a/internal/provider/resource_public_cloud_vm_instance_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_instance_unit_test.go
@@ -30,6 +30,12 @@ func okListPrimaryDisk(ctx context.Context, id string) ([]*client.PublicCloudVMD
 	return []*client.PublicCloudVMDisk{{ID: "osdisk-1", Position: 0, SizeGb: 38, StorageType: "st-1", IsPrimary: true}}, nil
 }
 
+// okNetworkReadPB is the networkRead seam for the create preflight: a plain
+// Private Backbone network (no vpc block), which the inline block accepts.
+func okNetworkReadPB(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error) {
+	return &client.PublicCloudVMNetwork{ID: id, Name: "pb-net"}, nil
+}
+
 // --- resize precondition (CustomizeDiff logic) ---
 
 func TestVMInstanceResizeRequiresOff(t *testing.T) {
@@ -206,7 +212,8 @@ func TestCreateVMInstanceWith(t *testing.T) {
 	t.Run("id comes from the activity concernedItems (vmi)", func(t *testing.T) {
 		d := createRD(t)
 		funcs := vmInstanceCRUDFuncs{
-			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
+			networkRead: okNetworkReadPB,
+			create:      func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
 			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
 				return vmiCompletedActivity("vm-1", "vm-1"), nil
 			},
@@ -227,7 +234,8 @@ func TestCreateVMInstanceWith(t *testing.T) {
 	t.Run("id falls back to the terminal state result when no vmi concernedItem", func(t *testing.T) {
 		d := createRD(t)
 		funcs := vmInstanceCRUDFuncs{
-			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
+			networkRead: okNetworkReadPB,
+			create:      func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
 			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
 				return vmiCompletedActivity("", "vm-2"), nil
 			},
@@ -245,7 +253,8 @@ func TestCreateVMInstanceWith(t *testing.T) {
 	t.Run("no id reported fails closed without setting an id", func(t *testing.T) {
 		d := createRD(t)
 		funcs := vmInstanceCRUDFuncs{
-			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
+			networkRead: okNetworkReadPB,
+			create:      func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
 			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
 				return vmiCompletedActivity("", ""), nil
 			},
@@ -262,7 +271,8 @@ func TestCreateVMInstanceWith(t *testing.T) {
 	t.Run("a wait failure fails and never sets an id", func(t *testing.T) {
 		d := createRD(t)
 		funcs := vmInstanceCRUDFuncs{
-			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
+			networkRead: okNetworkReadPB,
+			create:      func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) { return "act-1", nil },
 			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
 				return nil, errors.New("activity failed")
 			},
@@ -279,6 +289,7 @@ func TestCreateVMInstanceWith(t *testing.T) {
 	t.Run("a create error fails and never sets an id", func(t *testing.T) {
 		d := createRD(t)
 		funcs := vmInstanceCRUDFuncs{
+			networkRead: okNetworkReadPB,
 			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) {
 				return "", errors.New("bad request")
 			},
@@ -289,6 +300,84 @@ func TestCreateVMInstanceWith(t *testing.T) {
 		}
 		if d.Id() != "" {
 			t.Fatalf("a create error must not set an id, got %q", d.Id())
+		}
+	})
+}
+
+// TestCreateVMInstanceVPCGuard pins the phase-1 VPC rule: the inline
+// os_network_adapter block only supports Private Backbone networks. The
+// preflight resolves each declared network BEFORE the create POST — a VPC
+// network, an unreadable network or an absent network all refuse the create
+// without ever calling the API.
+func TestCreateVMInstanceVPCGuard(t *testing.T) {
+	newFuncs := func(networkRead func(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error)) (vmInstanceCRUDFuncs, *bool) {
+		created := false
+		return vmInstanceCRUDFuncs{
+			networkRead: networkRead,
+			create: func(ctx context.Context, r *client.CreateVMInstanceRequest) (string, error) {
+				created = true
+				return "act-1", nil
+			},
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
+				return vmiCompletedActivity("vm-1", "vm-1"), nil
+			},
+			read: func(ctx context.Context, id string) (*client.PublicCloudVMInstance, error) {
+				return &client.PublicCloudVMInstance{ID: id, Name: "web", Status: "running", VCPU: 2, RAMGb: 4}, nil
+			},
+			listDisks: okListPrimaryDisk,
+		}, &created
+	}
+
+	t.Run("a Private Backbone network passes", func(t *testing.T) {
+		d := createRD(t)
+		funcs, created := newFuncs(okNetworkReadPB)
+		if diags := createVMInstanceWith(context.Background(), d, funcs); diags.HasError() {
+			t.Fatalf("a PB network must pass the preflight: %v", diags)
+		}
+		if !*created {
+			t.Fatal("create must be called for a PB network")
+		}
+	})
+
+	t.Run("a VPC network is refused BEFORE the create POST", func(t *testing.T) {
+		d := createRD(t)
+		funcs, created := newFuncs(func(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error) {
+			return &client.PublicCloudVMNetwork{ID: id, Name: "fsn-pn-01", VPC: &client.PublicCloudVMNetworkVPC{ID: "vpc-1", Name: "fsn-01"}}, nil
+		})
+		if diags := createVMInstanceWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("a VPC network must refuse the create")
+		}
+		if *created {
+			t.Fatal("create must NOT be called when a NIC targets a VPC network")
+		}
+		if d.Id() != "" {
+			t.Fatal("no id must be set on a refused create")
+		}
+	})
+
+	t.Run("an unreadable network fails closed (no create)", func(t *testing.T) {
+		d := createRD(t)
+		funcs, created := newFuncs(func(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error) {
+			return nil, errors.New("400")
+		})
+		if diags := createVMInstanceWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("an unreadable network must refuse the create")
+		}
+		if *created {
+			t.Fatal("create must NOT be called against an unverifiable network")
+		}
+	})
+
+	t.Run("a nil network fails closed (no create)", func(t *testing.T) {
+		d := createRD(t)
+		funcs, created := newFuncs(func(ctx context.Context, id string) (*client.PublicCloudVMNetwork, error) {
+			return nil, nil
+		})
+		if diags := createVMInstanceWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("a nil network must refuse the create")
+		}
+		if *created {
+			t.Fatal("create must NOT be called against an absent network")
 		}
 	})
 }


### PR DESCRIPTION
Refs #473 — E9-4 of the pre-release feedback batch (#409). Builds on the vpc block shipped in #477.

## What
**VPC phase 1**: the VM resource's inline `os_network_adapter` block only supports **Private Backbone** networks — VPC attachments go through the standalone `cloudtemple_public_cloud_vm_network_adapter` resource.

- `createVMInstanceWith` resolves **each** declared network (new `networkRead` seam → `Network().Read`, 200-only) **before the create POST**;
- a VPC-backed network refuses the create with an actionable error pointing to the standalone resource;
- an unreadable or absent network **fails closed** (never create a VM against an unverifiable network);
- apply-time preflight by design (an API call in CustomizeDiff is fragile; the preflight→POST TOCTOU was accepted at the plan gate).

## Tests
Unit: PB passes (create called), VPC refused (create **not** called, no id), read-error and nil fail closed (create not called) — killing the "guard after create" and "guard skipped" mutants. Existing create tests keep their assertions with a PB stub. Docs updated.

Codex adversarial review — **GO**, no issue.