### PR TITLE
docs(#475): enrich the Public Cloud VM examples (E9-6)

### DIFF
--- a/docs/data-sources/public_cloud_vm_availability_zone.md
+++ b/docs/data-sources/public_cloud_vm_availability_zone.md
@@ -16,8 +16,8 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances availability zone by name.
-data "cloudtemple_public_cloud_vm_availability_zone" "az01" {
+# Retrieve an availability zone by name.
+data "cloudtemple_public_cloud_vm_availability_zone" "az1" {
   name = "fr1-az01"
 }
 
@@ -26,8 +26,13 @@ data "cloudtemple_public_cloud_vm_availability_zone" "by_id" {
   id = "18eea4f6-b4a1-40c1-8435-457ee7a9ab8e"
 }
 
-output "az_region" {
-  value = data.cloudtemple_public_cloud_vm_availability_zone.az01.region_id
+# The zone id is what a VM instance deploys into.
+output "az_id" {
+  value = data.cloudtemple_public_cloud_vm_availability_zone.az1.id
+}
+
+output "az_compatible_families" {
+  value = data.cloudtemple_public_cloud_vm_availability_zone.az1.compatible_families
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_availability_zones.md
+++ b/docs/data-sources/public_cloud_vm_availability_zones.md
@@ -19,13 +19,16 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 # Retrieve all availability zones of the tenant.
 data "cloudtemple_public_cloud_vm_availability_zones" "all" {}
 
-# Or only those of a given region.
-data "cloudtemple_public_cloud_vm_availability_zones" "fr1" {
-  region_id = "ed8bb3eb-a64c-46de-884f-65a5ea7d14c7"
+output "zone_names" {
+  value = [for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones : z.name]
 }
 
-output "az_names" {
-  value = [for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones : z.name]
+# Filter in HCL, e.g. the zones of a given region.
+output "fr1_zones" {
+  value = [
+    for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones :
+    z.name if startswith(z.name, "fr1-")
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_backup_policies.md
+++ b/docs/data-sources/public_cloud_vm_backup_policies.md
@@ -19,8 +19,11 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 # Retrieve all backup policies of the tenant.
 data "cloudtemple_public_cloud_vm_backup_policies" "all" {}
 
-output "policy_names" {
-  value = [for p in data.cloudtemple_public_cloud_vm_backup_policies.all.backup_policies : p.name]
+output "policies" {
+  value = [
+    for p in data.cloudtemple_public_cloud_vm_backup_policies.all.backup_policies :
+    "${p.name} (${coalesce(p.retention, 0)} restore points)"
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_backup_policy.md
+++ b/docs/data-sources/public_cloud_vm_backup_policy.md
@@ -16,14 +16,17 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances backup policy by name.
-# A backup policy is required to create a VM (backup_policy_id).
+# Retrieve a backup policy by name. A policy id is required to create a VM
+# (backup_policy_id).
 data "cloudtemple_public_cloud_vm_backup_policy" "daily" {
   name = "Daily backup — 30 days"
 }
 
-output "daily_retention" {
-  value = data.cloudtemple_public_cloud_vm_backup_policy.daily.retention
+output "policy" {
+  value = {
+    id        = data.cloudtemple_public_cloud_vm_backup_policy.daily.id
+    retention = data.cloudtemple_public_cloud_vm_backup_policy.daily.retention
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_disks.md
+++ b/docs/data-sources/public_cloud_vm_disks.md
@@ -16,13 +16,22 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# List the disks of a VM.
-data "cloudtemple_public_cloud_vm_disks" "all" {
-  virtual_machine_id = "00000000-0000-0000-0000-000000000000"
+variable "virtual_machine_id" {
+  type        = string
+  description = "The ID of the VM whose disks are listed."
 }
 
-output "data_disk_sizes" {
-  value = [for d in data.cloudtemple_public_cloud_vm_disks.all.disks : d.size_gb if !d.is_primary]
+# List the disks (system and data) of a VM.
+data "cloudtemple_public_cloud_vm_disks" "vm" {
+  virtual_machine_id = var.virtual_machine_id
+}
+
+output "system_disk_size_gb" {
+  value = one([for d in data.cloudtemple_public_cloud_vm_disks.vm.disks : d.size_gb if d.is_primary])
+}
+
+output "data_disks" {
+  value = [for d in data.cloudtemple_public_cloud_vm_disks.vm.disks : d.name if !d.is_primary]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_flavor.md
+++ b/docs/data-sources/public_cloud_vm_flavor.md
@@ -16,17 +16,16 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances flavor by name.
-data "cloudtemple_public_cloud_vm_flavor" "micro" {
-  name = "dev-micro"
+# Retrieve a flavor (a predefined vCPU/RAM sizing pair) by name.
+data "cloudtemple_public_cloud_vm_flavor" "medium" {
+  name = "m2.medium"
 }
 
-output "micro_vcpu" {
-  value = data.cloudtemple_public_cloud_vm_flavor.micro.vcpu
-}
-
-output "micro_ram_gb" {
-  value = data.cloudtemple_public_cloud_vm_flavor.micro.ram_gb
+output "flavor_sizing" {
+  value = {
+    vcpu   = data.cloudtemple_public_cloud_vm_flavor.medium.vcpu
+    ram_gb = data.cloudtemple_public_cloud_vm_flavor.medium.ram_gb
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_flavors.md
+++ b/docs/data-sources/public_cloud_vm_flavors.md
@@ -16,16 +16,20 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve all flavors of the tenant.
-data "cloudtemple_public_cloud_vm_flavors" "all" {}
-
-# Or only those of a given instance family.
-data "cloudtemple_public_cloud_vm_flavors" "dev" {
-  instance_family_id = "287e8d20-4f07-4107-8b86-8642f6864d3c"
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
 }
 
-output "flavor_names" {
-  value = [for f in data.cloudtemple_public_cloud_vm_flavors.all.flavors : f.name]
+# Retrieve the flavors of an instance family.
+data "cloudtemple_public_cloud_vm_flavors" "dev" {
+  instance_family_id = data.cloudtemple_public_cloud_vm_instance_family.family.id
+}
+
+output "dev_sizings" {
+  value = [
+    for f in data.cloudtemple_public_cloud_vm_flavors.dev.flavors :
+    "${f.name}: ${f.vcpu} vCPU / ${f.ram_gb} GB"
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_instance.md
+++ b/docs/data-sources/public_cloud_vm_instance.md
@@ -16,13 +16,18 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a single VM instance by its id.
-data "cloudtemple_public_cloud_vm_instance" "by_id" {
+# Retrieve a single VM instance by id.
+data "cloudtemple_public_cloud_vm_instance" "web" {
   id = "00000000-0000-0000-0000-000000000000"
 }
 
-output "vm_status" {
-  value = data.cloudtemple_public_cloud_vm_instance.by_id.status
+output "web" {
+  value = {
+    name   = data.cloudtemple_public_cloud_vm_instance.web.name
+    status = data.cloudtemple_public_cloud_vm_instance.web.status
+    vcpu   = data.cloudtemple_public_cloud_vm_instance.web.vcpu
+    ram_gb = data.cloudtemple_public_cloud_vm_instance.web.ram_gb
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_instance_family.md
+++ b/docs/data-sources/public_cloud_vm_instance_family.md
@@ -16,13 +16,19 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances instance family by name.
-data "cloudtemple_public_cloud_vm_instance_family" "general" {
-  name = "General Purpose"
+# Retrieve an instance family by name.
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
 }
 
-output "general_vcpu_max" {
-  value = data.cloudtemple_public_cloud_vm_instance_family.general.vcpu_max
+# The family id is required to create a VM, and bounds its cpu/memory sizing.
+output "family_sizing_bounds" {
+  value = {
+    vcpu_min   = data.cloudtemple_public_cloud_vm_instance_family.family.vcpu_min
+    vcpu_max   = data.cloudtemple_public_cloud_vm_instance_family.family.vcpu_max
+    ram_min_gb = data.cloudtemple_public_cloud_vm_instance_family.family.ram_min_gb
+    ram_max_gb = data.cloudtemple_public_cloud_vm_instance_family.family.ram_max_gb
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_instances.md
+++ b/docs/data-sources/public_cloud_vm_instances.md
@@ -16,13 +16,15 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# List all running VM instances of the tenant (the result set is paginated
-# automatically). Filters are optional.
+# List all VM instances of the tenant (paginated automatically).
+data "cloudtemple_public_cloud_vm_instances" "all" {}
+
+# Server-side filters: name, status, availability_zone_id, instance_family_id.
 data "cloudtemple_public_cloud_vm_instances" "running" {
   status = "running"
 }
 
-output "running_vm_names" {
+output "running_vms" {
   value = [for vm in data.cloudtemple_public_cloud_vm_instances.running.instances : vm.name]
 }
 ```

--- a/docs/data-sources/public_cloud_vm_networks.md
+++ b/docs/data-sources/public_cloud_vm_networks.md
@@ -16,11 +16,20 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve the full Public Cloud VM Instances network catalogue of the tenant.
+# Retrieve the full network catalogue of the tenant. There is no server-side
+# filter — filter in HCL.
 data "cloudtemple_public_cloud_vm_networks" "all" {}
 
 output "network_names" {
   value = [for n in data.cloudtemple_public_cloud_vm_networks.all.networks : n.name]
+}
+
+# A non-empty `vpc` block identifies a VPC network.
+output "vpc_networks" {
+  value = [
+    for n in data.cloudtemple_public_cloud_vm_networks.all.networks :
+    n.name if length(n.vpc) > 0
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_quota.md
+++ b/docs/data-sources/public_cloud_vm_quota.md
@@ -16,11 +16,15 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve the tenant's Public Cloud VM Instances quota (limits + usage).
+# Retrieve the tenant's quota (limits and current usage).
 data "cloudtemple_public_cloud_vm_quota" "current" {}
 
-output "vcpu_free" {
-  value = data.cloudtemple_public_cloud_vm_quota.current.vcpu_limit - data.cloudtemple_public_cloud_vm_quota.current.vcpu_used
+output "vcpu_usage" {
+  value = "${data.cloudtemple_public_cloud_vm_quota.current.vcpu_used}/${data.cloudtemple_public_cloud_vm_quota.current.vcpu_limit}"
+}
+
+output "storage_headroom_gb" {
+  value = data.cloudtemple_public_cloud_vm_quota.current.storage_limit_gb - data.cloudtemple_public_cloud_vm_quota.current.storage_used_gb
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_region.md
+++ b/docs/data-sources/public_cloud_vm_region.md
@@ -16,7 +16,7 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances region by name.
+# Retrieve a region by name.
 data "cloudtemple_public_cloud_vm_region" "fr1" {
   name = "fr1"
 }
@@ -28,6 +28,10 @@ data "cloudtemple_public_cloud_vm_region" "by_id" {
 
 output "region_country" {
   value = data.cloudtemple_public_cloud_vm_region.fr1.country_code
+}
+
+output "region_az_count" {
+  value = data.cloudtemple_public_cloud_vm_region.fr1.az_count
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_regions.md
+++ b/docs/data-sources/public_cloud_vm_regions.md
@@ -16,11 +16,16 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve all Public Cloud VM Instances regions of the tenant.
+# Retrieve all regions of the tenant.
 data "cloudtemple_public_cloud_vm_regions" "all" {}
 
 output "region_names" {
   value = [for r in data.cloudtemple_public_cloud_vm_regions.all.regions : r.name]
+}
+
+# Only the enabled regions.
+output "enabled_regions" {
+  value = [for r in data.cloudtemple_public_cloud_vm_regions.all.regions : r.name if r.is_enabled]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_snapshots.md
+++ b/docs/data-sources/public_cloud_vm_snapshots.md
@@ -16,13 +16,18 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
+variable "virtual_machine_id" {
+  type        = string
+  description = "The ID of the VM whose snapshots are listed."
+}
+
 # List the snapshots of a VM.
-data "cloudtemple_public_cloud_vm_snapshots" "all" {
-  virtual_machine_id = "00000000-0000-0000-0000-000000000000"
+data "cloudtemple_public_cloud_vm_snapshots" "vm" {
+  virtual_machine_id = var.virtual_machine_id
 }
 
 output "snapshot_names" {
-  value = [for s in data.cloudtemple_public_cloud_vm_snapshots.all.snapshots : s.name]
+  value = [for s in data.cloudtemple_public_cloud_vm_snapshots.vm.snapshots : s.name]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_storage_type.md
+++ b/docs/data-sources/public_cloud_vm_storage_type.md
@@ -16,13 +16,18 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances storage type by name.
-data "cloudtemple_public_cloud_vm_storage_type" "standard" {
-  name = "Standard"
+# Retrieve a storage type by name.
+data "cloudtemple_public_cloud_vm_storage_type" "fast" {
+  name = "Enterprise"
 }
 
-output "standard_max_size_gb" {
-  value = data.cloudtemple_public_cloud_vm_storage_type.standard.max_size_gb
+# The storage type id is consumed by the data-disk resource.
+output "storage_type" {
+  value = {
+    id          = data.cloudtemple_public_cloud_vm_storage_type.fast.id
+    iops_hint   = data.cloudtemple_public_cloud_vm_storage_type.fast.iops_hint
+    max_size_gb = data.cloudtemple_public_cloud_vm_storage_type.fast.max_size_gb
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_storage_types.md
+++ b/docs/data-sources/public_cloud_vm_storage_types.md
@@ -19,8 +19,11 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 # Retrieve all storage types available to the tenant.
 data "cloudtemple_public_cloud_vm_storage_types" "all" {}
 
-output "storage_type_names" {
-  value = [for s in data.cloudtemple_public_cloud_vm_storage_types.all.storage_types : s.name]
+output "available_storage_types" {
+  value = [
+    for st in data.cloudtemple_public_cloud_vm_storage_types.all.storage_types :
+    "${st.name} (${st.iops_hint})" if st.is_available
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_task.md
+++ b/docs/data-sources/public_cloud_vm_task.md
@@ -16,11 +16,11 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a diagnostic task by id.
-# NOTE: tasks are diagnostic only and are unrelated to the activities that track
-# writes; never use a task to follow a resource create/update/delete.
+# Retrieve a diagnostic task by id. Tasks are upstream diagnostic objects — the
+# provider tracks its own writes through the Activities service, never through
+# tasks.
 data "cloudtemple_public_cloud_vm_task" "t" {
-  id = "441e1d65-6639-497b-b41b-540955b83a03"
+  id = "00000000-0000-0000-0000-000000000000"
 }
 
 output "task_status" {

--- a/docs/data-sources/public_cloud_vm_tasks.md
+++ b/docs/data-sources/public_cloud_vm_tasks.md
@@ -16,18 +16,21 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve recent diagnostic tasks (optionally scoped to a VM).
-data "cloudtemple_public_cloud_vm_tasks" "recent" {
-  limit = 20
+variable "virtual_machine_id" {
+  type        = string
+  description = "Scope the diagnostic tasks to this VM."
 }
 
-# Or only the tasks of a given VM.
-data "cloudtemple_public_cloud_vm_tasks" "for_vm" {
-  virtual_machine_id = "e2f77153-21a9-4147-9638-6fba09a97b0e"
+# List the diagnostic tasks of a VM (e.g. to investigate a failed operation).
+data "cloudtemple_public_cloud_vm_tasks" "vm" {
+  virtual_machine_id = var.virtual_machine_id
 }
 
-output "recent_task_types" {
-  value = [for t in data.cloudtemple_public_cloud_vm_tasks.recent.tasks : t.task_type]
+output "failed_tasks" {
+  value = [
+    for t in data.cloudtemple_public_cloud_vm_tasks.vm.tasks :
+    "${t.task_type}: ${t.message}" if t.status == "failed"
+  ]
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_template.md
+++ b/docs/data-sources/public_cloud_vm_template.md
@@ -16,13 +16,17 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a Public Cloud VM Instances template (OS image) by name.
-data "cloudtemple_public_cloud_vm_template" "rocky9" {
-  name = "Rocky Linux 9"
+# Retrieve a template (OS image) by name.
+data "cloudtemple_public_cloud_vm_template" "os" {
+  name = "Debian 13"
 }
 
-output "rocky9_disk_sizes" {
-  value = data.cloudtemple_public_cloud_vm_template.rocky9.disk_sizes_gb
+output "template" {
+  value = {
+    id         = data.cloudtemple_public_cloud_vm_template.os.id
+    os_family  = data.cloudtemple_public_cloud_vm_template.os.os_family
+    os_version = data.cloudtemple_public_cloud_vm_template.os.os_version
+  }
 }
 ```
 

--- a/docs/data-sources/public_cloud_vm_templates.md
+++ b/docs/data-sources/public_cloud_vm_templates.md
@@ -16,11 +16,19 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve all templates of the tenant.
+# Retrieve all templates (OS images) of the tenant.
 data "cloudtemple_public_cloud_vm_templates" "all" {}
 
 output "template_names" {
   value = [for t in data.cloudtemple_public_cloud_vm_templates.all.templates : t.name]
+}
+
+# Filter in HCL, e.g. only the Linux images.
+output "linux_templates" {
+  value = [
+    for t in data.cloudtemple_public_cloud_vm_templates.all.templates :
+    t.name if t.os_family == "linux"
+  ]
 }
 ```
 

--- a/docs/resources/public_cloud_vm_disk.md
+++ b/docs/resources/public_cloud_vm_disk.md
@@ -24,14 +24,32 @@ To manage this resource you will need the following roles:
 ```terraform
 variable "virtual_machine_id" {
   type        = string
-  description = "The ID of the VM to attach the data disk to."
+  description = "The ID of the VM to attach the data disks to."
 }
 
-# A 20 GB data disk. Extending it (increasing `size`) requires the VM to be
-# stopped; the disk can only grow, never shrink.
+# A 20 GB data disk with the platform-default storage type and name.
 resource "cloudtemple_public_cloud_vm_disk" "data" {
   virtual_machine_id = var.virtual_machine_id
   size               = 20
+}
+
+# A named disk on an explicit storage type.
+data "cloudtemple_public_cloud_vm_storage_type" "fast" {
+  name = "Enterprise"
+}
+
+resource "cloudtemple_public_cloud_vm_disk" "logs" {
+  virtual_machine_id = var.virtual_machine_id
+  size               = 50
+  name               = "logs-01"
+  storage_type       = data.cloudtemple_public_cloud_vm_storage_type.fast.id
+}
+
+# Extending a disk (increasing `size`) is grow-only and requires the VM to be
+# stopped (power_state = "off" on the VM), as does destroying it.
+
+output "data_disk_position" {
+  value = cloudtemple_public_cloud_vm_disk.data.position
 }
 ```
 

--- a/docs/resources/public_cloud_vm_instance.md
+++ b/docs/resources/public_cloud_vm_instance.md
@@ -22,7 +22,7 @@ To manage this resource you will need the following roles:
 ## Example Usage
 
 ```terraform
-# Look up the catalogue ids by name.
+# Resolve the catalogue by name.
 data "cloudtemple_public_cloud_vm_availability_zone" "az" {
   name = "fr1-az01"
 }
@@ -32,19 +32,21 @@ data "cloudtemple_public_cloud_vm_instance_family" "family" {
 }
 
 data "cloudtemple_public_cloud_vm_template" "os" {
-  name = "Rocky Linux 9"
+  name = "Debian 13"
 }
 
 data "cloudtemple_public_cloud_vm_backup_policy" "policy" {
   name = "No Backup"
 }
 
-variable "network_id" {
-  type        = string
-  description = "The ID of the network to attach the VM's first interface to."
+# The inline os_network_adapter block only accepts Private Backbone networks;
+# attach VPC networks with the cloudtemple_public_cloud_vm_network_adapter
+# resource.
+data "cloudtemple_public_cloud_vm_network" "lan" {
+  name = "LAN01"
 }
 
-# A small Rocky Linux VM, booted at creation.
+# A small VM, booted at creation, bootstrapped with cloud-init.
 resource "cloudtemple_public_cloud_vm_instance" "web" {
   name                 = "web-01"
   availability_zone_id = data.cloudtemple_public_cloud_vm_availability_zone.az.id
@@ -57,18 +59,33 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
 
   os_network_adapter {
     device_index = 0
-    network_id   = var.network_id
+    network_id   = data.cloudtemple_public_cloud_vm_network.lan.id
   }
 
-  # The system disk comes from the template. To grow it later (grow-only),
-  # declare the block with the new size while power_state = "off":
-  # os_disk {
-  #   size_gb = 45
-  # }
+  cloud_init = {
+    cloud_config = <<-EOT
+      #cloud-config
+      hostname: web-01
+      packages:
+        - nginx
+    EOT
+  }
 }
 
-output "vm_status" {
+# Day-2 operations, each in its own apply:
+# - stop/start: toggle power_state between "on" and "off";
+# - resize: change cpu/memory together with power_state = "off";
+# - grow the system disk (grow-only, VM stopped) by declaring:
+#   os_disk {
+#     size_gb = 45
+#   }
+
+output "web_status" {
   value = cloudtemple_public_cloud_vm_instance.web.status
+}
+
+output "web_os_disk_size_gb" {
+  value = one(cloudtemple_public_cloud_vm_instance.web.os_disk[*].size_gb)
 }
 ```
 

--- a/docs/resources/public_cloud_vm_network_adapter.md
+++ b/docs/resources/public_cloud_vm_network_adapter.md
@@ -24,23 +24,43 @@ To manage this resource you will need the following roles:
 ```terraform
 variable "virtual_machine_id" {
   type        = string
-  description = "The ID of the VM to attach the network adapter to."
+  description = "The ID of the VM to attach the network adapters to."
 }
 
-# Resolve a network from the catalogue by name.
+# --- Private Backbone network -------------------------------------------
+
 data "cloudtemple_public_cloud_vm_network" "lan" {
   name = "LAN01"
 }
 
-# Attach a network adapter as eth1. Re-pointing it to another network
-# (changing network_id) and destroying it both require the VM to be stopped.
+# Re-pointing the adapter to another network (changing network_id) and
+# destroying it both require the VM to be stopped.
 resource "cloudtemple_public_cloud_vm_network_adapter" "eth1" {
   virtual_machine_id = var.virtual_machine_id
   device_index       = 1
   network_id         = data.cloudtemple_public_cloud_vm_network.lan.id
+}
 
-  # ip_address is only honoured on VPC networks (ignored on Private Backbone).
-  # ip_address = "10.0.0.5"
+# --- VPC network ---------------------------------------------------------
+
+# A network with a non-empty `vpc` block is a VPC network.
+data "cloudtemple_public_cloud_vm_network" "vpc_net" {
+  name = "my-vpc-private-network"
+}
+
+resource "cloudtemple_public_cloud_vm_network_adapter" "eth2" {
+  virtual_machine_id = var.virtual_machine_id
+  device_index       = 2
+  network_id         = data.cloudtemple_public_cloud_vm_network.vpc_net.id
+
+  # Optional static IPv4, registered on the VPC private network. Only honoured
+  # on VPC networks (ignored on Private Backbone, with a warning); when omitted
+  # the platform assigns one. Write-only: the observed address is `ipv4_address`.
+  ip_address = "10.0.0.50"
+}
+
+output "eth2_type" {
+  value = cloudtemple_public_cloud_vm_network_adapter.eth2.type
 }
 ```
 

--- a/docs/resources/public_cloud_vm_snapshot.md
+++ b/docs/resources/public_cloud_vm_snapshot.md
@@ -27,11 +27,20 @@ variable "virtual_machine_id" {
   description = "The ID of the VM to snapshot."
 }
 
-# A point-in-time snapshot of a VM. Renaming recreates the snapshot; reverting a
-# VM to a snapshot is not managed by Terraform.
-resource "cloudtemple_public_cloud_vm_snapshot" "backup" {
+# A point-in-time snapshot taken before a risky change. `name` is immutable —
+# renaming recreates the snapshot; reverting a VM to a snapshot is not managed
+# by Terraform.
+resource "cloudtemple_public_cloud_vm_snapshot" "pre_upgrade" {
   virtual_machine_id = var.virtual_machine_id
-  name               = "before-upgrade"
+  name               = "pre-upgrade"
+}
+
+output "snapshot_status" {
+  value = cloudtemple_public_cloud_vm_snapshot.pre_upgrade.status
+}
+
+output "snapshot_created_at" {
+  value = cloudtemple_public_cloud_vm_snapshot.pre_upgrade.created_at
 }
 ```
 

--- a/examples/data-sources/cloudtemple_public_cloud_vm_availability_zone/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_availability_zone/data-source.tf
@@ -1,5 +1,5 @@
-# Retrieve a Public Cloud VM Instances availability zone by name.
-data "cloudtemple_public_cloud_vm_availability_zone" "az01" {
+# Retrieve an availability zone by name.
+data "cloudtemple_public_cloud_vm_availability_zone" "az1" {
   name = "fr1-az01"
 }
 
@@ -8,6 +8,11 @@ data "cloudtemple_public_cloud_vm_availability_zone" "by_id" {
   id = "18eea4f6-b4a1-40c1-8435-457ee7a9ab8e"
 }
 
-output "az_region" {
-  value = data.cloudtemple_public_cloud_vm_availability_zone.az01.region_id
+# The zone id is what a VM instance deploys into.
+output "az_id" {
+  value = data.cloudtemple_public_cloud_vm_availability_zone.az1.id
+}
+
+output "az_compatible_families" {
+  value = data.cloudtemple_public_cloud_vm_availability_zone.az1.compatible_families
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_availability_zones/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_availability_zones/data-source.tf
@@ -1,11 +1,14 @@
 # Retrieve all availability zones of the tenant.
 data "cloudtemple_public_cloud_vm_availability_zones" "all" {}
 
-# Or only those of a given region.
-data "cloudtemple_public_cloud_vm_availability_zones" "fr1" {
-  region_id = "ed8bb3eb-a64c-46de-884f-65a5ea7d14c7"
+output "zone_names" {
+  value = [for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones : z.name]
 }
 
-output "az_names" {
-  value = [for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones : z.name]
+# Filter in HCL, e.g. the zones of a given region.
+output "fr1_zones" {
+  value = [
+    for z in data.cloudtemple_public_cloud_vm_availability_zones.all.availability_zones :
+    z.name if startswith(z.name, "fr1-")
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_backup_policies/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_backup_policies/data-source.tf
@@ -1,6 +1,9 @@
 # Retrieve all backup policies of the tenant.
 data "cloudtemple_public_cloud_vm_backup_policies" "all" {}
 
-output "policy_names" {
-  value = [for p in data.cloudtemple_public_cloud_vm_backup_policies.all.backup_policies : p.name]
+output "policies" {
+  value = [
+    for p in data.cloudtemple_public_cloud_vm_backup_policies.all.backup_policies :
+    "${p.name} (${coalesce(p.retention, 0)} restore points)"
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_backup_policy/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_backup_policy/data-source.tf
@@ -1,9 +1,12 @@
-# Retrieve a Public Cloud VM Instances backup policy by name.
-# A backup policy is required to create a VM (backup_policy_id).
+# Retrieve a backup policy by name. A policy id is required to create a VM
+# (backup_policy_id).
 data "cloudtemple_public_cloud_vm_backup_policy" "daily" {
   name = "Daily backup — 30 days"
 }
 
-output "daily_retention" {
-  value = data.cloudtemple_public_cloud_vm_backup_policy.daily.retention
+output "policy" {
+  value = {
+    id        = data.cloudtemple_public_cloud_vm_backup_policy.daily.id
+    retention = data.cloudtemple_public_cloud_vm_backup_policy.daily.retention
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_disks/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_disks/data-source.tf
@@ -1,8 +1,17 @@
-# List the disks of a VM.
-data "cloudtemple_public_cloud_vm_disks" "all" {
-  virtual_machine_id = "00000000-0000-0000-0000-000000000000"
+variable "virtual_machine_id" {
+  type        = string
+  description = "The ID of the VM whose disks are listed."
 }
 
-output "data_disk_sizes" {
-  value = [for d in data.cloudtemple_public_cloud_vm_disks.all.disks : d.size_gb if !d.is_primary]
+# List the disks (system and data) of a VM.
+data "cloudtemple_public_cloud_vm_disks" "vm" {
+  virtual_machine_id = var.virtual_machine_id
+}
+
+output "system_disk_size_gb" {
+  value = one([for d in data.cloudtemple_public_cloud_vm_disks.vm.disks : d.size_gb if d.is_primary])
+}
+
+output "data_disks" {
+  value = [for d in data.cloudtemple_public_cloud_vm_disks.vm.disks : d.name if !d.is_primary]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_flavor/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_flavor/data-source.tf
@@ -1,12 +1,11 @@
-# Retrieve a Public Cloud VM Instances flavor by name.
-data "cloudtemple_public_cloud_vm_flavor" "micro" {
-  name = "dev-micro"
+# Retrieve a flavor (a predefined vCPU/RAM sizing pair) by name.
+data "cloudtemple_public_cloud_vm_flavor" "medium" {
+  name = "m2.medium"
 }
 
-output "micro_vcpu" {
-  value = data.cloudtemple_public_cloud_vm_flavor.micro.vcpu
-}
-
-output "micro_ram_gb" {
-  value = data.cloudtemple_public_cloud_vm_flavor.micro.ram_gb
+output "flavor_sizing" {
+  value = {
+    vcpu   = data.cloudtemple_public_cloud_vm_flavor.medium.vcpu
+    ram_gb = data.cloudtemple_public_cloud_vm_flavor.medium.ram_gb
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_flavors/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_flavors/data-source.tf
@@ -1,11 +1,15 @@
-# Retrieve all flavors of the tenant.
-data "cloudtemple_public_cloud_vm_flavors" "all" {}
-
-# Or only those of a given instance family.
-data "cloudtemple_public_cloud_vm_flavors" "dev" {
-  instance_family_id = "287e8d20-4f07-4107-8b86-8642f6864d3c"
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
 }
 
-output "flavor_names" {
-  value = [for f in data.cloudtemple_public_cloud_vm_flavors.all.flavors : f.name]
+# Retrieve the flavors of an instance family.
+data "cloudtemple_public_cloud_vm_flavors" "dev" {
+  instance_family_id = data.cloudtemple_public_cloud_vm_instance_family.family.id
+}
+
+output "dev_sizings" {
+  value = [
+    for f in data.cloudtemple_public_cloud_vm_flavors.dev.flavors :
+    "${f.name}: ${f.vcpu} vCPU / ${f.ram_gb} GB"
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_instance/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_instance/data-source.tf
@@ -1,8 +1,13 @@
-# Retrieve a single VM instance by its id.
-data "cloudtemple_public_cloud_vm_instance" "by_id" {
+# Retrieve a single VM instance by id.
+data "cloudtemple_public_cloud_vm_instance" "web" {
   id = "00000000-0000-0000-0000-000000000000"
 }
 
-output "vm_status" {
-  value = data.cloudtemple_public_cloud_vm_instance.by_id.status
+output "web" {
+  value = {
+    name   = data.cloudtemple_public_cloud_vm_instance.web.name
+    status = data.cloudtemple_public_cloud_vm_instance.web.status
+    vcpu   = data.cloudtemple_public_cloud_vm_instance.web.vcpu
+    ram_gb = data.cloudtemple_public_cloud_vm_instance.web.ram_gb
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_instance_family/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_instance_family/data-source.tf
@@ -1,8 +1,14 @@
-# Retrieve a Public Cloud VM Instances instance family by name.
-data "cloudtemple_public_cloud_vm_instance_family" "general" {
-  name = "General Purpose"
+# Retrieve an instance family by name.
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
 }
 
-output "general_vcpu_max" {
-  value = data.cloudtemple_public_cloud_vm_instance_family.general.vcpu_max
+# The family id is required to create a VM, and bounds its cpu/memory sizing.
+output "family_sizing_bounds" {
+  value = {
+    vcpu_min   = data.cloudtemple_public_cloud_vm_instance_family.family.vcpu_min
+    vcpu_max   = data.cloudtemple_public_cloud_vm_instance_family.family.vcpu_max
+    ram_min_gb = data.cloudtemple_public_cloud_vm_instance_family.family.ram_min_gb
+    ram_max_gb = data.cloudtemple_public_cloud_vm_instance_family.family.ram_max_gb
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_instances/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_instances/data-source.tf
@@ -1,9 +1,11 @@
-# List all running VM instances of the tenant (the result set is paginated
-# automatically). Filters are optional.
+# List all VM instances of the tenant (paginated automatically).
+data "cloudtemple_public_cloud_vm_instances" "all" {}
+
+# Server-side filters: name, status, availability_zone_id, instance_family_id.
 data "cloudtemple_public_cloud_vm_instances" "running" {
   status = "running"
 }
 
-output "running_vm_names" {
+output "running_vms" {
   value = [for vm in data.cloudtemple_public_cloud_vm_instances.running.instances : vm.name]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_networks/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_networks/data-source.tf
@@ -1,6 +1,15 @@
-# Retrieve the full Public Cloud VM Instances network catalogue of the tenant.
+# Retrieve the full network catalogue of the tenant. There is no server-side
+# filter — filter in HCL.
 data "cloudtemple_public_cloud_vm_networks" "all" {}
 
 output "network_names" {
   value = [for n in data.cloudtemple_public_cloud_vm_networks.all.networks : n.name]
+}
+
+# A non-empty `vpc` block identifies a VPC network.
+output "vpc_networks" {
+  value = [
+    for n in data.cloudtemple_public_cloud_vm_networks.all.networks :
+    n.name if length(n.vpc) > 0
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_quota/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_quota/data-source.tf
@@ -1,6 +1,10 @@
-# Retrieve the tenant's Public Cloud VM Instances quota (limits + usage).
+# Retrieve the tenant's quota (limits and current usage).
 data "cloudtemple_public_cloud_vm_quota" "current" {}
 
-output "vcpu_free" {
-  value = data.cloudtemple_public_cloud_vm_quota.current.vcpu_limit - data.cloudtemple_public_cloud_vm_quota.current.vcpu_used
+output "vcpu_usage" {
+  value = "${data.cloudtemple_public_cloud_vm_quota.current.vcpu_used}/${data.cloudtemple_public_cloud_vm_quota.current.vcpu_limit}"
+}
+
+output "storage_headroom_gb" {
+  value = data.cloudtemple_public_cloud_vm_quota.current.storage_limit_gb - data.cloudtemple_public_cloud_vm_quota.current.storage_used_gb
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_region/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_region/data-source.tf
@@ -1,4 +1,4 @@
-# Retrieve a Public Cloud VM Instances region by name.
+# Retrieve a region by name.
 data "cloudtemple_public_cloud_vm_region" "fr1" {
   name = "fr1"
 }
@@ -10,4 +10,8 @@ data "cloudtemple_public_cloud_vm_region" "by_id" {
 
 output "region_country" {
   value = data.cloudtemple_public_cloud_vm_region.fr1.country_code
+}
+
+output "region_az_count" {
+  value = data.cloudtemple_public_cloud_vm_region.fr1.az_count
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_regions/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_regions/data-source.tf
@@ -1,6 +1,11 @@
-# Retrieve all Public Cloud VM Instances regions of the tenant.
+# Retrieve all regions of the tenant.
 data "cloudtemple_public_cloud_vm_regions" "all" {}
 
 output "region_names" {
   value = [for r in data.cloudtemple_public_cloud_vm_regions.all.regions : r.name]
+}
+
+# Only the enabled regions.
+output "enabled_regions" {
+  value = [for r in data.cloudtemple_public_cloud_vm_regions.all.regions : r.name if r.is_enabled]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_snapshots/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_snapshots/data-source.tf
@@ -1,8 +1,13 @@
+variable "virtual_machine_id" {
+  type        = string
+  description = "The ID of the VM whose snapshots are listed."
+}
+
 # List the snapshots of a VM.
-data "cloudtemple_public_cloud_vm_snapshots" "all" {
-  virtual_machine_id = "00000000-0000-0000-0000-000000000000"
+data "cloudtemple_public_cloud_vm_snapshots" "vm" {
+  virtual_machine_id = var.virtual_machine_id
 }
 
 output "snapshot_names" {
-  value = [for s in data.cloudtemple_public_cloud_vm_snapshots.all.snapshots : s.name]
+  value = [for s in data.cloudtemple_public_cloud_vm_snapshots.vm.snapshots : s.name]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_storage_type/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_storage_type/data-source.tf
@@ -1,8 +1,13 @@
-# Retrieve a Public Cloud VM Instances storage type by name.
-data "cloudtemple_public_cloud_vm_storage_type" "standard" {
-  name = "Standard"
+# Retrieve a storage type by name.
+data "cloudtemple_public_cloud_vm_storage_type" "fast" {
+  name = "Enterprise"
 }
 
-output "standard_max_size_gb" {
-  value = data.cloudtemple_public_cloud_vm_storage_type.standard.max_size_gb
+# The storage type id is consumed by the data-disk resource.
+output "storage_type" {
+  value = {
+    id          = data.cloudtemple_public_cloud_vm_storage_type.fast.id
+    iops_hint   = data.cloudtemple_public_cloud_vm_storage_type.fast.iops_hint
+    max_size_gb = data.cloudtemple_public_cloud_vm_storage_type.fast.max_size_gb
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_storage_types/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_storage_types/data-source.tf
@@ -1,6 +1,9 @@
 # Retrieve all storage types available to the tenant.
 data "cloudtemple_public_cloud_vm_storage_types" "all" {}
 
-output "storage_type_names" {
-  value = [for s in data.cloudtemple_public_cloud_vm_storage_types.all.storage_types : s.name]
+output "available_storage_types" {
+  value = [
+    for st in data.cloudtemple_public_cloud_vm_storage_types.all.storage_types :
+    "${st.name} (${st.iops_hint})" if st.is_available
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_task/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_task/data-source.tf
@@ -1,8 +1,8 @@
-# Retrieve a diagnostic task by id.
-# NOTE: tasks are diagnostic only and are unrelated to the activities that track
-# writes; never use a task to follow a resource create/update/delete.
+# Retrieve a diagnostic task by id. Tasks are upstream diagnostic objects — the
+# provider tracks its own writes through the Activities service, never through
+# tasks.
 data "cloudtemple_public_cloud_vm_task" "t" {
-  id = "441e1d65-6639-497b-b41b-540955b83a03"
+  id = "00000000-0000-0000-0000-000000000000"
 }
 
 output "task_status" {

--- a/examples/data-sources/cloudtemple_public_cloud_vm_tasks/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_tasks/data-source.tf
@@ -1,13 +1,16 @@
-# Retrieve recent diagnostic tasks (optionally scoped to a VM).
-data "cloudtemple_public_cloud_vm_tasks" "recent" {
-  limit = 20
+variable "virtual_machine_id" {
+  type        = string
+  description = "Scope the diagnostic tasks to this VM."
 }
 
-# Or only the tasks of a given VM.
-data "cloudtemple_public_cloud_vm_tasks" "for_vm" {
-  virtual_machine_id = "e2f77153-21a9-4147-9638-6fba09a97b0e"
+# List the diagnostic tasks of a VM (e.g. to investigate a failed operation).
+data "cloudtemple_public_cloud_vm_tasks" "vm" {
+  virtual_machine_id = var.virtual_machine_id
 }
 
-output "recent_task_types" {
-  value = [for t in data.cloudtemple_public_cloud_vm_tasks.recent.tasks : t.task_type]
+output "failed_tasks" {
+  value = [
+    for t in data.cloudtemple_public_cloud_vm_tasks.vm.tasks :
+    "${t.task_type}: ${t.message}" if t.status == "failed"
+  ]
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_template/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_template/data-source.tf
@@ -1,8 +1,12 @@
-# Retrieve a Public Cloud VM Instances template (OS image) by name.
-data "cloudtemple_public_cloud_vm_template" "rocky9" {
-  name = "Rocky Linux 9"
+# Retrieve a template (OS image) by name.
+data "cloudtemple_public_cloud_vm_template" "os" {
+  name = "Debian 13"
 }
 
-output "rocky9_disk_sizes" {
-  value = data.cloudtemple_public_cloud_vm_template.rocky9.disk_sizes_gb
+output "template" {
+  value = {
+    id         = data.cloudtemple_public_cloud_vm_template.os.id
+    os_family  = data.cloudtemple_public_cloud_vm_template.os.os_family
+    os_version = data.cloudtemple_public_cloud_vm_template.os.os_version
+  }
 }

--- a/examples/data-sources/cloudtemple_public_cloud_vm_templates/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_templates/data-source.tf
@@ -1,6 +1,14 @@
-# Retrieve all templates of the tenant.
+# Retrieve all templates (OS images) of the tenant.
 data "cloudtemple_public_cloud_vm_templates" "all" {}
 
 output "template_names" {
   value = [for t in data.cloudtemple_public_cloud_vm_templates.all.templates : t.name]
+}
+
+# Filter in HCL, e.g. only the Linux images.
+output "linux_templates" {
+  value = [
+    for t in data.cloudtemple_public_cloud_vm_templates.all.templates :
+    t.name if t.os_family == "linux"
+  ]
 }

--- a/examples/resources/cloudtemple_public_cloud_vm_disk/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_disk/resource.tf
@@ -1,11 +1,29 @@
 variable "virtual_machine_id" {
   type        = string
-  description = "The ID of the VM to attach the data disk to."
+  description = "The ID of the VM to attach the data disks to."
 }
 
-# A 20 GB data disk. Extending it (increasing `size`) requires the VM to be
-# stopped; the disk can only grow, never shrink.
+# A 20 GB data disk with the platform-default storage type and name.
 resource "cloudtemple_public_cloud_vm_disk" "data" {
   virtual_machine_id = var.virtual_machine_id
   size               = 20
+}
+
+# A named disk on an explicit storage type.
+data "cloudtemple_public_cloud_vm_storage_type" "fast" {
+  name = "Enterprise"
+}
+
+resource "cloudtemple_public_cloud_vm_disk" "logs" {
+  virtual_machine_id = var.virtual_machine_id
+  size               = 50
+  name               = "logs-01"
+  storage_type       = data.cloudtemple_public_cloud_vm_storage_type.fast.id
+}
+
+# Extending a disk (increasing `size`) is grow-only and requires the VM to be
+# stopped (power_state = "off" on the VM), as does destroying it.
+
+output "data_disk_position" {
+  value = cloudtemple_public_cloud_vm_disk.data.position
 }

--- a/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_instance/resource.tf
@@ -1,4 +1,4 @@
-# Look up the catalogue ids by name.
+# Resolve the catalogue by name.
 data "cloudtemple_public_cloud_vm_availability_zone" "az" {
   name = "fr1-az01"
 }
@@ -8,19 +8,21 @@ data "cloudtemple_public_cloud_vm_instance_family" "family" {
 }
 
 data "cloudtemple_public_cloud_vm_template" "os" {
-  name = "Rocky Linux 9"
+  name = "Debian 13"
 }
 
 data "cloudtemple_public_cloud_vm_backup_policy" "policy" {
   name = "No Backup"
 }
 
-variable "network_id" {
-  type        = string
-  description = "The ID of the network to attach the VM's first interface to."
+# The inline os_network_adapter block only accepts Private Backbone networks;
+# attach VPC networks with the cloudtemple_public_cloud_vm_network_adapter
+# resource.
+data "cloudtemple_public_cloud_vm_network" "lan" {
+  name = "LAN01"
 }
 
-# A small Rocky Linux VM, booted at creation.
+# A small VM, booted at creation, bootstrapped with cloud-init.
 resource "cloudtemple_public_cloud_vm_instance" "web" {
   name                 = "web-01"
   availability_zone_id = data.cloudtemple_public_cloud_vm_availability_zone.az.id
@@ -33,16 +35,31 @@ resource "cloudtemple_public_cloud_vm_instance" "web" {
 
   os_network_adapter {
     device_index = 0
-    network_id   = var.network_id
+    network_id   = data.cloudtemple_public_cloud_vm_network.lan.id
   }
 
-  # The system disk comes from the template. To grow it later (grow-only),
-  # declare the block with the new size while power_state = "off":
-  # os_disk {
-  #   size_gb = 45
-  # }
+  cloud_init = {
+    cloud_config = <<-EOT
+      #cloud-config
+      hostname: web-01
+      packages:
+        - nginx
+    EOT
+  }
 }
 
-output "vm_status" {
+# Day-2 operations, each in its own apply:
+# - stop/start: toggle power_state between "on" and "off";
+# - resize: change cpu/memory together with power_state = "off";
+# - grow the system disk (grow-only, VM stopped) by declaring:
+#   os_disk {
+#     size_gb = 45
+#   }
+
+output "web_status" {
   value = cloudtemple_public_cloud_vm_instance.web.status
+}
+
+output "web_os_disk_size_gb" {
+  value = one(cloudtemple_public_cloud_vm_instance.web.os_disk[*].size_gb)
 }

--- a/examples/resources/cloudtemple_public_cloud_vm_network_adapter/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_network_adapter/resource.tf
@@ -1,20 +1,40 @@
 variable "virtual_machine_id" {
   type        = string
-  description = "The ID of the VM to attach the network adapter to."
+  description = "The ID of the VM to attach the network adapters to."
 }
 
-# Resolve a network from the catalogue by name.
+# --- Private Backbone network -------------------------------------------
+
 data "cloudtemple_public_cloud_vm_network" "lan" {
   name = "LAN01"
 }
 
-# Attach a network adapter as eth1. Re-pointing it to another network
-# (changing network_id) and destroying it both require the VM to be stopped.
+# Re-pointing the adapter to another network (changing network_id) and
+# destroying it both require the VM to be stopped.
 resource "cloudtemple_public_cloud_vm_network_adapter" "eth1" {
   virtual_machine_id = var.virtual_machine_id
   device_index       = 1
   network_id         = data.cloudtemple_public_cloud_vm_network.lan.id
+}
 
-  # ip_address is only honoured on VPC networks (ignored on Private Backbone).
-  # ip_address = "10.0.0.5"
+# --- VPC network ---------------------------------------------------------
+
+# A network with a non-empty `vpc` block is a VPC network.
+data "cloudtemple_public_cloud_vm_network" "vpc_net" {
+  name = "my-vpc-private-network"
+}
+
+resource "cloudtemple_public_cloud_vm_network_adapter" "eth2" {
+  virtual_machine_id = var.virtual_machine_id
+  device_index       = 2
+  network_id         = data.cloudtemple_public_cloud_vm_network.vpc_net.id
+
+  # Optional static IPv4, registered on the VPC private network. Only honoured
+  # on VPC networks (ignored on Private Backbone, with a warning); when omitted
+  # the platform assigns one. Write-only: the observed address is `ipv4_address`.
+  ip_address = "10.0.0.50"
+}
+
+output "eth2_type" {
+  value = cloudtemple_public_cloud_vm_network_adapter.eth2.type
 }

--- a/examples/resources/cloudtemple_public_cloud_vm_snapshot/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_snapshot/resource.tf
@@ -3,9 +3,18 @@ variable "virtual_machine_id" {
   description = "The ID of the VM to snapshot."
 }
 
-# A point-in-time snapshot of a VM. Renaming recreates the snapshot; reverting a
-# VM to a snapshot is not managed by Terraform.
-resource "cloudtemple_public_cloud_vm_snapshot" "backup" {
+# A point-in-time snapshot taken before a risky change. `name` is immutable —
+# renaming recreates the snapshot; reverting a VM to a snapshot is not managed
+# by Terraform.
+resource "cloudtemple_public_cloud_vm_snapshot" "pre_upgrade" {
   virtual_machine_id = var.virtual_machine_id
-  name               = "before-upgrade"
+  name               = "pre-upgrade"
+}
+
+output "snapshot_status" {
+  value = cloudtemple_public_cloud_vm_snapshot.pre_upgrade.status
+}
+
+output "snapshot_created_at" {
+  value = cloudtemple_public_cloud_vm_snapshot.pre_upgrade.created_at
 }


### PR DESCRIPTION
Refs #475 — E9-6, last item of the pre-release feedback batch (#409): "more examples everywhere".

## What
Every `public_cloud_vm` datasource and resource now ships a practical example (all embedded into the generated docs):
- **by-id and by-name** lookups where both exist;
- **chaining**: catalogue datasources → VM create; storage type → data disk; network → adapter;
- **HCL filtering** where the API has no server-side filter (zones by region, Linux templates, VPC networks via `length(vpc) > 0`);
- **useful outputs** (quota headroom, failed diagnostic tasks, system-disk size, flavor sizings…);
- the **VM resource** example is a full scenario (catalogue lookups, `os_network_adapter`, `cloud_init`, day-2 notes for resize / `os_disk { size_gb }` growth);
- the **network adapter** example shows both **Private Backbone and VPC** (with the write-only `ip_address` semantics).

## Verification
Every referenced attribute checked against the actual schemas/flatten helpers; `terraform fmt` clean; `TestExample` gate green (run with credentials). Codex fact-check: two wording errors found (backup `retention` is restore points, not days; exact `instances` filter names) — **fixed verbatim**, no other issue.