### PR TITLE
fix(#425): base64-encode the cloud-init payload for the create API

### DIFF
--- a/docs/resources/public_cloud_vm_instance.md
+++ b/docs/resources/public_cloud_vm_instance.md
@@ -105,7 +105,7 @@ output "web_os_disk_size_gb" {
 
 ### Optional
 
-- `cloud_init` (Map of String) The cloud-init configuration applied at creation (keys `cloud_config` and/or `network_config`). Immutable and not readable back, so it is not reconciled on refresh.
+- `cloud_init` (Map of String) The cloud-init configuration applied at creation (keys `cloud_config` and/or `network_config`), as plain YAML — the provider base64-encodes it for the API. Immutable and not readable back, so it is not reconciled on refresh.
 - `os_disk` (Block List, Max: 1) The system (primary) disk of the VM, provided by the template. Declare the block with `size_gb` to grow it (grow-only; requires the VM to be stopped). Not settable at creation — the template's size is used. Data disks are managed by the separate disk resource. (see [below for nested schema](#nestedblock--os_disk))
 - `power_state` (String) The desired power state (`on` or `off`, default `off`). Honoured from the first apply (passed to the create call, so an `on` VM boots at creation). Changing it later issues a start (`off`->`on`) or stop (`on`->`off`).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/provider/resource_public_cloud_vm_instance.go
+++ b/internal/provider/resource_public_cloud_vm_instance.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -145,7 +146,7 @@ func resourcePublicCloudVMInstance() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "The cloud-init configuration applied at creation (keys `cloud_config` and/or `network_config`). Immutable and not readable back, so it is not reconciled on refresh.",
+				Description: "The cloud-init configuration applied at creation (keys `cloud_config` and/or `network_config`), as plain YAML — the provider base64-encodes it for the API. Immutable and not readable back, so it is not reconciled on refresh.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ValidateDiagFunc: validation.MapKeyMatch(
 					regexp.MustCompile("^cloud_config$|^network_config$"),
@@ -795,16 +796,21 @@ func expandVMInstanceNICs(raw []interface{}) []client.CreateVMInstanceNIC {
 	return nics
 }
 
+// expandVMInstanceCloudInit maps the cloud_init config into the create body.
+// The API only accepts base64-encoded payloads (verified live: a raw YAML is
+// rejected with "Must be a valid base64-encoded string"), so the user writes
+// plain YAML and the provider encodes it — always, never conditionally, so a
+// payload that happens to look like base64 is never double-interpreted.
 func expandVMInstanceCloudInit(raw map[string]interface{}) *client.CreateVMInstanceCloudInit {
 	if len(raw) == 0 {
 		return nil
 	}
 	ci := &client.CreateVMInstanceCloudInit{}
-	if v, ok := raw["cloud_config"].(string); ok {
-		ci.CloudConfig = v
+	if v, ok := raw["cloud_config"].(string); ok && v != "" {
+		ci.CloudConfig = base64.StdEncoding.EncodeToString([]byte(v))
 	}
-	if v, ok := raw["network_config"].(string); ok {
-		ci.NetworkConfig = v
+	if v, ok := raw["network_config"].(string); ok && v != "" {
+		ci.NetworkConfig = base64.StdEncoding.EncodeToString([]byte(v))
 	}
 	return ci
 }

--- a/internal/provider/resource_public_cloud_vm_instance_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_instance_unit_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"reflect"
 	"testing"
@@ -556,13 +557,25 @@ func TestBuildCreateVMInstanceRequest(t *testing.T) {
 	}
 }
 
+// TestExpandVMInstanceCloudInit pins the wire contract verified live: the API
+// only accepts base64-encoded cloud-init payloads, so the provider ALWAYS
+// encodes the user's plain YAML (never conditionally — a payload that happens
+// to look like base64 must not be passed through).
 func TestExpandVMInstanceCloudInit(t *testing.T) {
 	if ci := expandVMInstanceCloudInit(map[string]interface{}{}); ci != nil {
 		t.Fatalf("empty cloud_init must be nil, got %+v", ci)
 	}
 	ci := expandVMInstanceCloudInit(map[string]interface{}{"cloud_config": "#cloud-config", "network_config": "version: 2"})
-	if ci == nil || ci.CloudConfig != "#cloud-config" || ci.NetworkConfig != "version: 2" {
-		t.Fatalf("cloud_init mapping wrong: %+v", ci)
+	wantCC := base64.StdEncoding.EncodeToString([]byte("#cloud-config"))
+	wantNC := base64.StdEncoding.EncodeToString([]byte("version: 2"))
+	if ci == nil || ci.CloudConfig != wantCC || ci.NetworkConfig != wantNC {
+		t.Fatalf("cloud_init must be base64-encoded: got %+v, want cc=%q nc=%q", ci, wantCC, wantNC)
+	}
+	// base64-looking input is still (re-)encoded — never passed through on a guess.
+	in := "Zm9v" // valid base64 of "foo", but the user meant the literal string
+	ci = expandVMInstanceCloudInit(map[string]interface{}{"cloud_config": in})
+	if want := base64.StdEncoding.EncodeToString([]byte(in)); ci == nil || ci.CloudConfig != want {
+		t.Fatalf("base64-looking input must be re-encoded verbatim: got %+v, want %q", ci, want)
 	}
 }
 


### PR DESCRIPTION
Refs #425. Found while live-validating a full end-to-end scenario: the VM create API only accepts **base64-encoded** cloud-init payloads (a raw YAML is rejected with `Must be a valid base64-encoded string` on `user_data`) — so `cloud_init` was unusable as shipped in E2.

## What
`expandVMInstanceCloudInit` now **always** base64-encodes `cloud_config` / `network_config`: the user writes plain YAML (documented in the schema), the provider handles the wire format. Always-encode, never conditionally — a payload that happens to look like base64 is treated as literal content and re-encoded, so there is no double-interpretation ambiguity. Pre-release, so no compatibility path is needed.

## Verification
- Unit tests replace the old passthrough assertions: plain YAML → base64, base64-looking input re-encoded, empty map omitted.
- **Live on DEV**: the same YAML that failed raw now provisions end-to-end (VM boots with the declared user, SSH password auth enabled by cloud-init) — exercised through a full 2-VM composite scenario (VPC adapters + floating IPs + disks), then destroyed with 0 orphan.

Codex review — GO.