### PR TITLE
feat(#482): catalogue by-name lookups fail on ambiguity (E9-7)

### DIFF
--- a/docs/data-sources/public_cloud_vm_template.md
+++ b/docs/data-sources/public_cloud_vm_template.md
@@ -16,9 +16,21 @@ To query this datasource you will need the `public_cloud_vm_instances_read` role
 ## Example Usage
 
 ```terraform
-# Retrieve a template (OS image) by name.
+data "cloudtemple_public_cloud_vm_availability_zone" "az" {
+  name = "fr1-az01"
+}
+
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
+}
+
+# Template names are not guaranteed unique across zones and families: combine
+# the name with the server-side filters to select the right image. An ambiguous
+# match fails with the candidate ids instead of silently picking one.
 data "cloudtemple_public_cloud_vm_template" "os" {
-  name = "Debian 13"
+  name                 = "Debian 13"
+  availability_zone_id = data.cloudtemple_public_cloud_vm_availability_zone.az.id
+  instance_family_id   = data.cloudtemple_public_cloud_vm_instance_family.family.id
 }
 
 output "template" {

--- a/examples/data-sources/cloudtemple_public_cloud_vm_template/data-source.tf
+++ b/examples/data-sources/cloudtemple_public_cloud_vm_template/data-source.tf
@@ -1,6 +1,18 @@
-# Retrieve a template (OS image) by name.
+data "cloudtemple_public_cloud_vm_availability_zone" "az" {
+  name = "fr1-az01"
+}
+
+data "cloudtemple_public_cloud_vm_instance_family" "family" {
+  name = "Development"
+}
+
+# Template names are not guaranteed unique across zones and families: combine
+# the name with the server-side filters to select the right image. An ambiguous
+# match fails with the candidate ids instead of silently picking one.
 data "cloudtemple_public_cloud_vm_template" "os" {
-  name = "Debian 13"
+  name                 = "Debian 13"
+  availability_zone_id = data.cloudtemple_public_cloud_vm_availability_zone.az.id
+  instance_family_id   = data.cloudtemple_public_cloud_vm_instance_family.family.id
 }
 
 output "template" {

--- a/internal/provider/data_source_public_cloud_vm_availability_zone.go
+++ b/internal/provider/data_source_public_cloud_vm_availability_zone.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -97,14 +98,20 @@ func publicCloudVMAvailabilityZoneRead(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to find availability zone named %q: %s", name, err))
 		}
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, z := range zones {
 			if z.Name == name {
 				az = z
-				break
+				matches = append(matches, z.ID)
 			}
 		}
 		if az == nil {
 			return diag.FromErr(fmt.Errorf("failed to find availability zone named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d availability zones named %q (ids: %s); narrow with region_id or use id", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_backup_policy.go
+++ b/internal/provider/data_source_public_cloud_vm_backup_policy.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -75,14 +76,20 @@ func publicCloudVMBackupPolicyRead(ctx context.Context, d *schema.ResourceData, 
 
 	var policy *client.PublicCloudVMBackupPolicy
 	if name := d.Get("name").(string); name != "" {
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, p := range policies {
 			if p.Name == name {
 				policy = p
-				break
+				matches = append(matches, p.ID)
 			}
 		}
 		if policy == nil {
 			return diag.FromErr(fmt.Errorf("failed to find backup policy named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d backup policies named %q (ids: %s); use id to disambiguate", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_flavor.go
+++ b/internal/provider/data_source_public_cloud_vm_flavor.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -68,14 +69,20 @@ func publicCloudVMFlavorRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	var flavor *client.PublicCloudVMFlavor
 	if name := d.Get("name").(string); name != "" {
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, f := range flavors {
 			if f.Name == name {
 				flavor = f
-				break
+				matches = append(matches, f.ID)
 			}
 		}
 		if flavor == nil {
 			return diag.FromErr(fmt.Errorf("failed to find flavor named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d flavors named %q (ids: %s); narrow with instance_family_id or use id", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_instance_family.go
+++ b/internal/provider/data_source_public_cloud_vm_instance_family.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -74,14 +75,20 @@ func publicCloudVMInstanceFamilyRead(ctx context.Context, d *schema.ResourceData
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to find instance family named %q: %s", name, err))
 		}
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, f := range families {
 			if f.Name == name {
 				family = f
-				break
+				matches = append(matches, f.ID)
 			}
 		}
 		if family == nil {
 			return diag.FromErr(fmt.Errorf("failed to find instance family named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d instance families named %q (ids: %s); use id to disambiguate", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_region.go
+++ b/internal/provider/data_source_public_cloud_vm_region.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -85,14 +86,20 @@ func publicCloudVMRegionRead(ctx context.Context, d *schema.ResourceData, meta a
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to find region named %q: %s", name, err))
 		}
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, r := range regions {
 			if r.Name == name {
 				region = r
-				break
+				matches = append(matches, r.ID)
 			}
 		}
 		if region == nil {
 			return diag.FromErr(fmt.Errorf("failed to find region named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d regions named %q (ids: %s); use id to disambiguate", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_storage_type.go
+++ b/internal/provider/data_source_public_cloud_vm_storage_type.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -75,14 +76,20 @@ func publicCloudVMStorageTypeRead(ctx context.Context, d *schema.ResourceData, m
 
 	var st *client.PublicCloudVMStorageType
 	if name := d.Get("name").(string); name != "" {
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, s := range storageTypes {
 			if s.Name == name {
 				st = s
-				break
+				matches = append(matches, s.ID)
 			}
 		}
 		if st == nil {
 			return diag.FromErr(fmt.Errorf("failed to find storage type named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d storage types named %q (ids: %s); use id to disambiguate", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)

--- a/internal/provider/data_source_public_cloud_vm_template.go
+++ b/internal/provider/data_source_public_cloud_vm_template.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/provider/helpers"
@@ -76,14 +77,20 @@ func publicCloudVMTemplateRead(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to find template named %q: %s", name, err))
 		}
+		// Names are not guaranteed unique: refuse an ambiguous match rather
+		// than silently picking one.
+		var matches []string
 		for _, t := range tpls {
 			if t.Name == name {
 				tpl = t
-				break
+				matches = append(matches, t.ID)
 			}
 		}
 		if tpl == nil {
 			return diag.FromErr(fmt.Errorf("failed to find template named %q", name))
+		}
+		if len(matches) > 1 {
+			return diag.FromErr(fmt.Errorf("found %d templates named %q (ids: %s); narrow with instance_family_id and availability_zone_id, or use id", len(matches), name, strings.Join(matches, ", ")))
 		}
 	} else {
 		id := d.Get("id").(string)


### PR DESCRIPTION
Refs #482 — follow-up of the composite-scenario validation: with five live templates named "Debian 13" (two remaining even within one az+family), the catalogue single datasources silently picked the FIRST name match — which selected a wrong/incompatible template and surfaced as an opaque platform error.

## What
- All 7 catalogue by-name lookups (**region, availability_zone, flavor, instance_family, storage_type, template, backup_policy**) now **fail on >1 match**, listing the candidate ids with a type-appropriate hint (e.g. template: *narrow with `instance_family_id` and `availability_zone_id`, or use `id`*) — same idiom as the network datasource.
- The template example demonstrates the combined `name + availability_zone_id + instance_family_id` lookup (the server-side filters were already wired since E1 — the examples just never showed them).

## Verification
Live on DEV: name-only lookup fails listing the 5 candidates; filtered lookup fails listing the 2 genuine duplicates — both with actionable messages. Suites green; Codex review — GO.