### PR TITLE
feat(#484): destroy stops a running VM before deleting disks and adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 NEW FEATURES :
 
   * Added resource `cloudtemple_public_cloud_vm_instance` to manage a Public Cloud VM instance: create, start/stop (`power_state`), rename, change the backup policy, resize `cpu`/`memory` and grow the OS disk (`os_disk.size_gb`) — resize and OS disk growth require the VM to be stopped.
-  * Added resource `cloudtemple_public_cloud_vm_disk` to manage a data disk attached to a Public Cloud VM instance: create, grow-only extend and delete (extend and delete require the VM to be stopped). Import with `<virtual_machine_id>/<disk_id>`.
+  * Added resource `cloudtemple_public_cloud_vm_disk` to manage a data disk attached to a Public Cloud VM instance: create, grow-only extend and delete (extend requires the VM to be stopped; delete stops a running VM automatically). Import with `<virtual_machine_id>/<disk_id>`.
   * Added resource `cloudtemple_public_cloud_vm_snapshot` to manage a snapshot of a Public Cloud VM instance (`name` is immutable). Import with `<virtual_machine_id>/<snapshot_id>`.
-  * Added resource `cloudtemple_public_cloud_vm_network_adapter` to manage a network adapter attached to a Public Cloud VM instance. Changing `network_id` or deleting the adapter requires the VM to be stopped; `ip_address` is only honoured on VPC networks; `device_index` is immutable. Import with `<virtual_machine_id>/<network_adapter_id>`.
+  * Added resource `cloudtemple_public_cloud_vm_network_adapter` to manage a network adapter attached to a Public Cloud VM instance. Changing `network_id` requires the VM to be stopped (deleting stops a running VM automatically); `ip_address` is only honoured on VPC networks; `device_index` is immutable. Import with `<virtual_machine_id>/<network_adapter_id>`.
   * Added datasource `cloudtemple_public_cloud_vm_instance` to retrieve a VM instance by `id`.
   * Added datasource `cloudtemple_public_cloud_vm_instances` to list the tenant's VM instances (filterable by name, status, availability zone or instance family).
   * Added datasource `cloudtemple_public_cloud_vm_disks` to list the disks of a VM instance.

--- a/docs/resources/public_cloud_vm_disk.md
+++ b/docs/resources/public_cloud_vm_disk.md
@@ -3,7 +3,7 @@
 page_title: "cloudtemple_public_cloud_vm_disk Resource - terraform-provider-cloudtemple"
 subcategory: "Public Cloud VM Instances"
 description: |-
-  Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending and deleting a disk both require the VM to be stopped.
+  Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete).
   To manage this resource you will need the following roles:
     - public_cloud_vm_instances_management
     - public_cloud_vm_instances_read
@@ -12,7 +12,7 @@ description: |-
 
 # cloudtemple_public_cloud_vm_disk (Resource)
 
-Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending and deleting a disk both require the VM to be stopped.
+Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete).
 
 To manage this resource you will need the following roles:
   - `public_cloud_vm_instances_management`
@@ -46,7 +46,8 @@ resource "cloudtemple_public_cloud_vm_disk" "logs" {
 }
 
 # Extending a disk (increasing `size`) is grow-only and requires the VM to be
-# stopped (power_state = "off" on the VM), as does destroying it.
+# stopped (power_state = "off" on the VM). Destroying a disk stops a running
+# VM automatically.
 
 output "data_disk_position" {
   value = cloudtemple_public_cloud_vm_disk.data.position

--- a/docs/resources/public_cloud_vm_network_adapter.md
+++ b/docs/resources/public_cloud_vm_network_adapter.md
@@ -3,7 +3,7 @@
 page_title: "cloudtemple_public_cloud_vm_network_adapter Resource - terraform-provider-cloudtemple"
 subcategory: "Public Cloud VM Instances"
 description: |-
-  Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network and deleting the adapter both require the VM to be stopped. Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).
+  Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete). Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).
   To manage this resource you will need the following roles:
     - public_cloud_vm_instances_management
     - public_cloud_vm_instances_read
@@ -12,7 +12,7 @@ description: |-
 
 # cloudtemple_public_cloud_vm_network_adapter (Resource)
 
-Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network and deleting the adapter both require the VM to be stopped. Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).
+Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete). Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).
 
 To manage this resource you will need the following roles:
   - `public_cloud_vm_instances_management`
@@ -33,8 +33,8 @@ data "cloudtemple_public_cloud_vm_network" "lan" {
   name = "LAN01"
 }
 
-# Re-pointing the adapter to another network (changing network_id) and
-# destroying it both require the VM to be stopped.
+# Re-pointing the adapter to another network (changing network_id) requires
+# the VM to be stopped; destroying it stops a running VM automatically.
 resource "cloudtemple_public_cloud_vm_network_adapter" "eth1" {
   virtual_machine_id = var.virtual_machine_id
   device_index       = 1

--- a/examples/resources/cloudtemple_public_cloud_vm_disk/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_disk/resource.tf
@@ -22,7 +22,8 @@ resource "cloudtemple_public_cloud_vm_disk" "logs" {
 }
 
 # Extending a disk (increasing `size`) is grow-only and requires the VM to be
-# stopped (power_state = "off" on the VM), as does destroying it.
+# stopped (power_state = "off" on the VM). Destroying a disk stops a running
+# VM automatically.
 
 output "data_disk_position" {
   value = cloudtemple_public_cloud_vm_disk.data.position

--- a/examples/resources/cloudtemple_public_cloud_vm_network_adapter/resource.tf
+++ b/examples/resources/cloudtemple_public_cloud_vm_network_adapter/resource.tf
@@ -9,8 +9,8 @@ data "cloudtemple_public_cloud_vm_network" "lan" {
   name = "LAN01"
 }
 
-# Re-pointing the adapter to another network (changing network_id) and
-# destroying it both require the VM to be stopped.
+# Re-pointing the adapter to another network (changing network_id) requires
+# the VM to be stopped; destroying it stops a running VM automatically.
 resource "cloudtemple_public_cloud_vm_network_adapter" "eth1" {
   virtual_machine_id = var.virtual_machine_id
   device_index       = 1

--- a/internal/provider/resource_public_cloud_vm_disk.go
+++ b/internal/provider/resource_public_cloud_vm_disk.go
@@ -31,7 +31,7 @@ const (
 
 func resourcePublicCloudVMDisk() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending and deleting a disk both require the VM to be stopped.",
+		Description: "Manages a DATA disk attached to a Public Cloud VM instance. The system disk is provided by the template and is not managed here. Create, extend (grow-only) and delete are asynchronous; extending requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete).",
 
 		CreateContext: resourcePublicCloudVMDiskCreate,
 		ReadContext:   resourcePublicCloudVMDiskRead,
@@ -126,6 +126,7 @@ type vmDiskCRUDFuncs struct {
 	create       func(ctx context.Context, vmID string, req *client.CreateVMDiskRequest) (string, error)
 	extend       func(ctx context.Context, vmID, diskID string, size int) (string, error)
 	del          func(ctx context.Context, vmID, diskID string) (string, error)
+	vmStop       func(ctx context.Context, vmID string) (string, error)
 	read         func(ctx context.Context, vmID, diskID string) (*client.PublicCloudVMDisk, error)
 	listStrict   func(ctx context.Context, vmID string) ([]*client.PublicCloudVMDisk, error)
 	vmRead       func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error)
@@ -140,6 +141,7 @@ func vmDiskClientFuncs(c *client.Client) vmDiskCRUDFuncs {
 		create:     disk.Create,
 		extend:     disk.ExtendById,
 		del:        disk.Delete,
+		vmStop:     inst.Stop,
 		read:       disk.Read,
 		listStrict: disk.ListStrict,
 		vmRead:     inst.Read,
@@ -367,8 +369,10 @@ func deleteVMDiskWith(ctx context.Context, d *schema.ResourceData, funcs vmDiskC
 
 	// Deleting a data disk requires the VM to be stopped (verified live: a delete
 	// against a running VM fails with an opaque platform error and leaves the disk
-	// in place). Preflight and refuse clearly (no hidden auto-stop), mirroring
-	// extend.
+	// in place). Destroy must stay a single command, so a running VM is stopped
+	// here (tracked activity) instead of refusing: in a full destroy the VM is
+	// deleted right after, and in a partial removal the next apply converges the
+	// VM back to its declared power_state.
 	vm, err := funcs.vmRead(ctx, vmID)
 	if err != nil {
 		return diag.Errorf("failed to read VM %s before deleting disk %s: %s", vmID, diskID, err)
@@ -377,7 +381,13 @@ func deleteVMDiskWith(ctx context.Context, d *schema.ResourceData, funcs vmDiskC
 		return diag.Errorf("disk %s of VM %s is present but its VM could not be read; refusing to delete on an inconsistent/ambiguous signal.", diskID, vmID)
 	}
 	if vm.Status != "stopped" {
-		return diag.Errorf("disk %s cannot be deleted while VM %s is %q: the VM must be stopped (set power_state = \"off\" on the VM, apply, then destroy the disk).", diskID, vmID, vm.Status)
+		stopActivity, serr := funcs.vmStop(ctx, vmID)
+		if serr != nil {
+			return diag.Errorf("disk %s requires VM %s to be stopped and the provider-issued stop failed: %s; the disk is kept in the state.", diskID, vmID, serr)
+		}
+		if _, serr := funcs.waitActivity(ctx, stopActivity); serr != nil {
+			return diag.Errorf("disk %s requires VM %s to be stopped and the provider-issued stop (activity %q) did not complete: %s; the disk is kept in the state.", diskID, vmID, stopActivity, serr)
+		}
 	}
 
 	activityID, err := funcs.del(ctx, vmID, diskID)

--- a/internal/provider/resource_public_cloud_vm_disk_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_disk_unit_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
@@ -483,7 +484,40 @@ func TestDeleteVMDiskWith(t *testing.T) {
 		}
 	})
 
-	t.Run("delete refused while VM running (no del call)", func(t *testing.T) {
+	t.Run("delete on a running VM stops it first, then deletes", func(t *testing.T) {
+		d := newDiskRD(t, 10)
+		d.SetId(diskTestDiskID)
+		var order []string
+		funcs := vmDiskCRUDFuncs{
+			read: func(ctx context.Context, vmID, diskID string) (*client.PublicCloudVMDisk, error) {
+				return dataDisk(diskID, 10), nil
+			},
+			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
+				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
+			},
+			vmStop: func(ctx context.Context, vmID string) (string, error) {
+				order = append(order, "stop")
+				return "act-stop", nil
+			},
+			del: func(ctx context.Context, vmID, diskID string) (string, error) {
+				order = append(order, "del")
+				return "act", nil
+			},
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
+				order = append(order, "wait:"+a)
+				return diskActivity(diskTestDiskID), nil
+			},
+		}
+		if diags := deleteVMDiskWith(context.Background(), d, funcs); diags.HasError() {
+			t.Fatalf("destroy must be a single command (stop then delete), got %v", diags)
+		}
+		want := []string{"stop", "wait:act-stop", "del", "wait:act"}
+		if !reflect.DeepEqual(order, want) {
+			t.Fatalf("the stop activity must COMPLETE before the delete, got %v, want %v", order, want)
+		}
+	})
+
+	t.Run("a failed stop ACTIVITY keeps the disk (no del call)", func(t *testing.T) {
 		d := newDiskRD(t, 10)
 		d.SetId(diskTestDiskID)
 		deleted := false
@@ -494,13 +528,40 @@ func TestDeleteVMDiskWith(t *testing.T) {
 			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
 				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
 			},
-			del: func(ctx context.Context, vmID, diskID string) (string, error) { deleted = true; return "act", nil },
+			vmStop:       func(ctx context.Context, vmID string) (string, error) { return "act-stop", nil },
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) { return nil, errors.New("stop failed") },
+			del:          func(ctx context.Context, vmID, diskID string) (string, error) { deleted = true; return "act", nil },
 		}
 		if diags := deleteVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
-			t.Fatal("deleting a data disk while the VM is running must be refused")
+			t.Fatal("a failed stop activity must fail the destroy")
 		}
 		if deleted {
-			t.Fatal("delete must NOT be called while the VM is running")
+			t.Fatal("delete must NOT be called when the stop activity failed")
+		}
+	})
+
+	t.Run("a failed provider-issued stop keeps the disk (no del call)", func(t *testing.T) {
+		d := newDiskRD(t, 10)
+		d.SetId(diskTestDiskID)
+		deleted := false
+		funcs := vmDiskCRUDFuncs{
+			read: func(ctx context.Context, vmID, diskID string) (*client.PublicCloudVMDisk, error) {
+				return dataDisk(diskID, 10), nil
+			},
+			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
+				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
+			},
+			vmStop: func(ctx context.Context, vmID string) (string, error) { return "", errors.New("stop refused") },
+			del:    func(ctx context.Context, vmID, diskID string) (string, error) { deleted = true; return "act", nil },
+		}
+		if diags := deleteVMDiskWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("a failed stop must fail the destroy")
+		}
+		if deleted {
+			t.Fatal("delete must NOT be called when the stop failed")
+		}
+		if d.Id() == "" {
+			t.Fatal("the disk must stay in the state when the stop failed")
 		}
 	})
 

--- a/internal/provider/resource_public_cloud_vm_network_adapter.go
+++ b/internal/provider/resource_public_cloud_vm_network_adapter.go
@@ -20,7 +20,7 @@ const (
 
 func resourcePublicCloudVMNetworkAdapter() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network and deleting the adapter both require the VM to be stopped. Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).",
+		Description: "Manages a network adapter (NIC) attached to a Public Cloud VM instance. Create, change-network and delete are asynchronous; changing the network requires the VM to be stopped, and deleting stops a running VM automatically before detaching (the VM is not restarted by the delete). Attaching (create) is attempted hot but is not guaranteed on every network (hot-plug limitation).",
 
 		CreateContext: resourcePublicCloudVMNetworkAdapterCreate,
 		ReadContext:   resourcePublicCloudVMNetworkAdapterRead,
@@ -114,6 +114,7 @@ type vmNICCRUDFuncs struct {
 	create        func(ctx context.Context, vmID string, req *client.CreateVMNetworkAdapterRequest) (string, error)
 	changeNetwork func(ctx context.Context, vmID, nicID string, req *client.ChangeVMNetworkAdapterRequest) (string, error)
 	del           func(ctx context.Context, vmID, nicID string) (string, error)
+	vmStop        func(ctx context.Context, vmID string) (string, error)
 	read          func(ctx context.Context, vmID, nicID string) (*client.PublicCloudVMNetworkAdapter, error)
 	listStrict    func(ctx context.Context, vmID string) ([]*client.PublicCloudVMNetworkAdapter, error)
 	vmRead        func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error)
@@ -128,6 +129,7 @@ func vmNICClientFuncs(c *client.Client) vmNICCRUDFuncs {
 		create:        nic.Create,
 		changeNetwork: nic.ChangeNetwork,
 		del:           nic.Delete,
+		vmStop:        inst.Stop,
 		read:          nic.Read,
 		listStrict:    nic.ListStrict,
 		vmRead:        inst.Read,
@@ -392,8 +394,11 @@ func deleteVMNICWith(ctx context.Context, d *schema.ResourceData, funcs vmNICCRU
 	}
 
 	// Removing an adapter requires the VM to be stopped (worker guard: a delete
-	// against a running VM fails and leaves the adapter in place). Preflight and
-	// refuse clearly (no hidden auto-stop), mirroring the disk resource.
+	// against a running VM fails and leaves the adapter in place). Destroy must
+	// stay a single command, so a running VM is stopped here (tracked activity)
+	// instead of refusing: in a full destroy the VM is deleted right after, and
+	// in a partial removal the next apply converges the VM back to its declared
+	// power_state.
 	vm, err := funcs.vmRead(ctx, vmID)
 	if err != nil {
 		return diag.Errorf("failed to read VM %s before deleting network adapter %s: %s", vmID, nicID, err)
@@ -402,7 +407,13 @@ func deleteVMNICWith(ctx context.Context, d *schema.ResourceData, funcs vmNICCRU
 		return diag.Errorf("network adapter %s of VM %s is present but its VM could not be read; refusing to delete on an inconsistent/ambiguous signal.", nicID, vmID)
 	}
 	if vm.Status != "stopped" {
-		return diag.Errorf("network adapter %s cannot be removed while VM %s is %q: the VM must be stopped (set power_state = \"off\" on the VM, apply, then destroy the adapter).", nicID, vmID, vm.Status)
+		stopActivity, serr := funcs.vmStop(ctx, vmID)
+		if serr != nil {
+			return diag.Errorf("network adapter %s requires VM %s to be stopped and the provider-issued stop failed: %s; the adapter is kept in the state.", nicID, vmID, serr)
+		}
+		if _, serr := funcs.waitActivity(ctx, stopActivity); serr != nil {
+			return diag.Errorf("network adapter %s requires VM %s to be stopped and the provider-issued stop (activity %q) did not complete: %s; the adapter is kept in the state.", nicID, vmID, stopActivity, serr)
+		}
 	}
 
 	activityID, err := funcs.del(ctx, vmID, nicID)

--- a/internal/provider/resource_public_cloud_vm_network_adapter_unit_test.go
+++ b/internal/provider/resource_public_cloud_vm_network_adapter_unit_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
@@ -508,7 +509,38 @@ func TestDeleteVMNICWith(t *testing.T) {
 		}
 	})
 
-	t.Run("delete refused while VM running (no del call)", func(t *testing.T) {
+	t.Run("delete on a running VM stops it first, then deletes", func(t *testing.T) {
+		d := newNICRD(t, 1, nicTestNetworkID, "")
+		d.SetId(nicTestNICID)
+		var order []string
+		funcs := vmNICCRUDFuncs{
+			read: present,
+			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
+				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
+			},
+			vmStop: func(ctx context.Context, vmID string) (string, error) {
+				order = append(order, "stop")
+				return "act-stop", nil
+			},
+			del: func(ctx context.Context, vmID, nicID string) (string, error) {
+				order = append(order, "del")
+				return "act", nil
+			},
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) {
+				order = append(order, "wait:"+a)
+				return nicActivityResultOnly(nicTestVMID), nil
+			},
+		}
+		if diags := deleteVMNICWith(context.Background(), d, funcs); diags.HasError() {
+			t.Fatalf("destroy must be a single command (stop then delete), got %v", diags)
+		}
+		want := []string{"stop", "wait:act-stop", "del", "wait:act"}
+		if !reflect.DeepEqual(order, want) {
+			t.Fatalf("the stop activity must COMPLETE before the delete, got %v, want %v", order, want)
+		}
+	})
+
+	t.Run("a failed stop ACTIVITY keeps the adapter (no del call)", func(t *testing.T) {
 		d := newNICRD(t, 1, nicTestNetworkID, "")
 		d.SetId(nicTestNICID)
 		deleted := false
@@ -517,13 +549,38 @@ func TestDeleteVMNICWith(t *testing.T) {
 			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
 				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
 			},
-			del: func(ctx context.Context, vmID, nicID string) (string, error) { deleted = true; return "act", nil },
+			vmStop:       func(ctx context.Context, vmID string) (string, error) { return "act-stop", nil },
+			waitActivity: func(ctx context.Context, a string) (*client.Activity, error) { return nil, errors.New("stop failed") },
+			del:          func(ctx context.Context, vmID, nicID string) (string, error) { deleted = true; return "act", nil },
 		}
 		if diags := deleteVMNICWith(context.Background(), d, funcs); !diags.HasError() {
-			t.Fatal("deleting while the VM is running must be refused")
+			t.Fatal("a failed stop activity must fail the destroy")
 		}
 		if deleted {
-			t.Fatal("delete must NOT be called while the VM is running")
+			t.Fatal("delete must NOT be called when the stop activity failed")
+		}
+	})
+
+	t.Run("a failed provider-issued stop keeps the adapter (no del call)", func(t *testing.T) {
+		d := newNICRD(t, 1, nicTestNetworkID, "")
+		d.SetId(nicTestNICID)
+		deleted := false
+		funcs := vmNICCRUDFuncs{
+			read: present,
+			vmRead: func(ctx context.Context, vmID string) (*client.PublicCloudVMInstance, error) {
+				return &client.PublicCloudVMInstance{ID: vmID, Status: "running"}, nil
+			},
+			vmStop: func(ctx context.Context, vmID string) (string, error) { return "", errors.New("stop refused") },
+			del:    func(ctx context.Context, vmID, nicID string) (string, error) { deleted = true; return "act", nil },
+		}
+		if diags := deleteVMNICWith(context.Background(), d, funcs); !diags.HasError() {
+			t.Fatal("a failed stop must fail the destroy")
+		}
+		if deleted {
+			t.Fatal("delete must NOT be called when the stop failed")
+		}
+		if d.Id() == "" {
+			t.Fatal("the adapter must stay in the state when the stop failed")
 		}
 	})
 


### PR DESCRIPTION
Refs #484 — product-owner call: `terraform destroy` must be a **single command**. It used to fail on a running environment because deleting a data disk or a network adapter requires a stopped VM and the provider refused with a manual two-step instruction.

## What
- `cloudtemple_public_cloud_vm_disk` **Delete** and `cloudtemple_public_cloud_vm_network_adapter` **Delete**: a running VM is now **stopped by the provider** (tracked stop activity, **completed before** the delete is issued) instead of refusing.
- **Failure semantics**: a failed stop (call or activity) keeps the child in the state and never attempts the delete; a delete failing after a successful stop leaves the VM stopped and the child in state (surfaced error).
- The VM is intentionally **not restarted** by the delete: a full destroy deletes it right after (VM delete works on a running VM anyway), and a partial removal converges back to the declared `power_state` on the next apply (documented).
- **Update paths unchanged**: disk extend and adapter change-network keep the plan-time `power_state = "off"` requirement — there, the intent is expressible in a single apply (declared stop + change, already sequenced stop→op).
- All absence/pre-read guards (E0-9, 404-race, primary refusal, ambiguous-VM refusal) untouched.

## Tests
Unit: running → **stop, stop-activity completed, delete, delete-activity** order asserted; stop call failure AND stop activity failure → child kept, delete never called; already stopped → no stop issued (unwired seam would panic). Suites green; docs/CHANGELOG aligned.

Codex adversarial review — **GO** (order/atomicity under the per-VM mutex, failure semantics, TOCTOU acceptability all confirmed); its two recommendations (wait-completion marker in the order assertion, explicit stop-activity-failure tests, "not restarted" doc note) are applied.

## Live E2E
Currently blocked by the DEV storage quota (558/500 GB — a 10-VM composite deployment is occupying it). The destroy-on-running path will be exercised live as soon as the quota frees; the deployed 10-VM environment itself is the real-world validation case for this change.