### PR TITLE
fix(object-storage): éviter le nil-panic des data sources bucket & storage account sur 404

### DIFF
--- a/internal/provider/data_source_object_storage_bucket.go
+++ b/internal/provider/data_source_object_storage_bucket.go
@@ -110,6 +110,12 @@ func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading bucket with name %s: %s", bucketName, err))
 	}
+	// The client maps a not-found (HTTP 404) / access-denied answer to (nil, nil).
+	// A data source must resolve, so fail closed with an actionable diagnostic
+	// instead of dereferencing a nil bucket (which would panic).
+	if bucket == nil {
+		return diag.Errorf("no bucket found with name %q", bucketName)
+	}
 
 	// Définir l'ID de la datasource
 	d.SetId(bucket.ID)

--- a/internal/provider/data_source_object_storage_storage_account.go
+++ b/internal/provider/data_source_object_storage_storage_account.go
@@ -84,6 +84,12 @@ func dataSourceStorageAccountRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading storage account with name %s: %s", accountName, err))
 	}
+	// The client maps a not-found (HTTP 404) / access-denied answer to (nil, nil).
+	// A data source must resolve, so fail closed with an actionable diagnostic
+	// instead of dereferencing a nil account (which would panic).
+	if account == nil {
+		return diag.Errorf("no storage account found with name %q", accountName)
+	}
 
 	// Définir l'ID de la datasource
 	d.SetId(account.ID)


### PR DESCRIPTION
## Contexte

La campagne de normalisation des status code Shiva fait renvoyer **HTTP 404** (au lieu de 500) par l'API object-storage quand un bucket ou un storage account est **absent**.

Côté provider, le client mappe 404 → `(nil, nil)` via `requireNotFoundOrOK`. Ensuite `dataSourceBucketRead` et `dataSourceStorageAccountRead` déréférençaient le pointeur nil (`d.SetId(bucket.ID)` / `account.ID`) → **panic au refresh** (avant, le 500 produisait une `diag` propre).

## Correctif

Les deux lectures de data source échouent désormais proprement avec un diagnostic actionnable quand l'objet est introuvable, au lieu de paniquer :

```go
if bucket == nil {
    return diag.Errorf("no bucket found with name %q", bucketName)
}
```
(idem `account == nil` dans `data_source_object_storage_storage_account.go`)

Ce sont les **seules** data sources object-storage avec le pattern `Read()` → `d.SetId(x.ID)` (vérifié par grep) ; les listes (`buckets`, `storage_accounts`, `role`) renvoient des slices et ne sont pas concernées.

## Vérification
- `gofmt` : clean
- `go build ./internal/provider/` : OK

## Backport
À rétroporter sur **`rc/v1.9.0`** et **`rc/v1.10.0`** (les data sources y sont identiques).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
