### PR TITLE
chore(ci): refresh GitHub Actions to current majors in test and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,28 +22,28 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
           cache: true
       -
         name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4.4.0
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -52,10 +52,10 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -102,12 +102,12 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 'v1.5.7'
           terraform_wrapper: false
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -138,16 +138,16 @@ jobs:
   #   steps:
 
   #   - name: Check out code into the Go module directory
-  #     uses: actions/checkout@v3
+  #     uses: actions/checkout@v7
 
   #   - name: Set up Go
-  #     uses: actions/setup-go@v4
+  #     uses: actions/setup-go@v7
   #     with:
   #       go-version-file: 'go.mod'
   #       cache: true
   #     id: go
 
-  #   - uses: hashicorp/setup-terraform@v2
+  #   - uses: hashicorp/setup-terraform@v4
   #     with:
   #       terraform_version: ${{ matrix.terraform }}
   #       terraform_wrapper: false


### PR DESCRIPTION
Refs #493

## Context

Dependabot has six stale PRs from 2023-2024 (#108, #109, #110, #111, #121, #129). Two are obsolete — #108 targets `.github/workflows/add-content-to-project.yml`, which no longer exists on `main`, and #129 bumps `terraform-plugin-sdk/v2` to 2.32.0 while `main` is already on 2.35.0. The four GitHub Actions bumps are now several majors behind upstream. This PR supersedes #109, #110, #111 and #121 with a single refresh to the current majors.

## Changes

| Action | From | To |
|---|---|---|
| `actions/checkout` | v3 | v7 |
| `actions/setup-go` | v4 | v7 |
| `hashicorp/setup-terraform` | v2 | v4 |
| `crazy-max/ghaction-import-gpg` | v5 | v7 |
| `goreleaser/goreleaser-action` | v4.4.0 | v7 |

The GoReleaser distribution is now pinned to `version: '~> v2'` instead of `version: latest`, so the release pipeline stays on GoReleaser v2 if a v3 ships.

## Per-usage breaking-change audit

- The majors are mostly Node runtime bumps (16 → 20 → 24). All jobs run on GitHub-hosted `ubuntu-latest` runners, which satisfy the runner version requirements.
- `checkout` v6 moved persisted credentials to a separate file; the `git fetch --prune --unshallow` step in `release.yml` keeps working. The v7 fork-PR restriction only affects `pull_request_target`/`workflow_run` triggers, which these workflows do not use.
- `setup-go` v7 keeps `go-version-file` and cache-on defaults; the repo declares `go 1.24.0` and no `toolchain` directive.
- `setup-terraform` is only used with `terraform_wrapper: false`, so the v3 wrapper-stdout change does not apply; v4 is a Node 24 bump.
- The GPG signing chain is intact: `import-gpg` v7 keeps the `gpg_private_key`/`passphrase` inputs and the `fingerprint` output, consumed as `GPG_FINGERPRINT` by the `signs` section of `.goreleaser.yml`.
- `.goreleaser.yml` is already `version: 2` schema and current releases already run GoReleaser v2 (via `version: latest`), so `'~> v2'` changes nothing today.

An independent adversarial review (Codex) returned GO with no blocking or minor findings; its one NIT (optionally replace the unshallow step with `fetch-depth: 0`) is deliberately not applied to keep this PR strictly a version refresh.

## Residual risk

`test.yml` changes are fully exercised by this PR's own CI. `release.yml` is only exercised at the next `v*` tag push; a workflow failure there would occur before any publication and can be re-run after a fix.

Supersedes #109, #110, #111, #121. Refs #108, #129.
