### PR TITLE
fix(#488): stop capturing the cloud-init config drive as a managed os_disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ***Warning: Using "Release Candidate" versions (-rc.X) in a **production environment** is **strongly discouraged**, as they may contain unresolved bugs and pose risks to the stability and security of your systems.***
 
+# 1.11.0 (Unreleased)
+
+BUG FIXES :
+
+  * `cloudtemple_compute_iaas_opensource_virtual_machine`: a VM deployed with `cloud_init` no longer captures the platform's cloud-init config drive ("XO CloudConfigDrive", attached read-write by the platform during the deploy) as a managed `os_disk`, which made every subsequent plan propose to remove that block (permanent drift). The create now excludes the drive (and fails closed if the listing is ambiguous), and a create from a source image that itself carries the reserved disk name is rejected upfront. States already polluted by earlier versions keep planning normally: the refresh emits a warning explaining that applying the removal diff only cleans the Terraform state — the provider never detaches, renames or resizes the drive on the platform. The name "XO CloudConfigDrive" is now rejected as a user-declared `os_disk.name` (reserved by the platform).
+
 # 1.10.0 (July 17th, 2026)
 <img id="latest" src="https://badgen.net/badge/channel/latest/yellow" alt="Channel: latest" />
 

--- a/docs/resources/compute_iaas_opensource_virtual_machine.md
+++ b/docs/resources/compute_iaas_opensource_virtual_machine.md
@@ -222,7 +222,7 @@ Order of the elements in the list is the boot order.
 Optional:
 
 - `connected` (Boolean, Deprecated) Whether the disk is connected or not.
-- `name` (String) The name of the operating system disk. (Updating this property implies a disk disconnect-reconnect)
+- `name` (String) The name of the operating system disk. (Updating this property implies a disk disconnect-reconnect) The name "XO CloudConfigDrive" is reserved by the platform for the cloud-init config drive and cannot be used.
 - `size` (Number) The size of the operating system disk in bytes. (Updating this property implies a disk disconnect-reconnect)
 - `storage_repository_id` (String) The storage repository where the operating system disk is located.
 

--- a/internal/client/compute_iaas_opensource_virtual_disk_decode_test.go
+++ b/internal/client/compute_iaas_opensource_virtual_disk_decode_test.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestOpenIaaSVirtualDiskDecodeContract pins the deserialization of the
+// virtual-disk payload against the LIVE response shape (captured 2026-07-21
+// on the DEV tenant while reproducing #488). The structs carry no JSON tags:
+// decoding relies on Go's case-insensitive field matching, so a silent API
+// field rename (readOnly -> read_only, …) would zero the field without any
+// compile-time signal. IsPlatformManagedDisk keys the platform-drive
+// exclusion on VirtualMachines[].ReadOnly — this test is the tripwire.
+func TestOpenIaaSVirtualDiskDecodeContract(t *testing.T) {
+	const payload = `{
+		"id": "1f5c8276-99b2-4e16-9634-8f1ad51e4993",
+		"internalId": "3fe6abe0-028a-463f-91d9-3e6781778608",
+		"name": "XO CloudConfigDrive",
+		"description": "",
+		"size": 10485760,
+		"usage": 12582912,
+		"isSnapshot": false,
+		"storageRepository": {
+			"id": "2c882694-df86-4626-b456-4b89008bab4c",
+			"name": "sr018"
+		},
+		"virtualMachines": [
+			{
+				"id": "e3428d87-4594-41ab-bbd8-5fdae48e1faa",
+				"name": "some-vm",
+				"readOnly": true,
+				"connected": false
+			}
+		]
+	}`
+
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(payload))}
+	var disk OpenIaaSVirtualDisk
+	if err := decodeBody(resp, &disk); err != nil {
+		t.Fatalf("decodeBody: %v", err)
+	}
+
+	if disk.ID != "1f5c8276-99b2-4e16-9634-8f1ad51e4993" {
+		t.Errorf("ID not decoded: %q", disk.ID)
+	}
+	if disk.Name != "XO CloudConfigDrive" {
+		t.Errorf("Name not decoded: %q", disk.Name)
+	}
+	if disk.Size != 10485760 {
+		t.Errorf("Size not decoded: %d", disk.Size)
+	}
+	if disk.StorageRepository.ID != "2c882694-df86-4626-b456-4b89008bab4c" {
+		t.Errorf("StorageRepository.ID not decoded: %q", disk.StorageRepository.ID)
+	}
+	if len(disk.VirtualMachines) != 1 {
+		t.Fatalf("VirtualMachines not decoded: %#v", disk.VirtualMachines)
+	}
+	vbd := disk.VirtualMachines[0]
+	if vbd.ID != "e3428d87-4594-41ab-bbd8-5fdae48e1faa" {
+		t.Errorf("VBD ID not decoded: %q", vbd.ID)
+	}
+	// The load-bearing field: a decode regression here silently disables the
+	// read-only arm of the platform-drive exclusion (#255/#488).
+	if !vbd.ReadOnly {
+		t.Error("VirtualMachines[0].ReadOnly was not decoded from \"readOnly\": the platform-drive discriminator would silently stop matching")
+	}
+	if vbd.Connected {
+		t.Error("VirtualMachines[0].Connected mis-decoded: expected false")
+	}
+}

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine.go
@@ -103,36 +103,51 @@ func FlattenOpenIaaSVirtualMachine(vm *client.OpenIaaSVirtualMachine) map[string
 	}
 }
 
-// cloudConfigDriveName is the name XO gives to the cloud-init config drive
-// it attaches at deploy time.
-const cloudConfigDriveName = "XO CloudConfigDrive"
+// CloudConfigDriveName is the name XO gives to the cloud-init config drive
+// it attaches at deploy time. Exported so the resource schema can reject it
+// as a user-declared os_disk name (#488) and the Read classification can
+// recognize a captured drive in the state.
+const CloudConfigDriveName = "XO CloudConfigDrive"
 
-// IsPlatformManagedDisk reports whether the disk is managed by the platform
-// (cloud-init config drive, attached read-only by XO at deploy time) and must
-// never be reconciled as an os_disk: capturing it — which is timing dependent
-// at create — produces a permanent removal drift in every subsequent plan.
-// Both discriminators are required: the exact XO naming alone could hide a
-// legitimate user disk carrying the same name, and a read-only criterion
-// alone could drop legitimate read-only disks without a formal API
-// invariant. Only a disk attached read-only to this VM under the exact XO
-// platform naming is excluded; when the VBD is absent Find returns a zero
-// value, so the default stays fail-safe (the disk remains managed).
-func IsPlatformManagedDisk(osDisk *client.OpenIaaSVirtualDisk, virtualMachineId string) bool {
+// IsPlatformManagedDisk reports whether the disk is the platform's cloud-init
+// config drive and must not be reconciled as an os_disk: capturing it produces
+// a permanent removal drift in every subsequent plan (#255, #488). The exact
+// XO naming alone could hide a legitimate user disk carrying the same name, so
+// a second, independent evidence is always required on top of the name and the
+// VBD of THIS vm:
+//   - a read-only VBD (the original #255 criterion), or
+//   - cloudInitProvisioned: the resource's own cloud_init actually provisions
+//     a config drive (#488 — live evidence shows XO attaches the drive with a
+//     read-write VBD on the deploy path, so the read-only arm never matches).
+//
+// Callers choose the evidence they can vouch for: the Read drop path passes
+// false (strict #255 behavior, a state entry is never dropped on the weaker
+// evidence), the Create flatten passes the resource's real cloud-init intent.
+// When the VBD is absent Find returns a zero value and the disk stays managed
+// (fail-safe).
+func IsPlatformManagedDisk(osDisk *client.OpenIaaSVirtualDisk, virtualMachineId string, cloudInitProvisioned bool) bool {
 	if osDisk == nil {
 		// A nil disk (the API maps a deleted/forbidden disk to nil) is not a
 		// platform-managed disk; never dereference it (#320).
 		return false
 	}
-	if osDisk.Name != cloudConfigDriveName {
+	if virtualMachineId == "" {
+		return false
+	}
+	if osDisk.Name != CloudConfigDriveName {
 		return false
 	}
 	vbd := Find(osDisk.VirtualMachines, func(virtualMachine client.OpenIaaSVirtualDiskConnection) bool {
 		return virtualMachine.ID == virtualMachineId
 	})
-	return vbd.ReadOnly
+	if vbd.ID != virtualMachineId {
+		// No VBD on this VM: fail-safe, the disk stays managed.
+		return false
+	}
+	return vbd.ReadOnly || cloudInitProvisioned
 }
 
-func FlattenOpenIaaSOSDisksData(osDisks []*client.OpenIaaSVirtualDisk, virtualMachineId string) []interface{} {
+func FlattenOpenIaaSOSDisksData(osDisks []*client.OpenIaaSVirtualDisk, virtualMachineId string, cloudInitProvisioned bool) []interface{} {
 	disks := make([]interface{}, 0, len(osDisks))
 
 	for _, osDisk := range osDisks {
@@ -142,7 +157,7 @@ func FlattenOpenIaaSOSDisksData(osDisks []*client.OpenIaaSVirtualDisk, virtualMa
 		if osDisk == nil {
 			continue
 		}
-		if IsPlatformManagedDisk(osDisk, virtualMachineId) {
+		if IsPlatformManagedDisk(osDisk, virtualMachineId, cloudInitProvisioned) {
 			continue
 		}
 		disks = append(disks, FlattenOpenIaaSOSDiskData(osDisk, virtualMachineId))

--- a/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
+++ b/internal/provider/helpers/helper_compute_iaas_opensource_virtual_machine_test.go
@@ -100,14 +100,15 @@ func TestIsPlatformManagedDisk(t *testing.T) {
 	const vmID = "vm-1"
 
 	tests := []struct {
-		name string
-		disk *client.OpenIaaSVirtualDisk
-		want bool
+		name                 string
+		disk                 *client.OpenIaaSVirtualDisk
+		cloudInitProvisioned bool
+		want                 bool
 	}{
 		{
 			name: "read-only XO config drive on this VM is excluded",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: cloudConfigDriveName,
+				Name: CloudConfigDriveName,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: vmID, ReadOnly: true},
 				},
@@ -115,9 +116,23 @@ func TestIsPlatformManagedDisk(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "writable user disk with the colliding name stays managed",
+			// #488: the platform attaches the config drive with a READ-WRITE
+			// VBD on the deploy path (live evidence, 2026-07-21) — the
+			// resource's own cloud-init provisioning is the second evidence.
+			name: "writable XO config drive on this VM is excluded when cloud-init is provisioned (#488)",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: cloudConfigDriveName,
+				Name: CloudConfigDriveName,
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false},
+				},
+			},
+			cloudInitProvisioned: true,
+			want:                 true,
+		},
+		{
+			name: "writable user disk with the colliding name stays managed without cloud-init",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: CloudConfigDriveName,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: vmID, ReadOnly: false},
 				},
@@ -135,9 +150,20 @@ func TestIsPlatformManagedDisk(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "disk with another name stays managed even with cloud-init provisioned",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: "data-disk",
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false},
+				},
+			},
+			cloudInitProvisioned: true,
+			want:                 false,
+		},
+		{
 			name: "XO-named disk read-only on another VM only stays managed",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: cloudConfigDriveName,
+				Name: CloudConfigDriveName,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: "vm-other", ReadOnly: true},
 				},
@@ -145,25 +171,93 @@ func TestIsPlatformManagedDisk(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "XO-named disk without any VBD stays managed (fail-safe)",
+			// #488 F2 guard: the cloud-init arm must NOT bypass the
+			// VBD-on-this-VM requirement (fail-safe keep).
+			name: "XO-named disk without a VBD on this VM stays managed even with cloud-init provisioned",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: cloudConfigDriveName,
+				Name: CloudConfigDriveName,
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: "vm-other", ReadOnly: false},
+				},
 			},
-			want: false,
+			cloudInitProvisioned: true,
+			want:                 false,
 		},
 		{
-			name: "a nil disk is not platform-managed and must not panic (#320)",
-			disk: nil,
-			want: false,
+			name: "XO-named disk without any VBD stays managed (fail-safe)",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: CloudConfigDriveName,
+			},
+			cloudInitProvisioned: true,
+			want:                 false,
+		},
+		{
+			name:                 "a nil disk is not platform-managed and must not panic (#320)",
+			disk:                 nil,
+			cloudInitProvisioned: true,
+			want:                 false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPlatformManagedDisk(tt.disk, vmID); got != tt.want {
+			if got := IsPlatformManagedDisk(tt.disk, vmID, tt.cloudInitProvisioned); got != tt.want {
 				t.Errorf("IsPlatformManagedDisk() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsPlatformManagedDiskEmptyVMID pins the degenerate empty-id guard: the
+// zero-value VBD (ID "") must never accidentally match an empty resource id.
+func TestIsPlatformManagedDiskEmptyVMID(t *testing.T) {
+	disk := &client.OpenIaaSVirtualDisk{Name: CloudConfigDriveName}
+	if IsPlatformManagedDisk(disk, "", true) {
+		t.Fatal("an empty virtual machine id must never match the zero-value VBD")
+	}
+}
+
+// TestFlattenOpenIaaSOSDisksDataSkipsConfigDrive pins the #488 create-time
+// capture fix in both listing orders: with cloud-init provisioned, the
+// platform config drive (RW VBD) is skipped and the system disk survives as
+// the FIRST kept entry, whatever position the API listed the drive at.
+func TestFlattenOpenIaaSOSDisksDataSkipsConfigDrive(t *testing.T) {
+	const vmID = "vm-1"
+	system := &client.OpenIaaSVirtualDisk{
+		ID:   "disk-system",
+		Name: "ubuntu-24.04-disk-0",
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+			{ID: vmID, ReadOnly: false},
+		},
+	}
+	drive := &client.OpenIaaSVirtualDisk{
+		ID:   "disk-drive",
+		Name: CloudConfigDriveName,
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+			{ID: vmID, ReadOnly: false},
+		},
+	}
+
+	for name, order := range map[string][]*client.OpenIaaSVirtualDisk{
+		"system disk first":  {system, drive},
+		"config drive first": {drive, system},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := FlattenOpenIaaSOSDisksData(order, vmID, true)
+			if len(got) != 1 {
+				t.Fatalf("expected exactly the system disk to survive, got %d entries: %#v", len(got), got)
+			}
+			if id := got[0].(map[string]interface{})["id"]; id != "disk-system" {
+				t.Fatalf("expected the system disk at index 0, got id %v", id)
+			}
+		})
+	}
+
+	// Without cloud-init the RW drive is NOT skipped (pre-#488 behavior kept
+	// for non-cloud-init VMs: name alone is never enough).
+	got := FlattenOpenIaaSOSDisksData([]*client.OpenIaaSVirtualDisk{system, drive}, vmID, false)
+	if len(got) != 2 {
+		t.Fatalf("without cloud-init both disks must stay managed, got %d entries", len(got))
 	}
 }
 
@@ -188,7 +282,7 @@ func TestFlattenOpenIaaSOSDisksDataSkipsNil(t *testing.T) {
 		VirtualMachines:   []client.OpenIaaSVirtualDiskConnection{{ID: "vm-1", Connected: true}},
 	}
 
-	got := FlattenOpenIaaSOSDisksData([]*client.OpenIaaSVirtualDisk{nil, valid, nil}, "vm-1")
+	got := FlattenOpenIaaSOSDisksData([]*client.OpenIaaSVirtualDisk{nil, valid, nil}, "vm-1", false)
 	if len(got) != 1 {
 		t.Fatalf("expected exactly 1 disk (nils skipped), got %d: %#v", len(got), got)
 	}

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine.go
@@ -216,7 +216,24 @@ Order of the elements in the list is the boot order.`,
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							Description: "The name of the operating system disk. (Updating this property implies a disk disconnect-reconnect)",
+							Description: "The name of the operating system disk. (Updating this property implies a disk disconnect-reconnect) The name \"XO CloudConfigDrive\" is reserved by the platform for the cloud-init config drive and cannot be used.",
+							// #488: the platform names its cloud-init config drive
+							// exactly like this; a user disk declared under the
+							// reserved name would be indistinguishable from it.
+							// Config-only validation: captured drives living in the
+							// STATE (Computed values) are not validated, so polluted
+							// states keep planning and self-heal normally.
+							ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
+								if v.(string) == helpers.CloudConfigDriveName {
+									return diag.Diagnostics{{
+										Severity:      diag.Error,
+										Summary:       "Reserved os_disk name",
+										Detail:        fmt.Sprintf("%q is the name the platform gives to the cloud-init config drive it attaches at deploy time; it cannot be used as an os_disk name.", helpers.CloudConfigDriveName),
+										AttributePath: p,
+									}}
+								}
+								return nil
+							},
 						},
 						"size": {
 							Type:        schema.TypeInt,
@@ -467,6 +484,39 @@ func buildOpenIaasCloudInit(raw map[string]interface{}) (*client.CloudInit, erro
 	return &client.CloudInit{CloudConfig: cloudConfig, NetworkConfig: networkConfig}, nil
 }
 
+// openIaasCloudInitProvisioned reports whether the resource's cloud_init
+// actually provisions a platform config drive, with the exact semantics of
+// what Create sends (buildOpenIaasCloudInit: non-empty cloud_config). An
+// empty map is omitted from the deploy and creates no drive; a
+// network_config-only map fails the Create itself, so on the Read path it
+// simply means no drive was ever provisioned (flag false). cloud_init is
+// ForceNew, so the answer cannot diverge on a live resource between the
+// Create that deployed it and any later Read (#488).
+func openIaasCloudInitProvisioned(d *schema.ResourceData) bool {
+	raw, _ := d.Get("cloud_init").(map[string]interface{})
+	cloudInit, err := buildOpenIaasCloudInit(raw)
+	return err == nil && cloudInit != nil
+}
+
+// openIaasReservedSourceDiskError fails a create BEFORE anything is deployed
+// when the source image (template or marketplace item) carries a disk named
+// like the platform's cloud-init config drive while cloud_init is provisioned:
+// after the deploy that disk would be indistinguishable from the platform
+// drive (#488). Evidence-only rejection: absent or empty source-disk metadata
+// passes (incomplete catalogs must not be blocked), the post-deploy ambiguity
+// guard remains the net.
+func openIaasReservedSourceDiskError(sourceDiskNames []string, cloudInitProvisioned bool) error {
+	if !cloudInitProvisioned {
+		return nil
+	}
+	for _, name := range sourceDiskNames {
+		if name == helpers.CloudConfigDriveName {
+			return fmt.Errorf("the source image carries a disk named %q, which is reserved for the platform's cloud-init config drive: with cloud_init set, that disk could not be told apart from the platform drive after the deploy. Rename the source image disk or remove cloud_init", helpers.CloudConfigDriveName)
+		}
+	}
+	return nil
+}
+
 func openIaasVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	c := getClient(meta)
 
@@ -495,6 +545,16 @@ func openIaasVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 		if template == nil {
 			return diag.Errorf("Could not find template with id : %s", d.Get("template_id").(string))
+		}
+
+		// #488 preflight: fail before creating anything if a template disk
+		// carries the reserved cloud-init config drive name.
+		templateDiskNames := make([]string, 0, len(template.Disks))
+		for _, disk := range template.Disks {
+			templateDiskNames = append(templateDiskNames, disk.Name)
+		}
+		if err := openIaasReservedSourceDiskError(templateDiskNames, cloudInit != nil); err != nil {
+			return diag.FromErr(err)
 		}
 
 		if osNetworkAdapters != nil && len(osNetworkAdapters) != len(template.NetworkAdapters) {
@@ -535,6 +595,16 @@ func openIaasVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 		if openIaasItemInfo == nil {
 			return diag.Errorf("Could not find marketplace item info with id : %s", d.Get("marketplace_item_id").(string))
+		}
+
+		// #488 preflight: fail before deploying anything if a marketplace item
+		// disk carries the reserved cloud-init config drive name.
+		itemDiskNames := make([]string, 0, len(openIaasItemInfo.Disks))
+		for _, disk := range openIaasItemInfo.Disks {
+			itemDiskNames = append(itemDiskNames, disk.Name)
+		}
+		if err := openIaasReservedSourceDiskError(itemDiskNames, cloudInit != nil); err != nil {
+			return diag.FromErr(err)
 		}
 
 		if osNetworkAdapters != nil && len(osNetworkAdapters) != len(openIaasItemInfo.NetworkAdapters) {
@@ -581,7 +651,19 @@ func openIaasVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("could not list disks of virtual machine, %s", err)
 	}
 
-	osDisks := helpers.UpdateNestedMapItems(d, helpers.FlattenOpenIaaSOSDisksData(disks, d.Id()), "os_disk")
+	// #488: with cloud_init provisioned, the platform attached its config drive
+	// (read-write VBD, live-verified) before the deploy activity completed; the
+	// flatten below skips it so it is never captured as a managed os_disk.
+	// Exactly one disk may match the platform discriminator — the preflight
+	// rejected source images carrying the reserved name, so two or more matches
+	// mean the platform contract is broken: fail closed, never guess.
+	cloudInitProvisioned := cloudInit != nil
+	if cloudInitProvisioned {
+		if ambiguous := openIaasAmbiguousConfigDriveIDs(disks, d.Id()); len(ambiguous) > 1 {
+			return diag.Errorf("found %d disks matching the platform cloud-init config drive discriminator (%s): cannot tell the platform drive apart from a same-named disk; refusing to shape os_disk from an ambiguous listing", len(ambiguous), strings.Join(ambiguous, ", "))
+		}
+	}
+	osDisks := helpers.UpdateNestedMapItems(d, helpers.FlattenOpenIaaSOSDisksData(disks, d.Id(), cloudInitProvisioned), "os_disk")
 	if err := d.Set("os_disk", osDisks); err != nil {
 		return diag.FromErr(err)
 	}
@@ -710,6 +792,7 @@ func openIaasVirtualMachineRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	// Get the OS disks
+	cloudInitProvisioned := openIaasCloudInitProvisioned(d)
 	osDisks := []interface{}{}
 	for _, osDisk := range d.Get("os_disk").([]interface{}) {
 		if osDisk == nil {
@@ -719,13 +802,29 @@ func openIaasVirtualMachineRead(ctx context.Context, d *schema.ResourceData, met
 		if osDiskId == "" {
 			continue
 		}
+		// The state entry's own name is provenance evidence for the
+		// guidance-only classification (#488): it distinguishes an entry
+		// CAPTURED as the config drive from a managed disk renamed to the
+		// reserved name out-of-band.
+		stateName, _ := osDisk.(map[string]interface{})["name"].(string)
 		disk, err := c.Compute().OpenIaaS().VirtualDisk().Read(ctx, osDiskId)
 		if err != nil {
 			return diag.Errorf("failed to read os disk: %s", err)
 		}
-		switch classifyOSDiskOnRead(disk, d.Id()) {
+		switch classifyOSDiskOnRead(disk, stateName, d.Id(), cloudInitProvisioned) {
 		case osDiskReadKeep:
 			osDisks = append(osDisks, helpers.FlattenOpenIaaSOSDiskData(disk, d.Id()))
+		case osDiskReadKeepWarnConfigDrive:
+			// KEPT like osDiskReadKeep — never auto-drop on this weaker
+			// evidence (#488) — plus a warning that walks the user through
+			// the state-only purge.
+			osDisks = append(osDisks, helpers.FlattenOpenIaaSOSDiskData(disk, d.Id()))
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Captured cloud-init config drive present in os_disk",
+				Detail: fmt.Sprintf("The disk %s (%q) matches the cloud-init config drive the platform attaches at deploy time; it was captured into the Terraform state as an os_disk by an earlier provider version. If you did not create this disk yourself, apply the plan that removes this os_disk block: the apply only cleans the Terraform state — the provider will not detach, rename, resize or otherwise modify the disk on the platform.",
+					osDiskId, disk.Name),
+			})
 		case osDiskReadDropGone:
 			gone, err := confirmDiskGone(osDiskId)
 			if err != nil {
@@ -1177,6 +1276,16 @@ type osDiskReadAction int
 const (
 	// osDiskReadKeep: the disk exists and is user-managed — keep it.
 	osDiskReadKeep osDiskReadAction = iota
+	// osDiskReadKeepWarnConfigDrive: the entry is almost certainly the
+	// platform cloud-init config drive captured by an earlier provider
+	// version (state AND live carry the reserved name, the VBD of this VM
+	// is read-write, and the resource provisions cloud-init) — but that
+	// evidence is weaker than the read-only VBD, so the entry is KEPT and
+	// a warning guides the user through the one-apply state purge (#488).
+	// A state entry is never auto-dropped on this weaker evidence: a
+	// pre-#488 state could equally hold a real source disk that carried
+	// the reserved name.
+	osDiskReadKeepWarnConfigDrive
 	// osDiskReadDropGone: the disk no longer exists platform-side — drop
 	// the stale entry instead of crashing on the nil API answer.
 	osDiskReadDropGone
@@ -1187,17 +1296,40 @@ const (
 )
 
 // classifyOSDiskOnRead decides what the refresh does with an os_disk entry
-// of the state, based exclusively on the live API answer. Ambiguity is
-// conservative: a disk that merely shares the XO config drive name (writable,
-// read-only on another VM, or without a VBD on this VM) stays managed.
-func classifyOSDiskOnRead(disk *client.OpenIaaSVirtualDisk, virtualMachineID string) osDiskReadAction {
+// of the state, based on the live API answer plus, for the guidance-only
+// outcome, the state entry's own name (provenance) and the resource's
+// cloud-init intent. Ambiguity is conservative: a disk that merely shares
+// the XO config drive name (writable, read-only on another VM, without a
+// VBD on this VM, or renamed out-of-band so the STATE name differs) stays
+// plainly managed. The only destructive outcome, osDiskReadDropPlatformManaged,
+// still requires the strict #255 evidence (exact name AND read-only VBD).
+func classifyOSDiskOnRead(disk *client.OpenIaaSVirtualDisk, stateName string, virtualMachineID string, cloudInitProvisioned bool) osDiskReadAction {
 	if disk == nil {
 		return osDiskReadDropGone
 	}
-	if helpers.IsPlatformManagedDisk(disk, virtualMachineID) {
+	if helpers.IsPlatformManagedDisk(disk, virtualMachineID, false) {
 		return osDiskReadDropPlatformManaged
 	}
+	if stateName == helpers.CloudConfigDriveName &&
+		helpers.IsPlatformManagedDisk(disk, virtualMachineID, cloudInitProvisioned) {
+		return osDiskReadKeepWarnConfigDrive
+	}
 	return osDiskReadKeep
+}
+
+// openIaasAmbiguousConfigDriveIDs lists the ids of the disks matching the
+// full platform config-drive discriminator under a provisioned cloud-init.
+// The Create fails closed when more than one matches (#488): the preflight
+// already rejected source images carrying the reserved name, so a multiple
+// match means the listing cannot be shaped safely.
+func openIaasAmbiguousConfigDriveIDs(disks []*client.OpenIaaSVirtualDisk, virtualMachineID string) []string {
+	ids := []string{}
+	for _, disk := range disks {
+		if helpers.IsPlatformManagedDisk(disk, virtualMachineID, true) {
+			ids = append(ids, disk.ID)
+		}
+	}
+	return ids
 }
 
 // powerOnBestEffort powers the VM back on after a failed operation that

--- a/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
+++ b/internal/provider/resource_compute_iaas_opensource_virtual_machine_unit_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func boolPtr(b bool) *bool { return &b }
@@ -439,11 +440,14 @@ func TestBuildOpenIaasVIFPatch(t *testing.T) {
 
 func TestClassifyOSDiskOnRead(t *testing.T) {
 	const vmID = "vm-1"
+	const reserved = "XO CloudConfigDrive"
 
 	tests := []struct {
-		name string
-		disk *client.OpenIaaSVirtualDisk
-		want osDiskReadAction
+		name                 string
+		disk                 *client.OpenIaaSVirtualDisk
+		stateName            string
+		cloudInitProvisioned bool
+		want                 osDiskReadAction
 	}{
 		{
 			name: "deleted disk is dropped instead of crashing",
@@ -453,37 +457,85 @@ func TestClassifyOSDiskOnRead(t *testing.T) {
 		{
 			name: "read-only XO config drive on this VM is cleaned up",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: "XO CloudConfigDrive",
+				Name: reserved,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: vmID, ReadOnly: true},
 				},
 			},
-			want: osDiskReadDropPlatformManaged,
+			stateName: reserved,
+			want:      osDiskReadDropPlatformManaged,
 		},
 		{
-			name: "writable user disk with the colliding name stays managed (ambiguous)",
+			// The strict drop needs no state provenance nor cloud-init: the
+			// read-only VBD is the #255 evidence and stays sufficient.
+			name: "read-only XO config drive is cleaned up whatever the state name says",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: "XO CloudConfigDrive",
+				Name: reserved,
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: true},
+				},
+			},
+			stateName: "root",
+			want:      osDiskReadDropPlatformManaged,
+		},
+		{
+			// #488: the RW captured drive is NEVER auto-dropped — it is kept
+			// with a guidance warning (state purge is the user's one apply).
+			name: "captured RW config drive with cloud-init is kept with guidance (#488)",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: reserved,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: vmID, ReadOnly: false},
 				},
 			},
-			want: osDiskReadKeep,
+			stateName:            reserved,
+			cloudInitProvisioned: true,
+			want:                 osDiskReadKeepWarnConfigDrive,
+		},
+		{
+			// #488 P2 guard: a managed disk RENAMED out-of-band to the
+			// reserved name has a different STATE name — plain keep, the
+			// rename-back diff surfaces naturally, no guidance warning.
+			name: "managed disk renamed out-of-band to the reserved name stays plainly managed",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: reserved,
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false},
+				},
+			},
+			stateName:            "root",
+			cloudInitProvisioned: true,
+			want:                 osDiskReadKeep,
+		},
+		{
+			name: "writable disk with the colliding name stays plainly managed without cloud-init",
+			disk: &client.OpenIaaSVirtualDisk{
+				Name: reserved,
+				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
+					{ID: vmID, ReadOnly: false},
+				},
+			},
+			stateName: reserved,
+			want:      osDiskReadKeep,
 		},
 		{
 			name: "XO-named disk read-only on another VM stays managed (ambiguous)",
 			disk: &client.OpenIaaSVirtualDisk{
-				Name: "XO CloudConfigDrive",
+				Name: reserved,
 				VirtualMachines: []client.OpenIaaSVirtualDiskConnection{
 					{ID: "vm-other", ReadOnly: true},
 				},
 			},
-			want: osDiskReadKeep,
+			stateName:            reserved,
+			cloudInitProvisioned: true,
+			want:                 osDiskReadKeep,
 		},
 		{
-			name: "XO-named disk without any VBD stays managed (ambiguous, fail-safe)",
-			disk: &client.OpenIaaSVirtualDisk{Name: "XO CloudConfigDrive"},
-			want: osDiskReadKeep,
+			name:                 "XO-named disk without any VBD stays managed (ambiguous, fail-safe)",
+			disk:                 &client.OpenIaaSVirtualDisk{Name: reserved},
+			stateName:            reserved,
+			cloudInitProvisioned: true,
+			want:                 osDiskReadKeep,
 		},
 		{
 			name: "ordinary user disk stays managed",
@@ -493,7 +545,9 @@ func TestClassifyOSDiskOnRead(t *testing.T) {
 					{ID: vmID, ReadOnly: false, Connected: true},
 				},
 			},
-			want: osDiskReadKeep,
+			stateName:            "data-disk",
+			cloudInitProvisioned: true,
+			want:                 osDiskReadKeep,
 		},
 		{
 			name: "legitimate read-only disk with another name stays managed",
@@ -503,16 +557,114 @@ func TestClassifyOSDiskOnRead(t *testing.T) {
 					{ID: vmID, ReadOnly: true},
 				},
 			},
-			want: osDiskReadKeep,
+			stateName: "shared-iso",
+			want:      osDiskReadKeep,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := classifyOSDiskOnRead(tt.disk, vmID); got != tt.want {
+			if got := classifyOSDiskOnRead(tt.disk, tt.stateName, vmID, tt.cloudInitProvisioned); got != tt.want {
 				t.Errorf("classifyOSDiskOnRead() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestOpenIaasAmbiguousConfigDriveIDs pins the #488 create-time count guard
+// inputs: zero matches (valid deploy), one match (the platform drive), and
+// the >=2 ambiguity the Create refuses to shape state from.
+func TestOpenIaasAmbiguousConfigDriveIDs(t *testing.T) {
+	const vmID = "vm-1"
+	const reserved = "XO CloudConfigDrive"
+	system := &client.OpenIaaSVirtualDisk{
+		ID: "disk-system", Name: "root",
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{{ID: vmID}},
+	}
+	drive := &client.OpenIaaSVirtualDisk{
+		ID: "disk-drive", Name: reserved,
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{{ID: vmID}},
+	}
+	impostor := &client.OpenIaaSVirtualDisk{
+		ID: "disk-impostor", Name: reserved,
+		VirtualMachines: []client.OpenIaaSVirtualDiskConnection{{ID: vmID}},
+	}
+
+	if got := openIaasAmbiguousConfigDriveIDs([]*client.OpenIaaSVirtualDisk{system}, vmID); len(got) != 0 {
+		t.Fatalf("no reserved-name disk: expected zero matches, got %v", got)
+	}
+	if got := openIaasAmbiguousConfigDriveIDs([]*client.OpenIaaSVirtualDisk{system, drive}, vmID); len(got) != 1 || got[0] != "disk-drive" {
+		t.Fatalf("one platform drive: expected exactly [disk-drive], got %v", got)
+	}
+	got := openIaasAmbiguousConfigDriveIDs([]*client.OpenIaaSVirtualDisk{system, drive, impostor}, vmID)
+	if len(got) != 2 || got[0] != "disk-drive" || got[1] != "disk-impostor" {
+		t.Fatalf("two reserved-name disks: expected both ids reported for the fail-closed diagnostic, got %v", got)
+	}
+}
+
+// TestOpenIaasReservedSourceDiskError pins the #488 create preflight: reject
+// only on explicit evidence (a reserved-name source disk WITH cloud-init);
+// pass on missing/empty metadata and without cloud-init.
+func TestOpenIaasReservedSourceDiskError(t *testing.T) {
+	const reserved = "XO CloudConfigDrive"
+	if err := openIaasReservedSourceDiskError([]string{"root", reserved}, true); err == nil {
+		t.Fatal("a reserved-name source disk with cloud-init provisioned must fail the preflight")
+	}
+	if err := openIaasReservedSourceDiskError([]string{"root", reserved}, false); err != nil {
+		t.Fatalf("without cloud-init the reserved-name source disk is not a collision: %v", err)
+	}
+	if err := openIaasReservedSourceDiskError([]string{"root", "data"}, true); err != nil {
+		t.Fatalf("no reserved name in the source: %v", err)
+	}
+	if err := openIaasReservedSourceDiskError(nil, true); err != nil {
+		t.Fatalf("missing source metadata must pass (evidence-only rejection): %v", err)
+	}
+	if err := openIaasReservedSourceDiskError([]string{}, true); err != nil {
+		t.Fatalf("empty source metadata must pass (evidence-only rejection): %v", err)
+	}
+}
+
+// TestOpenIaasCloudInitProvisioned pins the flag's Create-payload semantics
+// (#488): true only when buildOpenIaasCloudInit would actually send a
+// cloud-init (non-empty cloud_config), through the real resource schema.
+func TestOpenIaasCloudInitProvisioned(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw  map[string]interface{}
+		want bool
+	}{
+		"absent":              {raw: nil, want: false},
+		"empty map":           {raw: map[string]interface{}{}, want: false},
+		"empty values":        {raw: map[string]interface{}{"cloud_config": ""}, want: false},
+		"network config only": {raw: map[string]interface{}{"network_config": "version: 2"}, want: false},
+		"cloud config set":    {raw: map[string]interface{}{"cloud_config": "#cloud-config\nhostname: x"}, want: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := map[string]interface{}{}
+			if tc.raw != nil {
+				values["cloud_init"] = tc.raw
+			}
+			d := schema.TestResourceDataRaw(t, resourceOpenIaasVirtualMachine().Schema, values)
+			if got := openIaasCloudInitProvisioned(d); got != tc.want {
+				t.Errorf("openIaasCloudInitProvisioned() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOSDiskNameReservedValidation pins the #488 schema guard on the REAL
+// resource schema: declaring the platform drive name is rejected at plan
+// time, any other name passes.
+func TestOSDiskNameReservedValidation(t *testing.T) {
+	osDisk := resourceOpenIaasVirtualMachine().Schema["os_disk"].Elem.(*schema.Resource)
+	validate := osDisk.Schema["name"].ValidateDiagFunc
+	if validate == nil {
+		t.Fatal("os_disk.name must carry the reserved-name validation")
+	}
+	if diags := validate("XO CloudConfigDrive", cty.GetAttrPath("name")); !diags.HasError() {
+		t.Fatal("declaring the reserved platform drive name must be rejected")
+	}
+	if diags := validate("my-disk", cty.GetAttrPath("name")); diags.HasError() {
+		t.Fatalf("a regular disk name must pass: %v", diags)
 	}
 }
 

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -511,6 +511,7 @@
               "type": "TypeString",
               "optional": true,
               "computed": true,
+              "has_validate_func": true,
               "elem_kind": "nil"
             },
             "size": {

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -24,6 +24,11 @@
 # stays 24.8 and internal/provider/helpers stays 70.0 (FlattenStaticIP was already
 # unit-covered at C2). Only the floor that C3's own tests improved is raised here;
 # the client slack remains deferred per the C2 note.
+# v1.11.0 #488: the platform-drive discriminator tests (flatten skip in both
+# orders, cloud-init arm, VBD fail-safe) raise internal/provider/helpers
+# 70.0 -> 70.9. Only the floor improved by #488's own tests is raised; the
+# client/provider slack accumulated by the v1.11.0 train is left for a
+# dedicated --update.
 internal/client 24.8
 internal/provider 14.3
-internal/provider/helpers 70.0
+internal/provider/helpers 70.9


### PR DESCRIPTION
Refs #488

## Problem

A `cloudtemple_compute_iaas_opensource_virtual_machine` deployed with `cloud_init` captured
the platform's cloud-init config drive ("XO CloudConfigDrive") as a managed `os_disk` at
create time. Every subsequent plan then proposed to remove that block — a permanent,
non-converging drift.

## Root cause (live-proven)

The #255/#273 guard excludes the drive on **exact name AND read-only VBD**. Live evidence
(raw API capture, DEV tenant, 2026-07-21) shows the platform attaches the drive with a
**read-write** VBD on the deploy path (`"readOnly": false`), and never auto-destroys it, so
the guard never matches. The drive is listed before the deploy activity completes (the
platform configures cloud-init before completion on both the marketplace and template
paths), so the capture is systematic, not a race.

Reproduced identically with released **v1.8.0** and HEAD: this is a platform-behavior gap,
not a v1.9.0 provider regression (the create path and the guard are byte-identical between
those versions).

## Fix (validated by a 4-round adversarial plan review)

**Create** (no pre-existing managed entry can be lost there):
- preflight: a create is rejected upfront when the source image (template or marketplace
  item) itself carries the reserved disk name while cloud-init is provisioned —
  evidence-only, absent/empty metadata passes;
- the flatten skips the platform drive on: exact name + VBD of this VM + (read-only VBD OR
  the resource's own cloud-init provisioning, with the exact `buildOpenIaasCloudInit`
  payload semantics);
- ambiguity guard: two or more discriminator matches fail the create closed, naming the ids.

**Read** (state safety):
- the automatic drop keeps the strict #255 evidence (name + read-only VBD) — a state entry
  is **never** dropped on the weaker evidence;
- a captured RW drive (state and live both carry the reserved name, cloud-init provisioned)
  is kept and a warning explains the remediation: applying the removal diff cleans the
  Terraform state only — the provider never detaches, renames or resizes the disk
  (`handleUpdateOSDevices` acts only on disks still present in the desired list).

**Schema**: "XO CloudConfigDrive" is rejected as a user-declared `os_disk.name`
(config-only validation; polluted states keep planning and self-heal).

## Evidence

- Unit: discriminator matrix (both evidences, VBD fail-safe, both listing orders), count
  guard, preflight rules, provisioning-flag semantics through the real schema,
  resource-level reserved-name validation, JSON decode contract-pin for
  `virtualMachines[].readOnly` (the client structs carry no JSON tags).
- Mutation proof: reverting the discriminator to the pre-fix `return vbd.ReadOnly` turns
  exactly the new tests RED (recorded in the review thread).
- Live E2E on the DEV tenant (az05, 2026-07-21), all PASSED:
  - (a) create with cloud_init using this branch: the state holds exactly ONE `os_disk`
    (the system disk) while the raw API lists TWO disks attached (system + the RW
    "XO CloudConfigDrive"); the immediate `terraform plan -detailed-exitcode` exits 0
    ("No changes") — the issue's idempotence expectation is restored;
  - (b) remediation: a state carrying the captured drive (real platform values, the exact
    v1.8.0/v1.9.0/v1.10.0 pollution shape) plans with the guidance warning
    ("Captured cloud-init config drive present in os_disk") plus the removal diff; one
    apply purges the entry (state back to one block), the next plan is empty, and the
    platform still reports the drive ATTACHED afterwards — nothing was detached;
  - baseline: the same deploy through the RELEASED v1.8.0 provider reproduces the capture
    (two os_disk blocks) when the create-time race is lost, confirming the pre-fix drift
    and its non-deterministic "sometimes v1.8.0 looks fine" behavior.

## Residual (documented)

The create-time skip relies on the platform completing the deploy activity only after the
config drive exists (verified in the worker source for both paths) when source-disk
metadata is absent. A deliberately colliding disk attached out-of-band stays simply
unmanaged, as any out-of-band disk (the Read never adopts unknown disks).
