### PR TITLE
feat(#507): expose the sku pricing object on the storage type datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1.11.0 (Unreleased)
 
+ENHANCEMENTS :
+
+  * The `cloudtemple_public_cloud_vm_storage_type` and `cloudtemple_public_cloud_vm_storage_types` data sources now expose the priced `sku` object the VM Instances API returns on each storage type: `sku.name`, `sku.price`, `sku.unit`, `sku.description` and `sku.description_en` (all read-only). The `sku` block is empty when the API returns no SKU for a given storage type. This requires a VM Instances API version that returns `StorageType.sku`; against an older API the block is simply empty (#507).
+
 BUG FIXES :
 
   * `cloudtemple_object_storage_bucket`: the resource now refreshes `access_type` from the API, so a change made out-of-band in the Cloud Temple console (for example `custom` -> `private`) is detected as drift instead of staying invisible to `terraform plan` (#490). Previously the read path never wrote `access_type` back to the state, so console-side changes were silently ignored. Existing states whose console value has already diverged will show a one-time reconciling diff on the next plan — the expected behaviour, letting `terraform apply` realign the intended value. The `cloudtemple_object_storage_bucket` and `cloudtemple_object_storage_buckets` data sources now also expose `access_type`.

--- a/docs/data-sources/public_cloud_vm_storage_type.md
+++ b/docs/data-sources/public_cloud_vm_storage_type.md
@@ -46,5 +46,17 @@ output "storage_type" {
 - `is_available` (Boolean) Whether the storage type is currently available.
 - `max_size_gb` (Number) The maximum disk size (GB) allowed for this storage type.
 - `min_size_gb` (Number) The minimum disk size (GB) allowed for this storage type.
+- `sku` (List of Object) The priced SKU of the storage resource. Empty when the API returns no SKU for this storage type. (see [below for nested schema](#nestedatt--sku))
+
+<a id="nestedatt--sku"></a>
+### Nested Schema for `sku`
+
+Read-Only:
+
+- `description` (String)
+- `description_en` (String)
+- `name` (String)
+- `price` (Number)
+- `unit` (String)
 
 

--- a/docs/data-sources/public_cloud_vm_storage_types.md
+++ b/docs/data-sources/public_cloud_vm_storage_types.md
@@ -47,5 +47,17 @@ Read-Only:
 - `max_size_gb` (Number)
 - `min_size_gb` (Number)
 - `name` (String)
+- `sku` (List of Object) (see [below for nested schema](#nestedobjatt--storage_types--sku))
+
+<a id="nestedobjatt--storage_types--sku"></a>
+### Nested Schema for `storage_types.sku`
+
+Read-Only:
+
+- `description` (String)
+- `description_en` (String)
+- `name` (String)
+- `price` (Number)
+- `unit` (String)
 
 

--- a/internal/client/public_cloud_vm_storage_type.go
+++ b/internal/client/public_cloud_vm_storage_type.go
@@ -22,6 +22,23 @@ type PublicCloudVMStorageType struct {
 	MinSizeGb   int
 	MaxSizeGb   int
 	IsAvailable bool
+	// Sku is the priced SKU of the storage resource. It is a pointer because
+	// the API may omit it (or send null) for a given storage type; a nil Sku
+	// then flattens to an empty list rather than a phantom zero-priced object.
+	Sku *PublicCloudVMSku
+}
+
+// PublicCloudVMSku is the priced SKU the VM Instances API carries on each
+// storage type. Unlike its sibling fields, this struct pins EXPLICIT json tags:
+// they lock the exact API spelling of these billing fields (notably the
+// French/English description pair) instead of relying on case-insensitive
+// matching.
+type PublicCloudVMSku struct {
+	Name          string  `json:"name"`
+	Price         float64 `json:"price"`
+	Unit          string  `json:"unit"`
+	Description   string  `json:"description"`
+	DescriptionEn string  `json:"descriptionEn"`
 }
 
 type publicCloudVMStorageTypeListResponse struct {

--- a/internal/client/public_cloud_vm_storage_type_test.go
+++ b/internal/client/public_cloud_vm_storage_type_test.go
@@ -2,12 +2,14 @@ package client
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"testing"
 )
 
 // TestPublicCloudVMStorageTypeList pins the WRAPPED-response decode
-// ({ "storageTypes": [...] }) including the camelCase int/bool fields.
+// ({ "storageTypes": [...] }) including the camelCase int/bool fields and the
+// nested `sku` billing object (issue #507).
 func TestPublicCloudVMStorageTypeList(t *testing.T) {
 	ctx := context.Background()
 	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -15,7 +17,7 @@ func TestPublicCloudVMStorageTypeList(t *testing.T) {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"storageTypes":[{"id":"st-1","name":"Standard","description":"Standard block storage","iopsHint":"~1500 IOPS/TB","minSizeGb":1,"maxSizeGb":2048,"isAvailable":true}]}`))
+		_, _ = w.Write([]byte(`{"storageTypes":[{"id":"st-1","name":"Standard","description":"Standard block storage","iopsHint":"~1500 IOPS/TB","minSizeGb":1,"maxSizeGb":2048,"isAvailable":true,"sku":{"name":"csp:fr1:iaas:storage:bloc:medium:v1","price":0.063,"unit":"1 Gio","description":"Stockage bloc medium","descriptionEn":"Medium block storage"}}]}`))
 	})
 	sts, err := c.PublicCloudVM().StorageType().List(ctx)
 	if err != nil {
@@ -30,6 +32,46 @@ func TestPublicCloudVMStorageTypeList(t *testing.T) {
 	}
 	if st.MinSizeGb != 1 || st.MaxSizeGb != 2048 || !st.IsAvailable {
 		t.Fatalf("numeric/bool fields not decoded: %+v", st)
+	}
+	if st.Sku == nil {
+		t.Fatalf("sku not decoded: %+v", st)
+	}
+	if st.Sku.Name != "csp:fr1:iaas:storage:bloc:medium:v1" || st.Sku.Unit != "1 Gio" {
+		t.Fatalf("sku string fields not decoded: %+v", st.Sku)
+	}
+	if st.Sku.Description != "Stockage bloc medium" || st.Sku.DescriptionEn != "Medium block storage" {
+		t.Fatalf("sku description pair not decoded (fr/en spelling lock): %+v", st.Sku)
+	}
+	// Compare the parsed float with a tolerance rather than exact equality.
+	if math.Abs(st.Sku.Price-0.063) > 1e-9 {
+		t.Fatalf("sku price not decoded: got %v, want ~0.063", st.Sku.Price)
+	}
+}
+
+// TestPublicCloudVMStorageTypeListSkuAbsent pins that a storage type whose `sku`
+// is OMITTED or explicitly null decodes to a nil Sku pointer (never a phantom
+// zero-priced object). This is the decode half of the pointer design: the
+// flatten half turns a nil Sku into an empty list.
+func TestPublicCloudVMStorageTypeListSkuAbsent(t *testing.T) {
+	ctx := context.Background()
+	c := newPATTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"storageTypes":[` +
+			`{"id":"st-omit","name":"NoSku","minSizeGb":1,"maxSizeGb":10,"isAvailable":true},` +
+			`{"id":"st-null","name":"NullSku","minSizeGb":1,"maxSizeGb":10,"isAvailable":true,"sku":null}` +
+			`]}`))
+	})
+	sts, err := c.PublicCloudVM().StorageType().List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sts) != 2 {
+		t.Fatalf("want 2 storage types, got %d", len(sts))
+	}
+	for _, st := range sts {
+		if st.Sku != nil {
+			t.Fatalf("storage type %q: want nil Sku on omitted/null sku, got %+v", st.ID, st.Sku)
+		}
 	}
 }
 

--- a/internal/provider/data_source_public_cloud_vm_storage_type.go
+++ b/internal/provider/data_source_public_cloud_vm_storage_type.go
@@ -12,6 +12,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// publicCloudVMStorageTypeSkuSchema returns the Computed, read-only `sku` block
+// exposing the priced SKU of a storage type. It is shared verbatim by the
+// single and list datasources so the nested shape cannot drift between them.
+// TypeFloat is the SDK type for the JSON `price` number (the first TypeFloat in
+// the provider). The block is absent (empty list) when the API returns no sku.
+func publicCloudVMStorageTypeSkuSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "The priced SKU of the storage resource. Empty when the API returns no SKU for this storage type.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The SKU identifier (e.g. `csp:fr1:iaas:storage:bloc:medium:v1`).",
+				},
+				"price": {
+					Type:        schema.TypeFloat,
+					Computed:    true,
+					Description: "The unit price of the SKU, expressed for `unit`.",
+				},
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The billing unit the price applies to (e.g. `1 Gio`).",
+				},
+				"description": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The human-readable description of the SKU (French).",
+				},
+				"description_en": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The human-readable description of the SKU (English).",
+				},
+			},
+		},
+	}
+}
+
 func dataSourcePublicCloudVMStorageType() *schema.Resource {
 	return &schema.Resource{
 		Description: "Used to retrieve a single Public Cloud VM Instances storage type, by `id` or by `name`. The API has no by-id endpoint for storage types; selection is done by listing and matching.",
@@ -62,6 +104,7 @@ func dataSourcePublicCloudVMStorageType() *schema.Resource {
 				Computed:    true,
 				Description: "Whether the storage type is currently available.",
 			},
+			"sku": publicCloudVMStorageTypeSkuSchema(),
 		},
 	}
 }

--- a/internal/provider/data_source_public_cloud_vm_storage_types.go
+++ b/internal/provider/data_source_public_cloud_vm_storage_types.go
@@ -57,6 +57,7 @@ func dataSourcePublicCloudVMStorageTypes() *schema.Resource {
 							Computed:    true,
 							Description: "Whether the storage type is currently available.",
 						},
+						"sku": publicCloudVMStorageTypeSkuSchema(),
 					},
 				},
 			},

--- a/internal/provider/helpers/helper_public_cloud_vm_storage_type.go
+++ b/internal/provider/helpers/helper_public_cloud_vm_storage_type.go
@@ -5,8 +5,20 @@ import (
 )
 
 // FlattenPublicCloudVMStorageType maps a client.PublicCloudVMStorageType to the
-// flat snake_case map consumed by both the single and list datasources.
+// flat snake_case map consumed by both the single and list datasources. A nil
+// Sku (the API may omit it or send null) flattens to an empty list, mirroring
+// the nested-single-object idiom used across the Public Cloud VM datasources.
 func FlattenPublicCloudVMStorageType(st *client.PublicCloudVMStorageType) map[string]interface{} {
+	sku := []map[string]interface{}{}
+	if st.Sku != nil {
+		sku = []map[string]interface{}{{
+			"name":           st.Sku.Name,
+			"price":          st.Sku.Price,
+			"unit":           st.Sku.Unit,
+			"description":    st.Sku.Description,
+			"description_en": st.Sku.DescriptionEn,
+		}}
+	}
 	return map[string]interface{}{
 		"id":           st.ID,
 		"name":         st.Name,
@@ -15,5 +27,6 @@ func FlattenPublicCloudVMStorageType(st *client.PublicCloudVMStorageType) map[st
 		"min_size_gb":  st.MinSizeGb,
 		"max_size_gb":  st.MaxSizeGb,
 		"is_available": st.IsAvailable,
+		"sku":          sku,
 	}
 }

--- a/internal/provider/helpers/helper_public_cloud_vm_storage_type_test.go
+++ b/internal/provider/helpers/helper_public_cloud_vm_storage_type_test.go
@@ -1,0 +1,84 @@
+package helpers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cloud-temple/terraform-provider-cloudtemple/internal/client"
+)
+
+// TestFlattenPublicCloudVMStorageTypeSku is the regression proof for issue #507.
+// It goes RED on the pre-#507 helper (which emitted no "sku" key at all) and
+// GREEN once the helper maps the nested billing object. It pins the exact
+// nested shape the datasource schema expects: a one-element list of a
+// snake_case map when a SKU is present.
+func TestFlattenPublicCloudVMStorageTypeSku(t *testing.T) {
+	st := &client.PublicCloudVMStorageType{
+		ID:          "st-1",
+		Name:        "Standard",
+		Description: "Standard block storage",
+		IopsHint:    "~1500 IOPS/TB",
+		MinSizeGb:   1,
+		MaxSizeGb:   2048,
+		IsAvailable: true,
+		Sku: &client.PublicCloudVMSku{
+			Name:          "csp:fr1:iaas:storage:bloc:medium:v1",
+			Price:         0.063,
+			Unit:          "1 Gio",
+			Description:   "Stockage bloc medium",
+			DescriptionEn: "Medium block storage",
+		},
+	}
+
+	out := FlattenPublicCloudVMStorageType(st)
+
+	raw, ok := out["sku"]
+	if !ok {
+		t.Fatalf("flatten emits no %q key; the datasource cannot expose the SKU", "sku")
+	}
+	sku, ok := raw.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("sku has type %T, want []map[string]interface{} (nested list-of-object shape)", raw)
+	}
+	if len(sku) != 1 {
+		t.Fatalf("want a one-element sku list, got %d elements", len(sku))
+	}
+	e := sku[0]
+	if e["name"] != "csp:fr1:iaas:storage:bloc:medium:v1" || e["unit"] != "1 Gio" {
+		t.Fatalf("sku string fields not flattened: %+v", e)
+	}
+	if e["description"] != "Stockage bloc medium" || e["description_en"] != "Medium block storage" {
+		t.Fatalf("sku description pair not flattened (fr/en): %+v", e)
+	}
+	price, ok := e["price"].(float64)
+	if !ok {
+		t.Fatalf("sku price has type %T, want float64", e["price"])
+	}
+	if math.Abs(price-0.063) > 1e-9 {
+		t.Fatalf("sku price not flattened: got %v, want ~0.063", price)
+	}
+}
+
+// TestFlattenPublicCloudVMStorageTypeSkuNil pins that a nil Sku (the API omitted
+// it or sent null) flattens to a NON-NIL empty list, not a nil value or a
+// phantom zero-priced element. This is what keeps the generic zero-input
+// invariant (helper_flatten_invariants_test.go) green without a knownNilSliceGaps
+// entry, and what stops the state from carrying a bogus price=0 SKU.
+func TestFlattenPublicCloudVMStorageTypeSkuNil(t *testing.T) {
+	out := FlattenPublicCloudVMStorageType(&client.PublicCloudVMStorageType{ID: "st-nosku"})
+
+	raw, ok := out["sku"]
+	if !ok {
+		t.Fatalf("flatten must always emit the %q key, even when nil", "sku")
+	}
+	sku, ok := raw.([]map[string]interface{})
+	if !ok {
+		t.Fatalf("sku has type %T, want []map[string]interface{}", raw)
+	}
+	if sku == nil {
+		t.Fatalf("sku is a typed nil slice on nil Sku; want a non-nil empty list to pin the present-but-empty intent")
+	}
+	if len(sku) != 0 {
+		t.Fatalf("want an empty sku list on nil Sku, got %d elements: %+v", len(sku), sku)
+	}
+}

--- a/internal/provider/testdata/schema_snapshot.json
+++ b/internal/provider/testdata/schema_snapshot.json
@@ -12043,6 +12043,38 @@
             "name"
           ],
           "elem_kind": "nil"
+        },
+        "sku": {
+          "type": "TypeList",
+          "computed": true,
+          "elem_kind": "resource",
+          "elem_resource": {
+            "description": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "description_en": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "name": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "price": {
+              "type": "TypeFloat",
+              "computed": true,
+              "elem_kind": "nil"
+            },
+            "unit": {
+              "type": "TypeString",
+              "computed": true,
+              "elem_kind": "nil"
+            }
+          }
         }
       }
     },
@@ -12087,6 +12119,38 @@
               "type": "TypeString",
               "computed": true,
               "elem_kind": "nil"
+            },
+            "sku": {
+              "type": "TypeList",
+              "computed": true,
+              "elem_kind": "resource",
+              "elem_resource": {
+                "description": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "description_en": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "name": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "price": {
+                  "type": "TypeFloat",
+                  "computed": true,
+                  "elem_kind": "nil"
+                },
+                "unit": {
+                  "type": "TypeString",
+                  "computed": true,
+                  "elem_kind": "nil"
+                }
+              }
             }
           }
         }

--- a/internal/provider/tests/data_source_public_cloud_vm_storage_type_test.go
+++ b/internal/provider/tests/data_source_public_cloud_vm_storage_type_test.go
@@ -24,6 +24,11 @@ func TestAccDataSourcePublicCloudVMStorageType(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_type.foo", "id"),
 					resource.TestCheckResourceAttr("data.cloudtemple_public_cloud_vm_storage_type.foo", "name", os.Getenv(PublicCloudVMStorageTypeName)),
 					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_type.foo", "max_size_gb"),
+					// The API now returns a priced SKU on each storage type (#507).
+					// Assert presence, not the live price value (which is volatile).
+					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_type.foo", "sku.0.name"),
+					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_type.foo", "sku.0.price"),
+					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_type.foo", "sku.0.unit"),
 				),
 			},
 			{

--- a/internal/provider/tests/data_source_public_cloud_vm_storage_types_test.go
+++ b/internal/provider/tests/data_source_public_cloud_vm_storage_types_test.go
@@ -17,6 +17,10 @@ func TestAccDataSourcePublicCloudVMStorageTypes(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_types.all", "storage_types.#"),
 					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_types.all", "storage_types.0.id"),
 					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_types.all", "storage_types.0.max_size_gb"),
+					// The API now returns a priced SKU on each storage type (#507).
+					// Assert presence, not the live price value (which is volatile).
+					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_types.all", "storage_types.0.sku.0.name"),
+					resource.TestCheckResourceAttrSet("data.cloudtemple_public_cloud_vm_storage_types.all", "storage_types.0.sku.0.price"),
 				),
 			},
 		},


### PR DESCRIPTION
Refs #507

## What & why

The VM Instances API now returns a `sku` object on each storage type, carrying the priced SKU of the storage resource. This exposes it, **read-only**, on both storage-type data sources:

- `cloudtemple_public_cloud_vm_storage_type` (at the root)
- `cloudtemple_public_cloud_vm_storage_types` (inside each `storage_types` element)

New nested read-only attributes: `sku.name` (String), `sku.price` (Number), `sku.unit` (String), `sku.description` (String), `sku.description_en` (String). **Required role unchanged.** Additive, backward-compatible.

## Changes

- **client** (`internal/client/public_cloud_vm_storage_type.go`): new `PublicCloudVMSku` struct with **explicit json tags** (to lock the exact API spelling of the billing fields, notably the FR/EN description pair) and a **pointer** `Sku` field, so an omitted or `null` sku decodes to `nil` rather than a phantom zero-priced object.
- **helper** (`helper_public_cloud_vm_storage_type.go`): a nil `Sku` flattens to an empty list, a present one to a single-element list — the nested-single-object idiom already used by `publicCloudVMInstanceRefSchema`.
- **schema**: a shared `publicCloudVMStorageTypeSkuSchema()` block (`TypeList`, computed) used by both data sources so the nested shape cannot drift between them. `price` is the provider's **first `schema.TypeFloat`**.
- **generated**: schema snapshot regenerated (**additive, +64 / −0**, only the two `sku` blocks); docs regenerated via `go generate`.
- **CHANGELOG**: `1.11.0 (Unreleased)` → `ENHANCEMENTS`.

## Test evidence (non-complacent)

- **Mutation proof (RED-without-fix):** reverting the helper to its pre-#507 body (no `sku` key) makes `TestFlattenPublicCloudVMStorageTypeSku` fail with *"flatten emits no \"sku\" key; the datasource cannot expose the SKU"*; restoring the fix turns it green.
- **Client decode:** `TestPublicCloudVMStorageTypeList` (sku present, with a float tolerance) + `TestPublicCloudVMStorageTypeListSkuAbsent` (sku **omitted** and explicit **null** → nil `Sku`).
- **Live evidence:** a read-only probe against the dev API confirmed `sku` is returned on 2/2 storage types and decoded by the production client, with the exact wire shape (`price` as a JSON number, `descriptionEn` spelling). The throwaway probe is **not** committed.
- **Auto-gates green:** `TestFlattenZeroInputInvariants` (nil `Sku` → non-nil empty list, no `knownNilSliceGaps` entry needed) and the flatten↔schema walker `TestDatasourceFlattenOutputsFitTheirSchemas` (first `TypeFloat`, and the nested list-under-list for the plural).
- **Acceptance:** both data-source acceptance tests assert `sku.0.name` / `sku.0.price` presence (`TestCheckResourceAttrSet`) — not the volatile live price.

## Design notes

- `sku` is modelled as a computed `TypeList` **without `MaxItems: 1`**, matching the existing computed nested-single-object convention in this domain (`publicCloudVMInstanceRefSchema`: `availability_zone`, `backup_policy`, …). Consistency over decorative precision.
- The schema-snapshot change is purely additive: no reordering, no deletions, no state-shape change → no `StateUpgrader`, `TF prod breaker = NO`.

## Residual risks (accepted, per the confirmed contract)

- The plural acceptance test assumes `storage_types.0` carries a `sku`. This holds for an API that returns `sku` across the catalogue (confirmed live). Against an older/mixed API that omits `sku`, the provider still behaves correctly (empty block), but that acceptance assertion would fail — expected, since #507 depends on the API release that returns `sku`.
- A present `sku` with a `null` scalar (e.g. `price: null`) would decode to a zero value. The contract (issue + live) has `price` as a JSON number, so this is not exercised.

## Review trail

- Adversarial **PLAN** review (Codex, read-only): `VERDICT: GO`, 0 blocking.
- Adversarial **pre-commit** review of this exact diff (Codex, read-only): `VERDICT: GO`, 0 blocking, 2 minor + 1 nit (addressed/accepted above).

## RC flow

Targets `rc/v1.11.0` with `Refs #507` (not `Closes` — the closing keyword is reserved for the RC → `main` PR). No tag/release from the RC branch.
